### PR TITLE
reimplemented offset_of macro using MaybeUninit and addr_of

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -31,13 +31,11 @@ use winit::{
 #[macro_export]
 macro_rules! offset_of {
     ($base:path, $field:ident) => {{
-        #[allow(unused_unsafe)]
-        unsafe {
-            let b: $base = mem::zeroed();
-            (&b.$field as *const _ as isize) - (&b as *const _ as isize)
-        }
+        let b: std::mem::MaybeUninit<$base> = std::mem::MaybeUninit::uninit();
+        unsafe { std::ptr::addr_of!((*b.as_ptr()).$field) as isize - b.as_ptr() as isize }
     }};
 }
+
 /// Helper function for submitting command buffers. Immediately waits for the fence before the command buffer
 /// is executed. That way we can delay the waiting for the fences by 1 frame which is good for performance.
 /// Make sure to create the fence in a signaled state on the first use.


### PR DESCRIPTION
It seems to me that the `offset_of!(..)` macro defined in examples/src/lib.rs causes undefined behavior when used with a type where zero-initialization does not produce a valid value. Specifically, the [documentation](https://doc.rust-lang.org/std/mem/fn.zeroed.html) for `std::mem::zeroed<T>()` states:

> There is no guarantee that an all-zero byte-pattern represents a valid value of some type T. For example, the all-zero byte-pattern is not a valid value for reference types (&T, &mut T) and functions pointers. Using zeroed on such types causes **_immediate_** [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) because [the Rust compiler assumes](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initialization-invariant) that there always is a valid value in a variable it considers initialized.

(emphasis mine)

I don't see a specific case where this could cause problems in this particular context, as for the data types susceptible of being passed to Vulkan the all-zero value generally is valid. That said, it still seems unfortunate to have potential undefined behavior in the code examples.

This pull request proposes a different implementation, which is based on [`std::mem::MaybeUninit<T>`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html) and [`std::ptr::addr_of!()`](https://doc.rust-lang.org/std/ptr/macro.addr_of.html) to avoid creating a value of type `T` at all. I *think* that this implementation should be sound for all cases, by analogy with the second example "Creating a pointer to uninitialized data" given in the documentation for [`std::mem::addr_of_mut!()`](https://doc.rust-lang.org/std/ptr/macro.addr_of_mut.html).