### PR TITLE
Remove unused `version.rs` module file from git

### DIFF
--- a/ash/src/version.rs
+++ b/ash/src/version.rs
@@ -1,3 +1,0 @@
-pub use crate::device::{DeviceV1_0, DeviceV1_1, DeviceV1_2};
-pub use crate::entry::{EntryV1_0, EntryV1_1, EntryV1_2};
-pub use crate::instance::{InstanceV1_0, InstanceV1_1, InstanceV1_2};


### PR DESCRIPTION
This seems to have been forgotten in #412.
