### PR TITLE
vk/prelude: Drop upstream-fixed `Self::` doc workaround

### DIFF
--- a/ash/src/vk/prelude.rs
+++ b/ash/src/vk/prelude.rs
@@ -29,11 +29,7 @@ impl Packed24_8 {
     }
 }
 
-// Intradoc `Self::` links refuse to resolve if `ColorComponentFlags`
-// isn't directly in scope: https://github.com/rust-lang/rust/issues/93205
-use vk::ColorComponentFlags;
-
-impl ColorComponentFlags {
+impl vk::ColorComponentFlags {
     /// Contraction of [`R`][Self::R] | [`G`][Self::G] | [`B`][Self::B] | [`A`][Self::A]
     pub const RGBA: Self = Self(Self::R.0 | Self::G.0 | Self::B.0 | Self::A.0);
 }


### PR DESCRIPTION
The report at https://github.com/rust-lang/rust/issues/93205 was closed as it has presumably been fixed in https://github.com/rust-lang/rust/pull/93805 which has long trickled down into stable releases, and I cannot reproduce the issue on `1.62.1` anymore (latest stable as of writing) 🎉

This workaround was originally added in #559.
