### PR TITLE
Release `ash 0.37.1`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - ReleaseDate
+## [0.37.1] - 2022-11-23
 
 ### Changed
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `VK_EXT_image_drm_format_modifier` device extension (#603)
+- Set MSRV (Minimum Supported Rust Version) in `Cargo.toml` for clearer errors (#604)
 - Update Vulkan-Headers to 1.3.235 (#605, #608, #619, #655, #667)
 - Added `const STRUCTURE_TYPE` to all Vulkan structures for matching with `match_struct!` macro (#614)
 - Added `VK_EXT_sample_locations` device extension (#616)
@@ -349,7 +350,8 @@ flags: vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER_BIT,
 can write to aligned memory.
 
 
-[Unreleased]: https://github.com/MaikKlein/ash/compare/0.37.0...HEAD
+[Unreleased]: https://github.com/MaikKlein/ash/compare/0.37.1...HEAD
+[0.37.1]: https://github.com/MaikKlein/ash/releases/tag/0.37.1
 [0.37.0]: https://github.com/MaikKlein/ash/releases/tag/0.37.0
 [0.36.0]: https://github.com/MaikKlein/ash/releases/tag/0.36.0
 [0.35.2]: https://github.com/MaikKlein/ash/releases/tag/0.35.2

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "ash"
-version = "0.37.0+1.3.235"
-authors = ["maik klein <maikklein@googlemail.com>"]
+version = "0.37.1+1.3.235"
+authors = [
+    "Maik Klein <maikklein@googlemail.com>",
+    "Benjamin Saunders <ben.e.saunders@gmail.com>",
+    "Marijn Suijten <marijn@traverseresearch.nl>",
+]
 description = "Vulkan bindings for Rust"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/MaikKlein/ash"


### PR DESCRIPTION
Since we don't seem to be gaining much traction on the `vk.xml` fixes (the ball is with Khronos to come up with a better way to represent these types) I'd like to get a patch release out now with new features and extensions requested by the community.  We can always release more patch versions, there's no harm in that.

I'd like to get #629 / #630 / #631 in for this release too, and perhaps #614 if we can.  As soon as those are merged to `main` I'll backport them to the `0.37-stable` branch and update the changelog accordingly.

After the release I'll update the version and changelog on `main` to reflect what has landed in `0.37.1`, and what has yet to come in a future release.
