### PR TITLE
Add `vk-mem-alloc-rs` crate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ cargo run --bin texture
 ### Utility libraries
 * [vk-sync](https://github.com/gwihlidal/vk-sync-rs) - Simplified Vulkan synchronization logic, written in rust.
 * [vk-mem-rs](https://github.com/gwihlidal/vk-mem-rs) - This crate provides an FFI layer and idiomatic rust wrappers for the excellent AMD Vulkan Memory Allocator (VMA) C/C++ library.
+* [vk-mem-alloc-rs](https://github.com/projectkml/vk-mem-alloc-rs) - A very lightweight wrapper around the AMD Vulkan Memory Allocator
 * [gpu-allocator](https://github.com/Traverse-Research/gpu-allocator) - Memory allocator written in pure Rust for GPU memory in Vulkan and in the future DirectX 12
 * [lahar](https://github.com/Ralith/lahar) - Tools for asynchronously uploading data to a Vulkan device.
 


### PR DESCRIPTION
Hey, I created a crate called `vk-mem-alloc-rs`. It's a very lightweight wrapper around the `Vulkan Memory Allocator` by AMD. I know that there is `vk-mem-rs`, but there hasn't been any update on `crates.io` for over two years now, so I think its okay to make a second crate there.

My thought was to add it to the `README` file. If you are interested, feel free to merge the pull request.
I am also available for suggestions for improvement and good ideas !:)

Here is a link to the repository:
https://github.com/projectkml/vk-mem-alloc-rs