### PR TITLE
changelog: Document removal of `query_count` parameter from `get_query_pool_results()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed all code generated for `"disabled"` extensions, typically with a number rather than a descriptive name (#448)
 - Removed experimental AMD extensions (#607)
+- Removed `query_count` parameter from `get_query_pool_results()` in favour of `data.len()` (#644)
 - Removed misnamed, deprecated `debug_utils_set_object_name()` and `debug_utils_set_object_tag()` entirely, use `set_debug_utils_object_name()` and `set_debug_utils_object_tag()` instead (#661)
 
 ## [0.37.2] - 2022-01-11


### PR DESCRIPTION
Commit c66db26 ("device: Replace `query_count` parameter in `get_query_pool_results` with `data.len()` (#644)") removed this parameter in favour of using `data.len()` to make it more obvious to use an appropriate element type that matches the kind of request (see also #639) so that the stride is filled in correctly, but it was not mentioned in the changelog yet.
