### PR TITLE
extensions/khr/ray_tracing_pipeline: Set length of capture-replay shader handle buffer after filling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed experimental AMD extensions (#607)
 
+### Fixed
+
+- `khr::RayTracingPipeline`: Set the buffer length in `get_ray_tracing_capture_replay_shader_group_handles` so it no longer always returns an empty `Vec` (#658)
+
 ## [0.37.0] - 2022-03-23
 
 ### Changed

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -113,7 +113,7 @@ impl RayTracingPipeline {
     ) -> VkResult<Vec<u8>> {
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
 
-        (self
+        let err_code = (self
             .fp
             .get_ray_tracing_capture_replay_shader_group_handles_khr)(
             self.handle,
@@ -122,8 +122,9 @@ impl RayTracingPipeline {
             group_count,
             data_size,
             data.as_mut_ptr() as *mut _,
-        )
-        .result_with_success(data)
+        );
+        data.set_len(data_size);
+        err_code.result_with_success(data)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdTraceRaysIndirectKHR.html>

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -112,7 +112,6 @@ impl RayTracingPipeline {
         data_size: usize,
     ) -> VkResult<Vec<u8>> {
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
-
         let err_code = (self
             .fp
             .get_ray_tracing_capture_replay_shader_group_handles_khr)(


### PR DESCRIPTION
Because the capacity is allocated but the length of the vector is not set, the vec returned from `get_ray_tracing_capture_replay_shader_group_handles` will always appear to be empty. I checked for other mistakes of this nature and did not locate any.