### PR TITLE
ash-window: Upgrade `winit` example to `0.26`

### DIFF
--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -22,7 +22,7 @@ raw-window-handle = "0.3.4"
 raw-window-metal = "0.1"
 
 [dev-dependencies]
-winit = "0.19.4"
+winit = "0.26"
 ash = { path = "../ash", version = "0.37", default-features = false, features = ["linked"] }
 
 [[example]]


### PR DESCRIPTION
We'll bump to 0.26 now so that we can land #505 with `raw-window-handle 0.4`, and shortly after bump to `raw-window-handle 0.5` + `winit 0.27` which have to be updated in unison. I'll perhaps make an intermediary release for `ash-window` to give users the opportunity to use `raw-window-handle 0.4`, which isn't (as a _consumer_) backwards nor forwards compatible with neither `0.3` nor `0.5`.