### PR TITLE
extensions: Only call `assume_init()` when Vulkan returns `SUCCESS`

### DIFF
--- a/ash/src/extensions/ext/acquire_drm_display.rs
+++ b/ash/src/extensions/ext/acquire_drm_display.rs
@@ -40,7 +40,7 @@ impl AcquireDrmDisplay {
     ) -> VkResult<vk::DisplayKHR> {
         let mut display = mem::MaybeUninit::uninit();
         (self.fp.get_drm_display_ext)(physical_device, drm_fd, connector_id, display.as_mut_ptr())
-            .result_with_success(display.assume_init())
+            .assume_init_on_success(display)
     }
 
     #[inline]

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -88,7 +88,7 @@ impl Display {
             allocation_callbacks.as_raw_ptr(),
             display_mode.as_mut_ptr(),
         )
-        .result_with_success(display_mode.assume_init())
+        .assume_init_on_success(display_mode)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDisplayPlaneCapabilitiesKHR.html>
@@ -106,7 +106,7 @@ impl Display {
             plane_index,
             display_plane_capabilities.as_mut_ptr(),
         )
-        .result_with_success(display_plane_capabilities.assume_init())
+        .assume_init_on_success(display_plane_capabilities)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateDisplayPlaneSurfaceKHR.html>
@@ -123,7 +123,7 @@ impl Display {
             allocation_callbacks.as_raw_ptr(),
             surface.as_mut_ptr(),
         )
-        .result_with_success(surface.assume_init())
+        .assume_init_on_success(surface)
     }
 
     #[inline]

--- a/ash/src/prelude.rs
+++ b/ash/src/prelude.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 #[cfg(feature = "debug")]
 use std::fmt;
+use std::mem;
 
 use crate::vk;
 pub type VkResult<T> = Result<T, vk::Result>;
@@ -17,6 +18,11 @@ impl vk::Result {
             Self::SUCCESS => Ok(v),
             _ => Err(self),
         }
+    }
+
+    #[inline]
+    pub unsafe fn assume_init_on_success<T>(self, v: mem::MaybeUninit<T>) -> VkResult<T> {
+        self.result().map(move |()| v.assume_init())
     }
 }
 


### PR DESCRIPTION
It is undefined behaviour to construct a safe object by calling `MaybeUninit::assume_init()` when the object in question hasn't been initialized by anything (in this case the underlying Vulkan call) at all, even if the object is never "used".  Postpone the `assume_init()` call until after checking if `vk::Result::SUCCESS` has been returned by the native implementation, by introducing a new `assume_init_on_success()` helper that takes a `MaybeUninit<T>`.
