### PR TITLE
extensions/ext: Rename `debug_utils_set_object_name` to `set_debug_utils_object_name` and `debug_utils_set_object_tag` to `set_debug_utils_object_tag` for consistency and deprecate old ones

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced builders with lifetimes/setters directly on Vulkan structs (#602)
 - Inlined struct setters (#602)
 - Inlined `Default` impls and trivial `Instance`/`Device`/`Entry` wrapper methods (#606, #632)
-- Renamed `debug_utils_set_object_name` and `debug_utils_set_object_tag` for consistency and deprecated old ones (#661)
+- Renamed `debug_utils_set_object_name` to `set_debug_utils_object_name` and `debug_utils_set_object_tag` to `set_debug_utils_object_tag` for consistency and deprecated old ones (#661)
 
 ### Added
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced builders with lifetimes/setters directly on Vulkan structs (#602)
 - Inlined struct setters (#602)
 - Inlined `Default` impls and trivial `Instance`/`Device`/`Entry` wrapper methods (#606, #632)
+- Renamed `debug_utils_set_object_name` and `debug_utils_set_object_tag` for consistency and deprecated old ones (#661)
 
 ### Added
 

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -20,8 +20,19 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>
+    #[deprecated]
     #[inline]
     pub unsafe fn debug_utils_set_object_name(
+        &self,
+        device: vk::Device,
+        name_info: &vk::DebugUtilsObjectNameInfoEXT,
+    ) -> VkResult<()> {
+        self.set_debug_utils_object_name(device, name_info)
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>
+    #[inline]
+    pub unsafe fn set_debug_utils_object_name(
         &self,
         device: vk::Device,
         name_info: &vk::DebugUtilsObjectNameInfoEXT,
@@ -30,8 +41,19 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>
+    #[deprecated]
     #[inline]
     pub unsafe fn debug_utils_set_object_tag(
+        &self,
+        device: vk::Device,
+        tag_info: &vk::DebugUtilsObjectTagInfoEXT,
+    ) -> VkResult<()> {
+        self.set_debug_utils_object_tag(device, tag_info)
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>
+    #[inline]
+    pub unsafe fn set_debug_utils_object_tag(
         &self,
         device: vk::Device,
         tag_info: &vk::DebugUtilsObjectTagInfoEXT,

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -20,6 +20,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>
+    /// Use `set_debug_utils_object_name` instead for consistency
     #[deprecated]
     #[inline]
     pub unsafe fn debug_utils_set_object_name(
@@ -41,6 +42,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>
+    /// Use `set_debug_utils_object_tag` instead for consistency
     #[deprecated]
     #[inline]
     pub unsafe fn debug_utils_set_object_tag(

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -20,7 +20,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>
-    #[deprecated = "Backwards-compatible alias containing a typo, use `Self::set_debug_utils_object_name()` instead"]
+    #[deprecated = "Backwards-compatible alias containing a typo, use `set_debug_utils_object_name()` instead"]
     #[inline]
     pub unsafe fn debug_utils_set_object_name(
         &self,
@@ -41,7 +41,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>
-    #[deprecated = "Backwards-compatible alias containing a typo, use `Self::set_debug_utils_object_tag()` instead"]
+    #[deprecated = "Backwards-compatible alias containing a typo, use `set_debug_utils_object_tag()` instead"]
     #[inline]
     pub unsafe fn debug_utils_set_object_tag(
         &self,

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -20,7 +20,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>
-    #[deprecated = "Backwards-compatible alias containing a typo, use [`set_debug_utils_object_name`] instead"]
+    #[deprecated = "Backwards-compatible alias containing a typo, use `Self::set_debug_utils_object_name()` instead"]
     #[inline]
     pub unsafe fn debug_utils_set_object_name(
         &self,
@@ -41,7 +41,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>
-    #[deprecated = "Backwards-compatible alias containing a typo, use [`set_debug_utils_object_tag`] instead"]
+    #[deprecated = "Backwards-compatible alias containing a typo, use `Self::set_debug_utils_object_tag()` instead"]
     #[inline]
     pub unsafe fn debug_utils_set_object_tag(
         &self,

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -20,8 +20,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>
-    /// Use `set_debug_utils_object_name` instead for consistency
-    #[deprecated]
+    #[deprecated = "Backwards-compatible alias containing a typo, use [`set_debug_utils_object_name`] instead"]
     #[inline]
     pub unsafe fn debug_utils_set_object_name(
         &self,
@@ -42,8 +41,7 @@ impl DebugUtils {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>
-    /// Use `set_debug_utils_object_tag` instead for consistency
-    #[deprecated]
+    #[deprecated = "Backwards-compatible alias containing a typo, use [`set_debug_utils_object_tag`] instead"]
     #[inline]
     pub unsafe fn debug_utils_set_object_tag(
         &self,


### PR DESCRIPTION
Fixes #660 