### PR TITLE
generator: Limit `pCode` member workaround to `VkShaderModuleCreateInfo`

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1667,7 +1667,7 @@ pub fn derive_setters(
             }
 
             // Unique cases
-            if name == "pCode" {
+            if struct_.name == "VkShaderModuleCreateInfo" && name == "pCode" {
                 return Some(quote!{
                     #[inline]
                     pub fn code(mut self, code: &'a [u32]) -> Self {


### PR DESCRIPTION
An upcoming extension will ship with an untyped `pCode` member (`void *`) including a valid `len` field pointing to a `codeSize` field rather than obscure Latex math and a `/4` expression in `altlen`.  Limit the scope of our workaround for that SPIR-V-specific `pCode` field to `VkShaderModuleCreateInfo`.
