### PR TITLE
ash-window: Link to the `ash` gitter instead of nonexistent `ash-window`

### DIFF
--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -7,7 +7,7 @@ Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-win
 [![Build Status](https://github.com/MaikKlein/ash/workflows/CI/badge.svg)](https://github.com/MaikKlein/ash/actions?workflow=CI)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
-[![Join the chat at https://gitter.im/MaikKlein/ash-window](https://badges.gitter.im/MaikKlein/ash-window.svg)](https://gitter.im/MaikKlein/ash-window?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/MaikKlein/ash](https://badges.gitter.im/MaikKlein/ash.svg)](https://gitter.im/MaikKlein/ash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Usage
 


### PR DESCRIPTION
It seems there's no gitter channel for `ash-window` (404), and since everyone is in the `ash` channel already, just use the same one.
