### PR TITLE
ash-window: Upgrade to raw-window-handle 0.4.2

### DIFF
--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -16,10 +16,10 @@ rust-version = "1.59.0"
 
 [dependencies]
 ash = { path = "../ash", version = "0.37", default-features = false }
-raw-window-handle = "0.3.4"
+raw-window-handle = "0.4.2"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-raw-window-metal = "0.1"
+raw-window-metal = "0.2"
 
 [dev-dependencies]
 winit = "0.26"

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bumped `raw-window-handle` to `0.4.2` (#505)
+
 ## [0.10.0] - 2022-03-23
+
+### Changed
 
 - Bumped `ash` version to [`0.37`](https://github.com/MaikKlein/ash/releases/tag/0.37.0) (#600)
 - Make `enumerate_required_extensions()` return `&[*const c_char]` instead of `Vec<&CStr>` to match `ash::vk::InstanceCreateInfo` (#590)

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -2,11 +2,12 @@
 
 use std::os::raw::c_char;
 
-use ash::{extensions::khr, prelude::*, vk, Entry, Instance};
+use ash::{
+    extensions::{ext, khr},
+    prelude::*,
+    vk, Entry, Instance,
+};
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-use ash::extensions::ext; // portability extensions
 
 /// Create a surface from a raw surface handle.
 ///
@@ -24,8 +25,7 @@ pub unsafe fn create_surface(
     allocation_callbacks: Option<&vk::AllocationCallbacks>,
 ) -> VkResult<vk::SurfaceKHR> {
     match window_handle.raw_window_handle() {
-        #[cfg(target_os = "windows")]
-        RawWindowHandle::Windows(handle) => {
+        RawWindowHandle::Win32(handle) => {
             let surface_desc = vk::Win32SurfaceCreateInfoKHR::default()
                 .hinstance(handle.hinstance)
                 .hwnd(handle.hwnd);
@@ -33,13 +33,6 @@ pub unsafe fn create_surface(
             surface_fn.create_win32_surface(&surface_desc, allocation_callbacks)
         }
 
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
         RawWindowHandle::Wayland(handle) => {
             let surface_desc = vk::WaylandSurfaceCreateInfoKHR::default()
                 .display(handle.display)
@@ -48,13 +41,6 @@ pub unsafe fn create_surface(
             surface_fn.create_wayland_surface(&surface_desc, allocation_callbacks)
         }
 
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
         RawWindowHandle::Xlib(handle) => {
             let surface_desc = vk::XlibSurfaceCreateInfoKHR::default()
                 .dpy(handle.display as *mut _)
@@ -63,13 +49,6 @@ pub unsafe fn create_surface(
             surface_fn.create_xlib_surface(&surface_desc, allocation_callbacks)
         }
 
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
         RawWindowHandle::Xcb(handle) => {
             let surface_desc = vk::XcbSurfaceCreateInfoKHR::default()
                 .connection(handle.connection)
@@ -78,19 +57,18 @@ pub unsafe fn create_surface(
             surface_fn.create_xcb_surface(&surface_desc, allocation_callbacks)
         }
 
-        #[cfg(any(target_os = "android"))]
-        RawWindowHandle::Android(handle) => {
+        RawWindowHandle::AndroidNdk(handle) => {
             let surface_desc =
                 vk::AndroidSurfaceCreateInfoKHR::default().window(handle.a_native_window);
             let surface_fn = khr::AndroidSurface::new(entry, instance);
             surface_fn.create_android_surface(&surface_desc, allocation_callbacks)
         }
 
-        #[cfg(any(target_os = "macos"))]
-        RawWindowHandle::MacOS(handle) => {
-            use raw_window_metal::{macos, Layer};
+        #[cfg(target_os = "macos")]
+        RawWindowHandle::AppKit(handle) => {
+            use raw_window_metal::{appkit, Layer};
 
-            let layer = match macos::metal_layer_from_handle(handle) {
+            let layer = match appkit::metal_layer_from_handle(handle) {
                 Layer::Existing(layer) | Layer::Allocated(layer) => layer as *mut _,
                 Layer::None => return Err(vk::Result::ERROR_INITIALIZATION_FAILED),
             };
@@ -100,11 +78,11 @@ pub unsafe fn create_surface(
             surface_fn.create_metal_surface(&surface_desc, allocation_callbacks)
         }
 
-        #[cfg(any(target_os = "ios"))]
-        RawWindowHandle::IOS(handle) => {
-            use raw_window_metal::{ios, Layer};
+        #[cfg(target_os = "ios")]
+        RawWindowHandle::UiKit(handle) => {
+            use raw_window_metal::{uikit, Layer};
 
-            let layer = match ios::metal_layer_from_handle(handle) {
+            let layer = match uikit::metal_layer_from_handle(handle) {
                 Layer::Existing(layer) | Layer::Allocated(layer) => layer as *mut _,
                 Layer::None => return Err(vk::Result::ERROR_INITIALIZATION_FAILED),
             };
@@ -114,7 +92,7 @@ pub unsafe fn create_surface(
             surface_fn.create_metal_surface(&surface_desc, allocation_callbacks)
         }
 
-        _ => Err(vk::Result::ERROR_EXTENSION_NOT_PRESENT), // not supported
+        _ => Err(vk::Result::ERROR_EXTENSION_NOT_PRESENT),
     }
 }
 
@@ -125,8 +103,7 @@ pub fn enumerate_required_extensions(
     window_handle: &dyn HasRawWindowHandle,
 ) -> VkResult<&'static [*const c_char]> {
     let extensions = match window_handle.raw_window_handle() {
-        #[cfg(target_os = "windows")]
-        RawWindowHandle::Windows(_) => {
+        RawWindowHandle::Win32(_) => {
             const WINDOWS_EXTS: [*const c_char; 2] = [
                 khr::Surface::name().as_ptr(),
                 khr::Win32Surface::name().as_ptr(),
@@ -134,13 +111,6 @@ pub fn enumerate_required_extensions(
             &WINDOWS_EXTS
         }
 
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
         RawWindowHandle::Wayland(_) => {
             const WAYLAND_EXTS: [*const c_char; 2] = [
                 khr::Surface::name().as_ptr(),
@@ -149,13 +119,6 @@ pub fn enumerate_required_extensions(
             &WAYLAND_EXTS
         }
 
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
         RawWindowHandle::Xlib(_) => {
             const XLIB_EXTS: [*const c_char; 2] = [
                 khr::Surface::name().as_ptr(),
@@ -164,13 +127,6 @@ pub fn enumerate_required_extensions(
             &XLIB_EXTS
         }
 
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
         RawWindowHandle::Xcb(_) => {
             const XCB_EXTS: [*const c_char; 2] = [
                 khr::Surface::name().as_ptr(),
@@ -179,8 +135,7 @@ pub fn enumerate_required_extensions(
             &XCB_EXTS
         }
 
-        #[cfg(any(target_os = "android"))]
-        RawWindowHandle::Android(_) => {
+        RawWindowHandle::AndroidNdk(_) => {
             const ANDROID_EXTS: [*const c_char; 2] = [
                 khr::Surface::name().as_ptr(),
                 khr::AndroidSurface::name().as_ptr(),
@@ -188,22 +143,12 @@ pub fn enumerate_required_extensions(
             &ANDROID_EXTS
         }
 
-        #[cfg(any(target_os = "macos"))]
-        RawWindowHandle::MacOS(_) => {
-            const MACOS_EXTS: [*const c_char; 2] = [
+        RawWindowHandle::AppKit(_) | RawWindowHandle::UiKit(_) => {
+            const METAL_EXTS: [*const c_char; 2] = [
                 khr::Surface::name().as_ptr(),
                 ext::MetalSurface::name().as_ptr(),
             ];
-            &MACOS_EXTS
-        }
-
-        #[cfg(any(target_os = "ios"))]
-        RawWindowHandle::IOS(_) => {
-            const IOS_EXTS: [*const c_char; 2] = [
-                khr::Surface::name().as_ptr(),
-                ext::MetalSurface::name().as_ptr(),
-            ];
-            &IOS_EXTS
+            &METAL_EXTS
         }
 
         _ => return Err(vk::Result::ERROR_EXTENSION_NOT_PRESENT),


### PR DESCRIPTION
Note that this depends on one of the many winit 0.25 example upgrades (though we'll require 0.26 to make `raw-window-handle` 0.4 work) in order to succeed compilation on the examples.

---

Not sure about the timing on this one: raw-window-handle just came out, and winit 0.26 too.  There's a compatibility in 0.3.4 that allows consumers like this ash-window crate to consume the 0.4 handle (because the trait is implemented for it) produced by ie. winit, so there's a good reason to stay on 0.3.4 for longer to have wider adoption before migrating the ash-window crate - which is unfortunately tied in to the ash version!  This just provides a git branch/rev for crate authors to use if they desire to deduplicate their raw-window-handle dependency in the crate graph.

I wonder if we can use a lower and upper version bound on ash and just perform minor releases of ash-window to increase that upper bound whenever a new, compatible version of ash is released.  A bit like the [proposed fixes for vma](https://github.com/gwihlidal/vk-mem-rs/pull/57/files).  We can keep two ash-window major releases in parallel, but that's going to get hairy as soon as there's a breaking change in ash (in fact the unreleased "Support linking vulkan directly" PR changes our API surface already).

---

The match arms are not guarded by `cfg` anymore, allowing us to compile-test these simple arms on every system whenever our Ash extension helpers and types are not guarded by `cfg` attributes either.  This applies to every platform except Mac/IOS where the symbols and external raw-window-metal crate are themselves guarded by cfg's.

CC @msiglreith, seems like we need an update to https://github.com/norse-rs/raw-window-metal before this could even work :)
