### PR TITLE
Fixed validation layer errors on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,10 @@ Make sure that you have a Vulkan ready driver and install the [LunarG Vulkan SDK
 Install the [LunarG Vulkan SDK](https://lunarg.com/vulkan-sdk/). This basically entails extracting the downloaded tarball to any location you choose and then setting a few environment variables. Specifically, if `SDK_PATH` is set to the root extracted SDK directory,
 
 * `DYLD_LIBRARY_PATH = $SDK_PATH/macOS/lib`
-* `VK_ICD_FILENAMES = $SDK_PATH/macOS/etc/vulkan/icd.d/MoltenVK_icd.json`
-* `VK_LAYER_PATH = $SDK_PATH/macOS/etc/vulkan/explicit_layer.d`
+* `VK_ICD_FILENAMES = $SDK_PATH/macOS/share/vulkan/icd.d/MoltenVK_icd.json`
+* `VK_LAYER_PATH = $SDK_PATH/macOS/share/vulkan/explicit_layer.d`
+* `MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1`
+If SDK version is < 1.2.135.0 replace 'share' with 'etc' in the above environment variables. 
 
 ### [Triangle](https://github.com/MaikKlein/ash/blob/master/examples/src/bin/triangle.rs)
 Displays a triangle with vertex colors.


### PR DESCRIPTION
The examples(triangle and textures) are causing validation errors on macOS (tested on Mojave 10.14.6) , i'll be listing them down below with the solutions :

**1.**

`ERROR:
VALIDATION [VUID-VkDeviceCreateInfo-pProperties-04451 (976972960)] : Validation Error: [ VUID-VkDeviceCreateInfo-pProperties-04451 ] Object 0: handle = 0x7fe53281c950, type = VK_OBJECT_TYPE_PHYSICAL_DEVICE; | MessageID = 0x3a3b6ca0 | vkCreateDevice: VK_KHR_portability_subset must be enabled because physical device VkPhysicalDevice 0x7fe53281c950[] supports it The Vulkan spec states: If the [VK_KHR_portability_subset] extension is included in pProperties of vkEnumerateDeviceExtensionProperties, ppEnabledExtensions must include "VK_KHR_portability_subset". (https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-VkDeviceCreateInfo-pProperties-04451)
`
solution : 
pushing `vk::KhrPortabilitySubsetFn` to `instance.enabled_extension_names()`  (examples/src/lib.rs ,line 293)

**2.**

.`ERROR:
VALIDATION [VUID-vkCreateDevice-ppEnabledExtensionNames-01387 (307460652)] : Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] Object 0: VK_NULL_HANDLE, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x12537a2c | Missing extension required by the device extension VK_KHR_portability_subset: VK_KHR_get_physical_device_properties2. The Vulkan spec states: All required extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)
`
solution : 
pushing `vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr()` to `device.enabled_extension_names()` (examples/src/lib.rs ,line 224)

**3.**

`ERROR:
VALIDATION [VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465 (-2102505392)] : Validation Error: [ VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465 ] Object 0: handle = 0x7fa9bb04ec18, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x82ae5050 | vkCreateImageView (portability error): swizzle is disabled for this device. The Vulkan spec states: If the [VK_KHR_portability_subset] extension is enabled, and VkPhysicalDevicePortabilitySubsetFeaturesKHR::imageViewFormatSwizzle is VK_FALSE, all elements of components must be VK_COMPONENT_SWIZZLE_IDENTITY. (https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465)
`

solution : 
we first enable `MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1` and then we fetch PhysicalDevicePortabilitySubsetFeaturesKHR::image_view_format_swizzle , value should be true because we enabled IMAGE_VIEW_SWIZZLE in the MVK layer (examples/src/lib.rs ,line 301-311) and then we push `PhysicalDevicePortabilitySubsetFeaturesKHR` to `DeviceCreateInfo.p_next` by calling `device_create_info.push_next()`
(examples/src/lib.rs ,line 327)


i've also updated the README on how to run the examples on macos when using a VulkanSDK version that is >= 1.2.135.0  :)