### PR TITLE
Bump MSRV to 1.60 to accomodate for `winit 0.28`/`objc` requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
           args: --workspace --all-targets --all-features
 
   check_msrv:
-    name: Check MSRV (1.59.0)
+    name: Check MSRV (1.60.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: dtolnay/rust-toolchain@1.59.0
+      - uses: dtolnay/rust-toolchain@1.60.0
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced builders with lifetimes/setters directly on Vulkan structs (#602)
 - Inlined struct setters (#602)
+- Bumped MSRV from 1.59 to 1.60 (#709)
 
 ### Removed
 

--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-engines", "graphics"]
 exclude = [".github/*"]
 workspace = ".."
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.60.0"
 
 [dependencies]
 ash = { path = "../ash", version = "0.37", default-features = false }

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -4,6 +4,7 @@
 
 - Bumped `raw-window-handle` to `0.5.0`, now taking `RawDisplayHandle` and `RawWindowHandle` directly
   instead of requiring dynamic dispatch through the `HasRaw{Display,Window}Handle` traits (#645)
+- Bumped MSRV from 1.59 to 1.60 (#709)
 
 ## [0.11.0] - 2022-07-29
 

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 keywords = ["vulkan", "graphic"]
 documentation = "https://docs.rs/ash"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.60.0"
 
 [dependencies]
 libloading = { version = "0.7", optional = true }


### PR DESCRIPTION
CC #703

These dependencies fail to resolve on older Rust/cargo versions before even complaining about them being a too-high MSRV.
