### PR TITLE
device: Replace `query_count` parameter in `get_query_pool_results` with `data.len()`

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -2016,21 +2016,15 @@ impl Device {
         &self,
         query_pool: vk::QueryPool,
         first_query: u32,
-        query_count: u32,
         data: &mut [T],
         flags: vk::QueryResultFlags,
     ) -> VkResult<()> {
-        let data_length = query_count as usize;
-        assert!(
-            data_length <= data.len(),
-            "query_count was higher than the length of the slice"
-        );
-        let data_size = mem::size_of::<T>() * data_length;
+        let data_size = mem::size_of_val(data);
         (self.device_fn_1_0.get_query_pool_results)(
             self.handle(),
             query_pool,
             first_query,
-            query_count,
+            data.len() as u32,
             data_size,
             data.as_mut_ptr() as *mut _,
             mem::size_of::<T>() as _,


### PR DESCRIPTION
Supersedes #640

A slice is designed to be a cheap view into a continuous segment of memory and easily recreated with a different offset and size.  This can be used to our advantage to let the user set exactly how many items they want to request, while ensuring all returned slots are filled on success or otherwise return `NOT_READY` if not enough query results could be copied to user memory (or block if the `WAIT` flag is set).

This also opens the door to accepting `MaybeUninit` in the future and returning the initialized slice in the `VkResult::Ok(here)` case.