### PR TITLE
Add platform-specific extension list for creating a surface to ash_window 

### DIFF
--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -119,6 +119,7 @@ pub unsafe fn create_surface(
 }
 
 #[cfg(target_os = "windows")]
+/// Extensions necessary for creating a surface on the target platform.
 pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
     khr::Surface::name().as_ptr(),
     khr::Win32Surface::name().as_ptr(),
@@ -130,6 +131,7 @@ pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
+/// Extensions necessary for creating a surface on the target platform.
 pub const TARGET_EXTENSIONS: [*const c_char; 4] = [
     khr::Surface::name().as_ptr(),
     khr::WaylandSurface::name().as_ptr(),
@@ -137,16 +139,19 @@ pub const TARGET_EXTENSIONS: [*const c_char; 4] = [
     khr::XcbSurface::name().as_ptr(),
 ];
 #[cfg(any(target_os = "android"))]
+/// Extensions necessary for creating a surface on the target platform.
 pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
     khr::Surface::name().as_ptr(),
     khr::AndroidSurface::name().as_ptr(),
 ];
 #[cfg(any(target_os = "macos"))]
+/// Extensions necessary for creating a surface on the target platform.
 pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),
 ];
 #[cfg(any(target_os = "ios"))]
+/// Extensions necessary for creating a surface on the target platform.
 pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -118,6 +118,40 @@ pub unsafe fn create_surface(
     }
 }
 
+#[cfg(target_os = "windows")]
+pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+    khr::Surface::name().as_ptr(),
+    khr::Win32Surface::name().as_ptr(),
+];
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+pub const TARGET_EXTENSIONS: [*const c_char; 4] = [
+    khr::Surface::name().as_ptr(),
+    khr::WaylandSurface::name().as_ptr(),
+    khr::XlibSurface::name().as_ptr(),
+    khr::XcbSurface::name().as_ptr(),
+];
+#[cfg(any(target_os = "android"))]
+pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+    khr::Surface::name().as_ptr(),
+    khr::AndroidSurface::name().as_ptr(),
+];
+#[cfg(any(target_os = "macos"))]
+pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+    khr::Surface::name().as_ptr(),
+    ext::MetalSurface::name().as_ptr(),
+];
+#[cfg(any(target_os = "ios"))]
+pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+    khr::Surface::name().as_ptr(),
+    ext::MetalSurface::name().as_ptr(),
+];
+
 /// Query the required instance extensions for creating a surface from a window handle.
 ///
 /// The returned extensions will include all extension dependencies.

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -118,12 +118,15 @@ pub unsafe fn create_surface(
     }
 }
 
-#[cfg(target_os = "windows")]
 /// Extensions necessary for creating a surface on the target platform.
+/// (Note that on Unix, this is not equal to the return value of [`enumerate_required_extensions`])
+#[cfg(target_os = "windows")]
 pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::Win32Surface::name().as_ptr(),
 ];
+/// Extensions necessary for creating a surface on the target platform.
+/// (Note that on Unix, this is not equal to the return value of [`enumerate_required_extensions`])
 #[cfg(any(
     target_os = "linux",
     target_os = "dragonfly",
@@ -131,27 +134,29 @@ pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-/// Extensions necessary for creating a surface on the target platform.
 pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::WaylandSurface::name().as_ptr(),
     khr::XlibSurface::name().as_ptr(),
     khr::XcbSurface::name().as_ptr(),
 ];
-#[cfg(any(target_os = "android"))]
 /// Extensions necessary for creating a surface on the target platform.
+/// (Note that on Unix, this is not equal to the return value of [`enumerate_required_extensions`])
+#[cfg(any(target_os = "android"))]
 pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::AndroidSurface::name().as_ptr(),
 ];
-#[cfg(any(target_os = "macos"))]
 /// Extensions necessary for creating a surface on the target platform.
+/// (Note that on Unix, this is not equal to the return value of [`enumerate_required_extensions`])
+#[cfg(any(target_os = "macos"))]
 pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),
 ];
-#[cfg(any(target_os = "ios"))]
 /// Extensions necessary for creating a surface on the target platform.
+/// (Note that on Unix, this is not equal to the return value of [`enumerate_required_extensions`])
+#[cfg(any(target_os = "ios"))]
 pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -120,7 +120,7 @@ pub unsafe fn create_surface(
 
 #[cfg(target_os = "windows")]
 /// Extensions necessary for creating a surface on the target platform.
-pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::Win32Surface::name().as_ptr(),
 ];
@@ -132,7 +132,7 @@ pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
     target_os = "openbsd"
 ))]
 /// Extensions necessary for creating a surface on the target platform.
-pub const TARGET_EXTENSIONS: [*const c_char; 4] = [
+pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::WaylandSurface::name().as_ptr(),
     khr::XlibSurface::name().as_ptr(),
@@ -140,19 +140,19 @@ pub const TARGET_EXTENSIONS: [*const c_char; 4] = [
 ];
 #[cfg(any(target_os = "android"))]
 /// Extensions necessary for creating a surface on the target platform.
-pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::AndroidSurface::name().as_ptr(),
 ];
 #[cfg(any(target_os = "macos"))]
 /// Extensions necessary for creating a surface on the target platform.
-pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),
 ];
 #[cfg(any(target_os = "ios"))]
 /// Extensions necessary for creating a surface on the target platform.
-pub const TARGET_EXTENSIONS: [*const c_char; 2] = [
+pub const TARGET_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),
 ];

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -174,7 +174,7 @@ pub fn enumerate_required_extensions(
 ) -> VkResult<&'static [*const c_char]> {
     let extensions = match window_handle.raw_window_handle() {
         #[cfg(target_os = "windows")]
-        RawWindowHandle::Windows(_) => &WINDOWS_SURFACE_EXTENSIONS,
+        RawWindowHandle::Windows(_) => WINDOWS_SURFACE_EXTENSIONS,
 
         #[cfg(any(
             target_os = "linux",
@@ -222,13 +222,13 @@ pub fn enumerate_required_extensions(
         }
 
         #[cfg(target_os = "android")]
-        RawWindowHandle::Android(_) => &ANDROID_SURFACE_EXTENSIONS,
+        RawWindowHandle::Android(_) => ANDROID_SURFACE_EXTENSIONS,
 
         #[cfg(target_os = "macos")]
-        RawWindowHandle::MacOS(_) => &METAL_SURFACE_EXTENSIONS,
+        RawWindowHandle::MacOS(_) => METAL_SURFACE_EXTENSIONS,
 
         #[cfg(target_os = "ios")]
-        RawWindowHandle::IOS(_) => &IOS_SURFACE_EXTENSIONS,
+        RawWindowHandle::IOS(_) => IOS_SURFACE_EXTENSIONS,
 
         _ => return Err(vk::Result::ERROR_EXTENSION_NOT_PRESENT),
     };

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -119,30 +119,35 @@ pub unsafe fn create_surface(
 }
 
 /// Extensions necessary for creating a surface on windows.
-pub const WINDOWS_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
+#[allow(dead_code)]
+const WINDOWS_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::Win32Surface::name().as_ptr(),
 ];
 /// Extensions necessary for creating a surface on unix.
 /// Note that this is not equal to the return value of [`enumerate_required_extensions`] on Unix due to the multiple window types.
-pub const UNIX_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
+#[allow(dead_code)]
+const UNIX_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::WaylandSurface::name().as_ptr(),
     khr::XlibSurface::name().as_ptr(),
     khr::XcbSurface::name().as_ptr(),
 ];
 /// Extensions necessary for creating a surface on android.
-pub const ANDROID_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
+#[allow(dead_code)]
+const ANDROID_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     khr::AndroidSurface::name().as_ptr(),
 ];
 /// Extensions necessary for creating a surface on macos.
-pub const MACOS_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
+#[allow(dead_code)]
+const MACOS_SURFACE_EXTENSIONS: &'static [*const c_char] = &[
     khr::Surface::name().as_ptr(),
     ext::MetalSurface::name().as_ptr(),
 ];
 /// Extensions necessary for creating a surface on ios.
-pub const IOS_SURFACE_EXTENSIONS: &'static [*const c_char] = MACOS_SURFACE_EXTENSIONS;
+#[allow(dead_code)]
+const IOS_SURFACE_EXTENSIONS: &'static [*const c_char] = MACOS_SURFACE_EXTENSIONS;
 
 /// Extensions necessary for creating a surface on the current target platform.
 /// (Note that on Unix, this is not equal to the return value of [`enumerate_required_extensions`])


### PR DESCRIPTION
This pull request adds a constant `TARGET_EXTENSIONS` to ash_window, which allows people to create the `Instance` before the window by using it instead of `enumerate_required_extensions`. (see #595)