### PR TITLE
Add optional SmallVec support

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.59.0"
 
 [dependencies]
 libloading = { version = "0.7", optional = true }
-smallvec = { version = "1.9.0", features = ["union", "const_generics", "const_new", "write"], optional = true}
+smallvec = { version = "1.9.0", features = ["union"], optional = true}
 
 [features]
 default = ["loaded", "debug"]

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.59.0"
 
 [dependencies]
 libloading = { version = "0.7", optional = true }
+smallvec = { version = "1.9.0", features = ["union", "const_generics", "const_new", "write"], optional = true}
 
 [features]
 default = ["loaded", "debug"]

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -2680,6 +2680,7 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSparseMemoryRequirements.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_image_sparse_memory_requirements(
         &self,
         image: vk::Image,
@@ -2695,5 +2696,25 @@ impl Device {
         })
         // The closure always returns SUCCESS
         .unwrap()
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSparseMemoryRequirements.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_image_sparse_memory_requirements(
+        &self,
+        image: vk::Image,
+    ) -> smallvec::SmallVec<[vk::SparseImageMemoryRequirements; SMALLVEC_SIZE]> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.device_fn_1_0.get_image_sparse_memory_requirements)(
+                self.handle(),
+                image,
+                count,
+                data,
+            );
+            vk::Result::SUCCESS
+        })
+            // The closure always returns SUCCESS
+            .unwrap()
     }
 }

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -238,6 +238,7 @@ impl Entry {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateInstanceLayerProperties.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub fn enumerate_instance_layer_properties(&self) -> VkResult<Vec<vk::LayerProperties>> {
         unsafe {
             read_into_uninitialized_vector(|count, data| {
@@ -246,14 +247,44 @@ impl Entry {
         }
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateInstanceLayerProperties.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub fn enumerate_instance_layer_properties(&self) -> VkResult<smallvec::SmallVec<[vk::LayerProperties; SMALLVEC_SIZE]>> {
+        unsafe {
+            read_into_uninitialized_small_vector(|count, data| {
+                (self.entry_fn_1_0.enumerate_instance_layer_properties)(count, data)
+            })
+        }
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateInstanceExtensionProperties.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub fn enumerate_instance_extension_properties(
         &self,
         layer_name: Option<&CStr>,
     ) -> VkResult<Vec<vk::ExtensionProperties>> {
         unsafe {
             read_into_uninitialized_vector(|count, data| {
+                (self.entry_fn_1_0.enumerate_instance_extension_properties)(
+                    layer_name.map_or(ptr::null(), |str| str.as_ptr()),
+                    count,
+                    data,
+                )
+            })
+        }
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateInstanceExtensionProperties.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub fn enumerate_instance_extension_properties(
+        &self,
+        layer_name: Option<&CStr>,
+    ) -> VkResult<smallvec::SmallVec<[vk::ExtensionProperties; SMALLVEC_SIZE]>> {
+        unsafe {
+            read_into_uninitialized_small_vector(|count, data| {
                 (self.entry_fn_1_0.enumerate_instance_extension_properties)(
                     layer_name.map_or(ptr::null(), |str| str.as_ptr()),
                     count,

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -30,12 +30,31 @@ impl FullScreenExclusive {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModes2EXT.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_surface_present_modes2(
         &self,
         physical_device: vk::PhysicalDevice,
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
+            (self.fp.get_physical_device_surface_present_modes2_ext)(
+                physical_device,
+                surface_info,
+                count,
+                data,
+            )
+        })
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModes2EXT.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_surface_present_modes2(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::PresentModeKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
             (self.fp.get_physical_device_surface_present_modes2_ext)(
                 physical_device,
                 surface_info,

--- a/ash/src/extensions/khr/device_group.rs
+++ b/ash/src/extensions/khr/device_group.rs
@@ -113,12 +113,38 @@ impl DeviceGroup {
     /// [Vulkan 1.1]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_VERSION_1_1.html
     /// [`VK_KHR_surface`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface.html
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_present_rectangles(
         &self,
         physical_device: vk::PhysicalDevice,
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::Rect2D>> {
         read_into_uninitialized_vector(|count, data| {
+            (self.fp.get_physical_device_present_rectangles_khr)(
+                physical_device,
+                surface,
+                count,
+                data,
+            )
+        })
+    }
+
+    /// Requires [`VK_KHR_surface`] to be enabled.
+    ///
+    /// Also available as [`Swapchain::get_physical_device_present_rectangles()`] since [Vulkan 1.1].
+    ///
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDevicePresentRectanglesKHR.html>
+    ///
+    /// [Vulkan 1.1]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_VERSION_1_1.html
+    /// [`VK_KHR_surface`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface.html
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_present_rectangles(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::Rect2D; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
             (self.fp.get_physical_device_present_rectangles_khr)(
                 physical_device,
                 surface,

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -22,6 +22,7 @@ impl Display {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceDisplayPropertiesKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_display_properties(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -31,8 +32,21 @@ impl Display {
         })
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceDisplayPropertiesKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_display_properties(
+        &self,
+        physical_device: vk::PhysicalDevice,
+    ) -> VkResult<smallvec::SmallVec<[vk::DisplayPropertiesKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.fp.get_physical_device_display_properties_khr)(physical_device, count, data)
+        })
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceDisplayPlanePropertiesKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_display_plane_properties(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -42,8 +56,21 @@ impl Display {
         })
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceDisplayPlanePropertiesKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_display_plane_properties(
+        &self,
+        physical_device: vk::PhysicalDevice,
+    ) -> VkResult<smallvec::SmallVec<[vk::DisplayPlanePropertiesKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.fp.get_physical_device_display_plane_properties_khr)(physical_device, count, data)
+        })
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDisplayPlaneSupportedDisplaysKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_display_plane_supported_displays(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -59,14 +86,46 @@ impl Display {
         })
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDisplayPlaneSupportedDisplaysKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_display_plane_supported_displays(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        plane_index: u32,
+    ) -> VkResult<smallvec::SmallVec<[vk::DisplayKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.fp.get_display_plane_supported_displays_khr)(
+                physical_device,
+                plane_index,
+                count,
+                data,
+            )
+        })
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDisplayModePropertiesKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_display_mode_properties(
         &self,
         physical_device: vk::PhysicalDevice,
         display: vk::DisplayKHR,
     ) -> VkResult<Vec<vk::DisplayModePropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
+            (self.fp.get_display_mode_properties_khr)(physical_device, display, count, data)
+        })
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDisplayModePropertiesKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_display_mode_properties(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        display: vk::DisplayKHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::DisplayModePropertiesKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
             (self.fp.get_display_mode_properties_khr)(physical_device, display, count, data)
         })
     }

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -40,12 +40,31 @@ impl Surface {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_surface_present_modes(
         &self,
         physical_device: vk::PhysicalDevice,
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
+            (self.fp.get_physical_device_surface_present_modes_khr)(
+                physical_device,
+                surface,
+                count,
+                data,
+            )
+        })
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_surface_present_modes(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::PresentModeKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
             (self.fp.get_physical_device_surface_present_modes_khr)(
                 physical_device,
                 surface,
@@ -73,12 +92,26 @@ impl Surface {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_surface_formats(
         &self,
         physical_device: vk::PhysicalDevice,
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::SurfaceFormatKHR>> {
         read_into_uninitialized_vector(|count, data| {
+            (self.fp.get_physical_device_surface_formats_khr)(physical_device, surface, count, data)
+        })
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_surface_formats(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::SurfaceFormatKHR; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
             (self.fp.get_physical_device_surface_formats_khr)(physical_device, surface, count, data)
         })
     }

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -51,11 +51,24 @@ impl Swapchain {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetSwapchainImagesKHR.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_swapchain_images(
         &self,
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<Vec<vk::Image>> {
         read_into_uninitialized_vector(|count, data| {
+            (self.fp.get_swapchain_images_khr)(self.handle, swapchain, count, data)
+        })
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetSwapchainImagesKHR.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_swapchain_images(
+        &self,
+        swapchain: vk::SwapchainKHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::Image; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
             (self.fp.get_swapchain_images_khr)(self.handle, swapchain, count, data)
         })
     }
@@ -154,6 +167,7 @@ impl Swapchain {
     /// [Vulkan 1.1]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_VERSION_1_1.html
     /// [`VK_KHR_surface`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface.html
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_present_rectangles(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -169,6 +183,31 @@ impl Swapchain {
         })
     }
 
+    /// Only available since [Vulkan 1.1].
+    ///
+    /// Also available as [`DeviceGroup::get_physical_device_present_rectangles()`]
+    /// when [`VK_KHR_surface`] is enabled.
+    ///
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDevicePresentRectanglesKHR.html>
+    ///
+    /// [Vulkan 1.1]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_VERSION_1_1.html
+    /// [`VK_KHR_surface`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface.html
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_present_rectangles(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> VkResult<smallvec::SmallVec<[vk::Rect2D; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.fp.get_physical_device_present_rectangles_khr)(
+                physical_device,
+                surface,
+                count,
+                data,
+            )
+        })
+    }
     /// On success, returns the next image's index and whether the swapchain is suboptimal for the surface.
     ///
     /// Only available since [Vulkan 1.1].

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -441,6 +441,7 @@ impl Instance {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_queue_family_properties(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -457,6 +458,25 @@ impl Instance {
         .unwrap()
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_queue_family_properties(
+        &self,
+        physical_device: vk::PhysicalDevice,
+    ) -> smallvec::SmallVec<[vk::QueueFamilyProperties; SMALLVEC_SIZE]> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self
+                .instance_fn_1_0
+                .get_physical_device_queue_family_properties)(
+                physical_device, count, data
+            );
+            vk::Result::SUCCESS
+        })
+            // The closure always returns SUCCESS
+            .unwrap()
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceFeatures.html>
     #[inline]
     pub unsafe fn get_physical_device_features(
@@ -470,14 +490,25 @@ impl Instance {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumeratePhysicalDevices.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn enumerate_physical_devices(&self) -> VkResult<Vec<vk::PhysicalDevice>> {
         read_into_uninitialized_vector(|count, data| {
             (self.instance_fn_1_0.enumerate_physical_devices)(self.handle(), count, data)
         })
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumeratePhysicalDevices.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn enumerate_physical_devices(&self) -> VkResult<smallvec::SmallVec<[vk::PhysicalDevice; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.instance_fn_1_0.enumerate_physical_devices)(self.handle(), count, data)
+        })
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateDeviceExtensionProperties.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn enumerate_device_extension_properties(
         &self,
         device: vk::PhysicalDevice,
@@ -492,8 +523,26 @@ impl Instance {
         })
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateDeviceExtensionProperties.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn enumerate_device_extension_properties(
+        &self,
+        device: vk::PhysicalDevice,
+    ) -> VkResult<smallvec::SmallVec<[vk::ExtensionProperties; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.instance_fn_1_0.enumerate_device_extension_properties)(
+                device,
+                ptr::null(),
+                count,
+                data,
+            )
+        })
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateDeviceLayerProperties.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn enumerate_device_layer_properties(
         &self,
         device: vk::PhysicalDevice,
@@ -503,8 +552,21 @@ impl Instance {
         })
     }
 
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateDeviceLayerProperties.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn enumerate_device_layer_properties(
+        &self,
+        device: vk::PhysicalDevice,
+    ) -> VkResult<smallvec::SmallVec<[vk::LayerProperties; SMALLVEC_SIZE]>> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self.instance_fn_1_0.enumerate_device_layer_properties)(device, count, data)
+        })
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties.html>
     #[inline]
+    #[cfg(not(feature = "smallvec"))]
     pub unsafe fn get_physical_device_sparse_image_format_properties(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -531,5 +593,36 @@ impl Instance {
         })
         // The closure always returns SUCCESS
         .unwrap()
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties.html>
+    #[inline]
+    #[cfg(feature = "smallvec")]
+    pub unsafe fn get_physical_device_sparse_image_format_properties(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        format: vk::Format,
+        typ: vk::ImageType,
+        samples: vk::SampleCountFlags,
+        usage: vk::ImageUsageFlags,
+        tiling: vk::ImageTiling,
+    ) -> smallvec::SmallVec<[vk::SparseImageFormatProperties; SMALLVEC_SIZE]> {
+        read_into_uninitialized_small_vector(|count, data| {
+            (self
+                .instance_fn_1_0
+                .get_physical_device_sparse_image_format_properties)(
+                physical_device,
+                format,
+                typ,
+                samples,
+                usage,
+                tiling,
+                count,
+                data,
+            );
+            vk::Result::SUCCESS
+        })
+            // The closure always returns SUCCESS
+            .unwrap()
     }
 }

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -39,6 +39,7 @@
 //! * **debug** (default): Whether Vulkan structs should implement `Debug`.
 //! * **loaded** (default): Support searching for the Vulkan loader manually at runtime.
 //! * **linked**: Link the Vulkan loader at compile time.
+//! * **smallvec**: Make most functions that would normally return a Vec return a SmallVec
 
 pub use crate::device::Device;
 pub use crate::entry::Entry;

--- a/ash/src/prelude.rs
+++ b/ash/src/prelude.rs
@@ -49,6 +49,7 @@ where
     }
 }
 
+/// Size of the internal array for SmallVec
 #[cfg(feature = "smallvec")]
 pub(crate) const SMALLVEC_SIZE: usize = 16;
 


### PR DESCRIPTION
This pull request adds the [smallvec](https://crates.io/crates/smallvecl) crate as an optional dependency and makes most functions that would normally return a `Vec<T>` return a `SmallVec<[T;16]>` when the "smallvec" feature is enabled. Since many ash functions are likely to only return a relatively small number of elements, this can help avoid unnecessary heap allocation.

The API is exactly the same as the existing ash functions, and in fact I mostly copied the existing functions and just modified them to return a SmallVec instead of a Vec. Everything is gated behind the "smallvec" feature flag, so it is completely optional and does not change how ash works unless the feature is enabled.

I currently have chosen 16 as the size of the array for SmallVec, though it might be better to allow the user to choose an array size with a const generic parameter instead. This would be a bit more flexible, but I was trying to keep the API identical to the existing ash functions.
