### PR TITLE
Replace `<<ref>>` in documentation with link to `ref`

### DIFF
--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -966,7 +966,7 @@ impl Result {
     pub const ERROR_OUT_OF_DEVICE_MEMORY: Self = Self(-2);
     #[doc = "Initialization of an object has failed"]
     pub const ERROR_INITIALIZATION_FAILED: Self = Self(-3);
-    #[doc = "The logical device has been lost. See <<devsandqueues-lost-device>>"]
+    #[doc = "The logical device has been lost. See <https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#devsandqueues-lost-device>"]
     pub const ERROR_DEVICE_LOST: Self = Self(-4);
     #[doc = "Mapping of a memory object has failed"]
     pub const ERROR_MEMORY_MAP_FAILED: Self = Self(-5);
@@ -990,40 +990,7 @@ impl Result {
 impl ::std::error::Error for Result {}
 impl fmt::Display for Result {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let name = match *self {
-            Self::SUCCESS => Some("Command completed successfully"),
-            Self::NOT_READY => Some("A fence or query has not yet completed"),
-            Self::TIMEOUT => Some("A wait operation has not completed in the specified time"),
-            Self::EVENT_SET => Some("An event is signaled"),
-            Self::EVENT_RESET => Some("An event is unsignaled"),
-            Self::INCOMPLETE => Some("A return array was too small for the result"),
-            Self::ERROR_OUT_OF_HOST_MEMORY => Some("A host memory allocation has failed"),
-            Self::ERROR_OUT_OF_DEVICE_MEMORY => Some("A device memory allocation has failed"),
-            Self::ERROR_INITIALIZATION_FAILED => Some("Initialization of an object has failed"),
-            Self::ERROR_DEVICE_LOST => {
-                Some("The logical device has been lost. See <<devsandqueues-lost-device>>")
-            }
-            Self::ERROR_MEMORY_MAP_FAILED => Some("Mapping of a memory object has failed"),
-            Self::ERROR_LAYER_NOT_PRESENT => Some("Layer specified does not exist"),
-            Self::ERROR_EXTENSION_NOT_PRESENT => Some("Extension specified does not exist"),
-            Self::ERROR_FEATURE_NOT_PRESENT => {
-                Some("Requested feature is not available on this device")
-            }
-            Self::ERROR_INCOMPATIBLE_DRIVER => Some("Unable to find a Vulkan driver"),
-            Self::ERROR_TOO_MANY_OBJECTS => {
-                Some("Too many objects of the type have already been created")
-            }
-            Self::ERROR_FORMAT_NOT_SUPPORTED => {
-                Some("Requested format is not supported on this device")
-            }
-            Self::ERROR_FRAGMENTED_POOL => Some(
-                "A requested pool allocation has failed due to fragmentation of the pool's memory",
-            ),
-            Self::ERROR_UNKNOWN => {
-                Some("An unknown error has occurred, due to an implementation or application bug")
-            }
-            _ => None,
-        };
+        let name = match * self { Self :: SUCCESS => Some ("Command completed successfully") , Self :: NOT_READY => Some ("A fence or query has not yet completed") , Self :: TIMEOUT => Some ("A wait operation has not completed in the specified time") , Self :: EVENT_SET => Some ("An event is signaled") , Self :: EVENT_RESET => Some ("An event is unsignaled") , Self :: INCOMPLETE => Some ("A return array was too small for the result") , Self :: ERROR_OUT_OF_HOST_MEMORY => Some ("A host memory allocation has failed") , Self :: ERROR_OUT_OF_DEVICE_MEMORY => Some ("A device memory allocation has failed") , Self :: ERROR_INITIALIZATION_FAILED => Some ("Initialization of an object has failed") , Self :: ERROR_DEVICE_LOST => Some ("The logical device has been lost. See <https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#devsandqueues-lost-device>") , Self :: ERROR_MEMORY_MAP_FAILED => Some ("Mapping of a memory object has failed") , Self :: ERROR_LAYER_NOT_PRESENT => Some ("Layer specified does not exist") , Self :: ERROR_EXTENSION_NOT_PRESENT => Some ("Extension specified does not exist") , Self :: ERROR_FEATURE_NOT_PRESENT => Some ("Requested feature is not available on this device") , Self :: ERROR_INCOMPATIBLE_DRIVER => Some ("Unable to find a Vulkan driver") , Self :: ERROR_TOO_MANY_OBJECTS => Some ("Too many objects of the type have already been created") , Self :: ERROR_FORMAT_NOT_SUPPORTED => Some ("Requested format is not supported on this device") , Self :: ERROR_FRAGMENTED_POOL => Some ("A requested pool allocation has failed due to fragmentation of the pool's memory") , Self :: ERROR_UNKNOWN => Some ("An unknown error has occurred, due to an implementation or application bug") , _ => None , } ;
         if let Some(x) = name {
             fmt.write_str(x)
         } else {


### PR DESCRIPTION
Rustdoc since 1.66 points out that `<<ref>>` is malformed HTML, and the resulting `<<devsandqueues-lost-device>>` isn't very helpful to users.  Convert it to the relevant link in both documentation and `Result` `Display` to solve both issues at once.

This may be a bit overzealous since there's only one documentation string containing these (aside from `#define`s around `VK_MAKE_VERSION`) but it's almost easier to fix generically than to make a workaround for this specific string.
