### PR TITLE
examples: Fix validation errors on macOS and iOS

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -15,6 +15,11 @@ use std::ffi::CStr;
 use std::ops::Drop;
 use std::os::raw::c_char;
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use ash::vk::{
+    KhrGetPhysicalDeviceProperties2Fn, KhrPortabilityEnumerationFn, KhrPortabilitySubsetFn,
+};
+
 use winit::{
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -229,6 +234,13 @@ impl ExampleBase {
                 .to_vec();
             extension_names.push(DebugUtils::name().as_ptr());
 
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            {
+                extension_names.push(KhrPortabilityEnumerationFn::name().as_ptr());
+                // Enabling this extension is a requirement when using `VK_KHR_portability_subset`
+                extension_names.push(KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+            }
+
             let appinfo = vk::ApplicationInfo::default()
                 .application_name(app_name)
                 .application_version(0)
@@ -236,10 +248,17 @@ impl ExampleBase {
                 .engine_version(0)
                 .api_version(vk::make_api_version(0, 1, 0, 0));
 
+            let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+                vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+            } else {
+                vk::InstanceCreateFlags::default()
+            };
+
             let create_info = vk::InstanceCreateInfo::default()
                 .application_info(&appinfo)
                 .enabled_layer_names(&layers_names_raw)
-                .enabled_extension_names(&extension_names);
+                .enabled_extension_names(&extension_names)
+                .flags(create_flags);
 
             let instance: Instance = entry
                 .create_instance(&create_info, None)
@@ -293,7 +312,11 @@ impl ExampleBase {
                 })
                 .expect("Couldn't find suitable device.");
             let queue_family_index = queue_family_index as u32;
-            let device_extension_names_raw = [Swapchain::name().as_ptr()];
+            let device_extension_names_raw = [
+                Swapchain::name().as_ptr(),
+                #[cfg(any(target_os = "macos", target_os = "ios"))]
+                KhrPortabilitySubsetFn::name().as_ptr(),
+            ];
             let features = vk::PhysicalDeviceFeatures {
                 shader_clip_distance: 1,
                 ..Default::default()


### PR DESCRIPTION
When trying to run the examples on macOS, I was seeing the following validation errors:

<details>
<summary>Error: vkCreateDevice: VK_KHR_portability_subset must be enabled [...]</summary>
ERROR: VALIDATION [VUID-VkDeviceCreateInfo-pProperties-04451 (976972960)] : Validation Error: [ VUID-VkDeviceCreateInfo-pProperties-04451 ] Object 0: handle = 0x6000001f8020, type = VK_OBJECT_TYPE_PHYSICAL_DEVICE; | MessageID = 0x3a3b6ca0 | vkCreateDevice: VK_KHR_portability_subset must be enabled because physical device VkPhysicalDevice 0x6000001f8020[] supports it The Vulkan spec states: If the VK_KHR_portability_subset extension is included in pProperties of vkEnumerateDeviceExtensionProperties, ppEnabledExtensionNames must include "VK_KHR_portability_subset" (https://vulkan.lunarg.com/doc/view/1.3.211.0/mac/1.3-extensions/vkspec.html#VUID-VkDeviceCreateInfo-pProperties-04451)
</details>

<details>
<summary>Error: Attempting to create a VkDevice from a VkPhysicalDevice which is from a portability driver without the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR [...]</summary>
ERROR: GENERAL [Loader Message (0)] : vkCreateDevice: Attempting to create a VkDevice from a VkPhysicalDevice which is from a portability driver without the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit in the VkInstanceCreateInfo flags being set and the VK_KHR_portability_enumeration extension enabled. In future versions of the loader this VkPhysicalDevice will not be enumerated.
</details>

I was able to fix these errors with the attached changes, and later realized they are somewhat similar to #466. As far as I can tell (from the error messages) enabling these extensions is required by the spec for running on macOS, but I'm quite new to Vulkan, so I might be wrong.

In any case, feedback is appreciated :)