### PR TITLE
ash/entry: Fix `trivial_casts` lint warning on Android/aarch64

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -194,10 +194,12 @@ impl Entry {
         unsafe {
             let mut api_version = 0;
             let enumerate_instance_version: Option<vk::PFN_vkEnumerateInstanceVersion> = {
-                let name = b"vkEnumerateInstanceVersion\0".as_ptr() as *const _;
+                let name = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkEnumerateInstanceVersion\0",
+                );
                 mem::transmute((self.static_fn.get_instance_proc_addr)(
                     vk::Instance::null(),
-                    name,
+                    name.as_ptr(),
                 ))
             };
             if let Some(enumerate_instance_version) = enumerate_instance_version {


### PR DESCRIPTION
On certain platforms including Android and `aarch64` `c_char` is unsigned, resulting in the same `u8` type as the byte-string here making the cast redundant.

Just like any other code calling `get_instance_proc_addr`, use `CStr::from_bytes_with_nul_unchecked` which abstracts away any pointer-cast.
