### PR TITLE
extensions/ext: Add VK_EXT_acquire_drm_display

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VK_KHR_device_group_creation` instance extension (#630)
 - Added `VK_KHR_device_group` device extension (#631)
 - Added `VK_EXT_mesh_shader` device extension (#657)
+- Added `VK_EXT_acquire_drm_display` instance extension (#668)
 
 ### Removed
 

--- a/ash/src/extensions/ext/acquire_drm_display.rs
+++ b/ash/src/extensions/ext/acquire_drm_display.rs
@@ -26,14 +26,9 @@ impl AcquireDrmDisplay {
         &self,
         physical_device: vk::PhysicalDevice,
         drm_fd: i32,
-        display: vk::DisplayKHR
+        display: vk::DisplayKHR,
     ) -> VkResult<()> {
-        (self.fp.acquire_drm_display_ext)(
-            physical_device,
-            drm_fd,
-            display
-        )
-        .result()
+        (self.fp.acquire_drm_display_ext)(physical_device, drm_fd, display).result()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDrmDisplayEXT.html>
@@ -42,16 +37,11 @@ impl AcquireDrmDisplay {
         &self,
         physical_device: vk::PhysicalDevice,
         drm_fd: i32,
-        connector_id: u32
+        connector_id: u32,
     ) -> VkResult<vk::DisplayKHR> {
         let mut display = mem::MaybeUninit::uninit();
-        (self.fp.get_drm_display_ext)(
-            physical_device,
-            drm_fd,
-            connector_id,
-            display.as_mut_ptr()
-        )
-        .result_with_success(display.assume_init())
+        (self.fp.get_drm_display_ext)(physical_device, drm_fd, connector_id, display.as_mut_ptr())
+            .result_with_success(display.assume_init())
     }
 
     #[inline]

--- a/ash/src/extensions/ext/acquire_drm_display.rs
+++ b/ash/src/extensions/ext/acquire_drm_display.rs
@@ -1,0 +1,71 @@
+use crate::prelude::*;
+use crate::vk;
+use crate::{Entry, Instance};
+use std::ffi::CStr;
+use std::mem;
+
+/// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_acquire_drm_display.html>
+#[derive(Clone)]
+pub struct AcquireDrmDisplay {
+    handle: vk::Instance,
+    fp: vk::ExtAcquireDrmDisplayFn,
+}
+
+impl AcquireDrmDisplay {
+    pub fn new(entry: &Entry, instance: &Instance) -> Self {
+        let handle = instance.handle();
+        let fp = vk::ExtAcquireDrmDisplayFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
+        });
+        Self { handle, fp }
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkAcquireDrmDisplayEXT.html>
+    #[inline]
+    pub unsafe fn acquire_drm_display(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        drm_fd: i32,
+        display: vk::DisplayKHR
+    ) -> VkResult<()> {
+        (self.fp.acquire_drm_display_ext)(
+            physical_device,
+            drm_fd,
+            display
+        )
+        .result()
+    }
+
+    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDrmDisplayEXT.html>
+    #[inline]
+    pub unsafe fn get_drm_display(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        drm_fd: i32,
+        connector_id: u32
+    ) -> VkResult<vk::DisplayKHR> {
+        let mut display = mem::MaybeUninit::uninit();
+        (self.fp.get_drm_display_ext)(
+            physical_device,
+            drm_fd,
+            connector_id,
+            display.as_mut_ptr()
+        )
+        .result_with_success(display.assume_init())
+    }
+
+    #[inline]
+    pub const fn name() -> &'static CStr {
+        vk::ExtAcquireDrmDisplayFn::name()
+    }
+
+    #[inline]
+    pub fn fp(&self) -> &vk::ExtAcquireDrmDisplayFn {
+        &self.fp
+    }
+
+    #[inline]
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
+}

--- a/ash/src/extensions/ext/acquire_drm_display.rs
+++ b/ash/src/extensions/ext/acquire_drm_display.rs
@@ -7,7 +7,6 @@ use std::mem;
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_acquire_drm_display.html>
 #[derive(Clone)]
 pub struct AcquireDrmDisplay {
-    handle: vk::Instance,
     fp: vk::ExtAcquireDrmDisplayFn,
 }
 
@@ -17,7 +16,7 @@ impl AcquireDrmDisplay {
         let fp = vk::ExtAcquireDrmDisplayFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fp }
+        Self { fp }
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkAcquireDrmDisplayEXT.html>
@@ -52,10 +51,5 @@ impl AcquireDrmDisplay {
     #[inline]
     pub fn fp(&self) -> &vk::ExtAcquireDrmDisplayFn {
         &self.fp
-    }
-
-    #[inline]
-    pub fn instance(&self) -> vk::Instance {
-        self.handle
     }
 }

--- a/ash/src/extensions/ext/mod.rs
+++ b/ash/src/extensions/ext/mod.rs
@@ -1,3 +1,4 @@
+pub use self::acquire_drm_display::AcquireDrmDisplay;
 pub use self::buffer_device_address::BufferDeviceAddress;
 pub use self::calibrated_timestamps::CalibratedTimestamps;
 #[allow(deprecated)]
@@ -18,6 +19,7 @@ pub use self::private_data::PrivateData;
 pub use self::sample_locations::SampleLocations;
 pub use self::tooling_info::ToolingInfo;
 
+mod acquire_drm_display;
 mod buffer_device_address;
 mod calibrated_timestamps;
 #[deprecated(note = "Please use the [DebugUtils](struct.DebugUtils.html) extension instead.")]


### PR DESCRIPTION
Note that https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4136 prevents the use of `vkGetDrmDisplayEXT` while using  `VK_LAYER_KHRONOS_validation`.