### PR TITLE
Fix invalid data length calculated in `get_query_pool_results()` when called with `WITH_AVAILABILITY` flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed experimental AMD extensions (#607)
 
+### Fixed
+
+-  Fix invalid data length calculated inside of `get_query_pool_results` when called with `WITH_AVAILABILITY` flag (#640)
+
 ## [0.37.0] - 2022-03-23
 
 ### Changed

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -2025,7 +2025,7 @@ impl Device {
             data_length <= data.len(),
             "query_count was higher than the length of the slice"
         );
-        let data_size = mem::size_of::<T>() * data.len();
+        let data_size = mem::size_of_val(data);
         (self.device_fn_1_0.get_query_pool_results)(
             self.handle(),
             query_pool,

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -2025,7 +2025,7 @@ impl Device {
             data_length <= data.len(),
             "query_count was higher than the length of the slice"
         );
-        let data_size = mem::size_of::<T>() * data_length;
+        let data_size = mem::size_of::<T>() * data.len();
         (self.device_fn_1_0.get_query_pool_results)(
             self.handle(),
             query_pool,


### PR DESCRIPTION
Fixes #639