### PR TITLE
CI: Only MSRV-test published `ash` and `ash-window` crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --workspace --all-targets --all-features
+          args: -p ash -p ash-window --all-features
 
   generated:
     name: Generated


### PR DESCRIPTION
`bytemuck` recently bumped its MSRV to 1.60 which is incompatible with what we're currently advertising.  Fortunately this doesn't affect MSRV of the publicly published crates, but only `dev-dependencies` inside `ash-window` via `winit`: make sure the CI doesn't reject this.

```console
$ cargo tree -i bytemuck
bytemuck v1.12.3
├── image v0.24.4
│   └── examples v0.1.0 (ash/examples)
├── safe_arch v0.5.2
│   └── tiny-skia v0.7.0
│       └── sctk-adwaita v0.4.3
│           └── winit v0.27.5
│               └── examples v0.1.0 (ash/examples)
│               [dev-dependencies]
│               └── ash-window v0.11.0 (ash/ash-window)
│                   └── examples v0.1.0 (ash/examples)
├── tiny-skia v0.7.0 (*)
└── tiny-skia-path v0.7.0
    └── tiny-skia v0.7.0 (*)
```
