### PR TITLE
extensions/ext: Add VK_EXT_sample_locations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `VK_EXT_sample_locations` device extension (#616)
 - Update Vulkan-Headers to 1.3.211 (#605, #608)
 
 ### Removed

--- a/ash/src/extensions/ext/mod.rs
+++ b/ash/src/extensions/ext/mod.rs
@@ -12,6 +12,7 @@ pub use self::headless_surface::HeadlessSurface;
 pub use self::metal_surface::MetalSurface;
 pub use self::physical_device_drm::PhysicalDeviceDrm;
 pub use self::private_data::PrivateData;
+pub use self::sample_locations::SampleLocations;
 pub use self::tooling_info::ToolingInfo;
 
 mod buffer_device_address;
@@ -28,4 +29,5 @@ mod headless_surface;
 mod metal_surface;
 mod physical_device_drm;
 mod private_data;
+mod sample_locations;
 mod tooling_info;

--- a/ash/src/extensions/ext/sample_locations.rs
+++ b/ash/src/extensions/ext/sample_locations.rs
@@ -1,0 +1,50 @@
+use crate::vk;
+use crate::{Entry, Instance};
+use std::ffi::CStr;
+use std::mem;
+
+/// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_sample_locations.html>
+#[derive(Clone)]
+pub struct SampleLocations {
+    fp: vk::ExtSampleLocationsFn,
+}
+
+impl SampleLocations {
+    pub fn new(entry: &Entry, instance: &Instance) -> Self {
+        let fp = vk::ExtSampleLocationsFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        });
+        Self { fp }
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceMultisamplePropertiesEXT.html>
+    pub unsafe fn get_physical_device_multisample_properties(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        samples: vk::SampleCountFlags,
+        multisample_properties: &mut vk::MultisamplePropertiesEXT,
+    ) {
+        (self.fp.get_physical_device_multisample_properties_ext)(
+            physical_device,
+            samples,
+            multisample_properties,
+        )
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetSampleLocationsEXT.html>
+    pub unsafe fn cmd_set_sample_locations(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        sample_locations_info: &vk::SampleLocationsInfoEXT,
+    ) {
+        (self.fp.cmd_set_sample_locations_ext)(command_buffer, sample_locations_info)
+    }
+
+    pub const fn name() -> &'static CStr {
+        vk::ExtSampleLocationsFn::name()
+    }
+
+    pub fn fp(&self) -> &vk::ExtSampleLocationsFn {
+        &self.fp
+    }
+}


### PR DESCRIPTION
CC @coffeenotfound

Note that this is again a "device" extension that we can't load as such because it needs to load an instance function that operates on a `physical_device`.
