### PR TITLE
ban wildcard imports for non-vulkan imports

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -365,7 +365,7 @@ mod loaded {
     use std::error::Error;
     use std::fmt;
 
-    use super::*;
+    use super::MissingEntryPoint;
 
     #[derive(Debug)]
     #[cfg_attr(docsrs, doc(cfg(feature = "loaded")))]

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::use_self)]
+#![deny(clippy::wildcard_imports)]
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![allow(
     clippy::too_many_arguments,

--- a/ash/src/vk/aliases.rs
+++ b/ash/src/vk/aliases.rs
@@ -1,5 +1,8 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::bitflags::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::definitions::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::enums::*;
 pub type GeometryFlagsNV = GeometryFlagsKHR;
 pub type GeometryInstanceFlagsNV = GeometryInstanceFlagsKHR;

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::definitions::*;
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -1,6 +1,9 @@
 use crate::prelude::debug_flags;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::bitflags::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::definitions::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::enums::*;
 use std::fmt;
 impl fmt::Debug for AccelerationStructureBuildTypeKHR {

--- a/ash/src/vk/constants.rs
+++ b/ash/src/vk/constants.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::definitions::*;
 pub const MAX_PHYSICAL_DEVICE_NAME_SIZE: usize = 256;
 pub const UUID_SIZE: usize = 16;

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -1,14 +1,23 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::aliases::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::bitflags::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::constants::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::enums::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::native::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::platform_types::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::prelude::*;
 use crate::vk::{ptr_chain_iter, Handle};
 use std::fmt;
 use std::marker::PhantomData;
-use std::os::raw::*;
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+use std::os::raw::c_void;
 #[deprecated = "This define is deprecated. VK_MAKE_API_VERSION should be used instead."]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_MAKE_VERSION.html>"]
 pub const fn make_version(major: u32, minor: u32, patch: u32) -> u32 {

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -1,9 +1,16 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::aliases::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::bitflags::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::definitions::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::enums::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::platform_types::*;
-use std::os::raw::*;
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+use std::os::raw::c_void;
 impl KhrSurfaceFn {
     #[inline]
     pub const fn name() -> &'static ::std::ffi::CStr {

--- a/ash/src/vk/feature_extensions.rs
+++ b/ash/src/vk/feature_extensions.rs
@@ -1,4 +1,6 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::bitflags::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::enums::*;
 #[doc = "Generated from 'VK_VERSION_1_1'"]
 impl BufferCreateFlags {

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -1,7 +1,11 @@
+#[allow(clippy::wildcard_imports)]
 use crate::vk::bitflags::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::definitions::*;
+#[allow(clippy::wildcard_imports)]
 use crate::vk::enums::*;
-use std::os::raw::*;
+use std::os::raw::c_char;
+use std::os::raw::c_void;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetInstanceProcAddr =
     unsafe extern "system" fn(instance: Instance, p_name: *const c_char) -> PFN_vkVoidFunction;

--- a/ash/src/vk/platform_types.rs
+++ b/ash/src/vk/platform_types.rs
@@ -1,6 +1,8 @@
 #![allow(non_camel_case_types)]
 
-use std::os::raw::*;
+use std::os::raw::c_uint;
+use std::os::raw::c_ulong;
+use std::os::raw::c_void;
 pub type RROutput = c_ulong;
 pub type VisualID = c_uint;
 pub type Display = *const c_void;

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -2573,9 +2573,13 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let mut vk_aliases_file = File::create(vk_dir.join("aliases.rs")).expect("vk/aliases.rs");
 
     let feature_code = quote! {
-        use std::os::raw::*;
+        use std::os::raw::c_char;
+        use std::os::raw::c_void;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::bitflags::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::definitions::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::enums::*;
         #(#feature_code)*
     };
@@ -2583,14 +2587,23 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let definition_code = quote! {
         use std::marker::PhantomData;
         use std::fmt;
-        use std::os::raw::*;
+        use std::os::raw::c_char;
+        use std::os::raw::c_int;
+        use std::os::raw::c_void;
         use crate::vk::{Handle, ptr_chain_iter};
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::aliases::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::bitflags::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::constants::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::enums::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::native::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::platform_types::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::prelude::*;
         #(#definition_code)*
     };
@@ -2602,43 +2615,60 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     };
 
     let bitflags_code = quote! {
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::definitions::*;
         #(#bitflags_code)*
     };
 
     let constants_code = quote! {
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::definitions::*;
         #(#constants_code)*
     };
 
     let extension_code = quote! {
-        use std::os::raw::*;
+        use std::os::raw::c_char;
+        use std::os::raw::c_int;
+        use std::os::raw::c_void;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::platform_types::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::aliases::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::bitflags::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::definitions::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::enums::*;
         #(#extension_code)*
     };
 
     let feature_extensions_code = quote! {
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::bitflags::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::enums::*;
-       #feature_extensions_code
+        #feature_extensions_code
     };
 
     let const_debugs = quote! {
         use std::fmt;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::bitflags::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::definitions::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::enums::*;
         use crate::prelude::debug_flags;
         #const_debugs
     };
 
     let aliases = quote! {
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::bitflags::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::definitions::*;
+        #[allow(clippy::wildcard_imports)]
         use crate::vk::enums::*;
         #(#aliases)*
     };


### PR DESCRIPTION
The wildcard clean up will help in the future with no_std support to avoid needing to also untangle wildcard imports along with getting the equivalent core and alloc types for imports.