### PR TITLE
Document crate `feature`s in library docs

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -14,14 +14,13 @@ rust-version = "1.59.0"
 [dependencies]
 libloading = { version = "0.7", optional = true }
 
-# note: features are also documented at the top of lib.rs
 [features]
 default = ["loaded", "debug"]
 # Link the Vulkan loader at compile time.
 linked = []
 # Support searching for the Vulkan loader manually at runtime.
 loaded = ["libloading"]
-# Whether Vulkan structs should implement Debug
+# Whether Vulkan structs should implement Debug.
 debug = []
 
 [package.metadata.release]

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.59.0"
 [dependencies]
 libloading = { version = "0.7", optional = true }
 
+# note: features are also documented at the top of lib.rs
 [features]
 default = ["loaded", "debug"]
 # Link the Vulkan loader at compile time.

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! ## Crate features
 //!
-//! * **debug** (default): Whether Vulkan structs should implement Debug.
+//! * **debug** (default): Whether Vulkan structs should implement `Debug`.
 //! * **loaded** (default): Support searching for the Vulkan loader manually at runtime.
 //! * **linked**: Link the Vulkan loader at compile time.
 

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -34,11 +34,11 @@
 //! using [`Entry::load()`], which uses `libloading`. If you want to perform entry point loading
 //! yourself, call [`Entry::from_static_fn()`].
 //!
-//! ## Create features
+//! ## Crate features
 //!
-//! * __debug__ (default): Whether Vulkan structs should implement Debug.
-//! * __loaded__ (default): Support searching for the Vulkan loader manually at runtime.
-//! * __linked__: Link the Vulkan loader at compile time.
+//! * **debug** (default): Whether Vulkan structs should implement Debug.
+//! * **loaded** (default): Support searching for the Vulkan loader manually at runtime.
+//! * **linked**: Link the Vulkan loader at compile time.
 
 pub use crate::device::Device;
 pub use crate::entry::Entry;

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -36,9 +36,9 @@
 //!
 //! ## Create features
 //!
-//! * **linked** - Link the Vulkan loader at compile time.
-//! * **loaded** (default) - Support searching for the Vulkan loader manually at runtime.
-//! * **debug** (default) - Whether Vulkan structs should implement Debug
+//! * __debug__ (default): Whether Vulkan structs should implement Debug.
+//! * __loaded__ (default): Support searching for the Vulkan loader manually at runtime.
+//! * __linked__: Link the Vulkan loader at compile time.
 
 pub use crate::device::Device;
 pub use crate::entry::Entry;

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -33,6 +33,12 @@
 //! Load the Vulkan library linked at compile time using [`Entry::linked()`], or load it at runtime
 //! using [`Entry::load()`], which uses `libloading`. If you want to perform entry point loading
 //! yourself, call [`Entry::from_static_fn()`].
+//!
+//! ## Create features
+//!
+//! * **linked** - Link the Vulkan loader at compile time.
+//! * **loaded** (default) - Support searching for the Vulkan loader manually at runtime.
+//! * **debug** (default) - Whether Vulkan structs should implement Debug
 
 pub use crate::device::Device;
 pub use crate::entry::Entry;


### PR DESCRIPTION
Closes #583

Just copied and pasted the Cargo.toml feature comments into lib.rs based on the first recommendation on the [cargo feature docs](https://doc.rust-lang.org/cargo/reference/features.html#feature-documentation-and-discovery) (which links [regex](https://github.com/rust-lang/regex/blob/1.4.2/src/lib.rs#L488-L583) as reference). Also added a note in Cargo.toml so that anyone who updates features in the future knows to also update the docs.

**Reasoning:**
Makes feature descriptions more accessible (see discussion on issue #583). Currently you can see the list of ash features on [docs.rs](https://docs.rs/crate/ash/latest/features) but need to get Cargo.toml to see what they do. All three features seem to have potential utility for users imo.