### PR TITLE
Implement indexing for Align<T>

### DIFF
--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use std::mem::size_of;
 use std::os::raw::c_void;
 use std::{io, slice};
+use std::ops::Range;
 
 /// `Align` handles dynamic alignment. The is useful for dynamic uniform buffers where
 /// the alignment might be different. For example a 4x4 f32 matrix has a size of 64 bytes

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -59,6 +59,15 @@ impl<T> Align<T> {
         }
     }
 
+    pub unsafe fn index(&self, index: Range<usize>) -> Align<T> {
+        Align {
+            ptr: (self.ptr as *mut u8).offset((index.start as u64 * self.elem_size) as isize) as *mut c_void,
+            elem_size: self.elem_size,
+            size: (index.end - index.start) as u64 * self.elem_size as u64,
+            _m: self._m,
+        }
+    }
+
     pub fn iter_mut(&mut self) -> AlignIter<T> {
         AlignIter {
             current: 0,

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -61,6 +61,9 @@ impl<T> Align<T> {
     }
 
     pub unsafe fn index(&self, index: Range<usize>) -> Align<T> {
+        if index.end<index.start {
+            panic!();
+        }
         Align {
             ptr: (self.ptr as *mut u8).offset((index.start as u64 * self.elem_size) as isize) as *mut c_void,
             elem_size: self.elem_size,

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -41,11 +41,6 @@ impl<T: Copy> Align<T> {
             }
         }
     }
-
-    pub fn len(self) -> u64 {
-        assert_eq!(self.size % self.elem_size, 0);
-        self.size / self.elem_size
-    }
 }
 
 fn calc_padding(adr: vk::DeviceSize, align: vk::DeviceSize) -> vk::DeviceSize {
@@ -79,6 +74,11 @@ impl<T> Align<T> {
             current: 0,
             align: self,
         }
+    }
+
+    pub fn len(self) -> u64 {
+        assert_eq!(self.size % self.elem_size, 0);
+        self.size / self.elem_size
     }
 }
 

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -76,7 +76,7 @@ impl<T> Align<T> {
         }
     }
 
-    pub fn len(self) -> u64 {
+    pub fn len(&self) -> u64 {
         assert_eq!(self.size % self.elem_size, 0);
         self.size / self.elem_size
     }

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -41,6 +41,11 @@ impl<T: Copy> Align<T> {
             }
         }
     }
+
+    pub fn len(self) -> u64 {
+        assert_eq!(self.size % self.elem_size, 0);
+        self.size / self.elem_size
+    }
 }
 
 fn calc_padding(adr: vk::DeviceSize, align: vk::DeviceSize) -> vk::DeviceSize {


### PR DESCRIPTION
Small speculative PR.

This is useful for a variety of situations where the alternative, recreating the Align<T> with the relevant start and sizes, would involve the need to lug around information already stored in Align<T> itself.