### PR TITLE
changelog: Document removal of `"disabled"` extension code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed all code generated for `"disabled"` extensions, typically with a number rather than a descriptive name (#448)
 - Removed experimental AMD extensions (#607)
-- Removed misnamed, deprecated `debug_utils_set_object_name()` and `debug_utils_set_object_tag()` entirely, use `set_debug_utils_object_name()` and `set_debug_utils_object_tag()` instead
+- Removed misnamed, deprecated `debug_utils_set_object_name()` and `debug_utils_set_object_tag()` entirely, use `set_debug_utils_object_name()` and `set_debug_utils_object_tag()` instead (#661)
 
 ## [0.37.1] - 2022-11-23
 


### PR DESCRIPTION
Looks like [my edit for delaying the merge of #448](https://github.com/ash-rs/ash/pull/448#issuecomment-1345634661) came in just too late, as I was unable to edit this in on the phone at 1:30am :)
