### PR TITLE
Replace `as *...` raw pointer-type changes with more explicit `.cast()`

### DIFF
--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -51,7 +51,7 @@ pub unsafe fn create_surface(
 
         (RawDisplayHandle::Xlib(display), RawWindowHandle::Xlib(window)) => {
             let surface_desc = vk::XlibSurfaceCreateInfoKHR::default()
-                .dpy(display.display as *mut _)
+                .dpy(display.display.cast())
                 .window(window.window);
             let surface_fn = khr::XlibSurface::new(entry, instance);
             surface_fn.create_xlib_surface(&surface_desc, allocation_callbacks)
@@ -77,7 +77,7 @@ pub unsafe fn create_surface(
             use raw_window_metal::{appkit, Layer};
 
             let layer = match appkit::metal_layer_from_handle(window) {
-                Layer::Existing(layer) | Layer::Allocated(layer) => layer as *mut _,
+                Layer::Existing(layer) | Layer::Allocated(layer) => layer.cast(),
                 Layer::None => return Err(vk::Result::ERROR_INITIALIZATION_FAILED),
             };
 
@@ -91,7 +91,7 @@ pub unsafe fn create_surface(
             use raw_window_metal::{uikit, Layer};
 
             let layer = match uikit::metal_layer_from_handle(window) {
-                Layer::Existing(layer) | Layer::Allocated(layer) => layer as *mut _,
+                Layer::Existing(layer) | Layer::Allocated(layer) => layer.cast(),
                 Layer::None => return Err(vk::Result::ERROR_INITIALIZATION_FAILED),
             };
 

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -2026,7 +2026,7 @@ impl Device {
             first_query,
             data.len() as u32,
             data_size,
-            data.as_mut_ptr() as *mut _,
+            data.as_mut_ptr().cast(),
             mem::size_of::<T>() as _,
             flags,
         )

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -200,7 +200,7 @@ impl AccelerationStructure {
             acceleration_structures.as_ptr(),
             query_type,
             data.len(),
-            data.as_mut_ptr() as *mut std::ffi::c_void,
+            data.as_mut_ptr().cast(),
             stride,
         )
         .result()

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -206,7 +206,7 @@ impl RayTracing {
             first_group,
             group_count,
             data.len(),
-            data.as_mut_ptr() as *mut std::ffi::c_void,
+            data.as_mut_ptr().cast(),
         )
         .result()
     }
@@ -223,7 +223,7 @@ impl RayTracing {
             self.handle,
             accel_struct,
             std::mem::size_of::<u64>(),
-            handle_ptr as *mut std::ffi::c_void,
+            handle_ptr.cast(),
         )
         .result_with_success(handle)
     }

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -3440,7 +3440,7 @@ impl<'a> SpecializationInfo<'a> {
     #[inline]
     pub fn data(mut self, data: &'a [u8]) -> Self {
         self.data_size = data.len();
-        self.p_data = data.as_ptr() as *const c_void;
+        self.p_data = data.as_ptr().cast();
         self
     }
 }
@@ -4657,7 +4657,7 @@ impl<'a> PipelineCacheCreateInfo<'a> {
     #[inline]
     pub fn initial_data(mut self, initial_data: &'a [u8]) -> Self {
         self.initial_data_size = initial_data.len();
-        self.p_initial_data = initial_data.as_ptr() as *const c_void;
+        self.p_initial_data = initial_data.as_ptr().cast();
         self
     }
 }
@@ -8796,7 +8796,7 @@ impl<'a> DebugMarkerObjectTagInfoEXT<'a> {
     #[inline]
     pub fn tag(mut self, tag: &'a [u8]) -> Self {
         self.tag_size = tag.len();
-        self.p_tag = tag.as_ptr() as *const c_void;
+        self.p_tag = tag.as_ptr().cast();
         self
     }
 }
@@ -16659,7 +16659,7 @@ impl<'a> WriteDescriptorSetInlineUniformBlock<'a> {
     #[inline]
     pub fn data(mut self, data: &'a [u8]) -> Self {
         self.data_size = data.len() as _;
-        self.p_data = data.as_ptr() as *const c_void;
+        self.p_data = data.as_ptr().cast();
         self
     }
 }
@@ -16839,7 +16839,7 @@ impl<'a> ValidationCacheCreateInfoEXT<'a> {
     #[inline]
     pub fn initial_data(mut self, initial_data: &'a [u8]) -> Self {
         self.initial_data_size = initial_data.len();
-        self.p_initial_data = initial_data.as_ptr() as *const c_void;
+        self.p_initial_data = initial_data.as_ptr().cast();
         self
     }
 }
@@ -17775,7 +17775,7 @@ impl<'a> DebugUtilsObjectTagInfoEXT<'a> {
     #[inline]
     pub fn tag(mut self, tag: &'a [u8]) -> Self {
         self.tag_size = tag.len();
-        self.p_tag = tag.as_ptr() as *const c_void;
+        self.p_tag = tag.as_ptr().cast();
         self
     }
 }
@@ -27527,7 +27527,7 @@ impl<'a> PipelineExecutableInternalRepresentationKHR<'a> {
     #[inline]
     pub fn data(mut self, data: &'a mut [u8]) -> Self {
         self.data_size = data.len();
-        self.p_data = data.as_mut_ptr() as *mut c_void;
+        self.p_data = data.as_mut_ptr().cast();
         self
     }
 }
@@ -30960,7 +30960,7 @@ impl<'a> AccelerationStructureBuildGeometryInfoKHR<'a> {
         geometries_ptrs: &'a [&'a AccelerationStructureGeometryKHR],
     ) -> Self {
         self.geometry_count = geometries_ptrs.len() as _;
-        self.pp_geometries = geometries_ptrs.as_ptr() as *const *const _;
+        self.pp_geometries = geometries_ptrs.as_ptr().cast();
         self
     }
     #[inline]
@@ -38723,7 +38723,7 @@ impl<'a> CuModuleCreateInfoNVX<'a> {
     #[inline]
     pub fn data(mut self, data: &'a [u8]) -> Self {
         self.data_size = data.len();
-        self.p_data = data.as_ptr() as *const c_void;
+        self.p_data = data.as_ptr().cast();
         self
     }
 }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -34,7 +34,7 @@ macro_rules! offset_of {
         #[allow(unused_unsafe)]
         unsafe {
             let b: $base = mem::zeroed();
-            (&b.$field as *const _ as isize) - (&b as *const _ as isize)
+            std::ptr::addr_of!(b.$field) as isize - std::ptr::addr_of!(b) as isize
         }
     }};
 }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1720,10 +1720,8 @@ pub fn derive_setters(
 
                     // Interpret void array as byte array
                     if field.basetype == "void" && matches!(field.reference, Some(vkxml::ReferenceType::Pointer)) {
-                        let mutable = if field.is_const { quote!(const) } else { quote!(mut) };
-
                         slice_param_ty_tokens = quote!([u8]);
-                        ptr = quote!(#ptr as *#mutable c_void);
+                        ptr = quote!(#ptr.cast());
                     };
 
                     let set_size_stmt = if field.is_pointer_to_static_sized_array() {
@@ -1741,7 +1739,7 @@ pub fn derive_setters(
                         let array_size = if let Some(array_size) = array_size.strip_suffix(",1") {
                             param_ident_short = format_ident!("{}_ptrs", param_ident_short);
                             slice_param_ty_tokens = field.safe_type_tokens(quote!('a), Some(1));
-                            ptr = quote!(#ptr as *const *const _);
+                            ptr = quote!(#ptr.cast());
                             array_size
                         } else {
                             array_size


### PR DESCRIPTION
`.cast()` allows changing the pointer type without hiding (accidental) mutability changes (noting that `*mut` still coerces to `*.const`).

For mutability changes Rust 1.65 included `cast_mut()` and `cast_const()`, but those would bump our MSRV too eagerly for now.
