### PR TITLE
utils: add getter for the aligned size

### DIFF
--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -59,6 +59,10 @@ impl<T> Align<T> {
         }
     }
 
+    pub fn aligned_size(&self) -> vk::DeviceSize {
+        self.elem_size
+    }
+
     pub fn iter_mut(&mut self) -> AlignIter<T> {
         AlignIter {
             current: 0,


### PR DESCRIPTION
I was following the famous tutorials from Sascha Willems. At some point he uses a utility function called `alignedSize` when building the shader binding table for a raytracing pipeline:

```cpp
uint32_t alignedSize(uint32_t value, uint32_t alignment)
{
        return (value + alignment - 1) & ~(alignment - 1);
}
```

 I was hoping to find that same function in `ash::utils` and I did find the `Align` struct. From what I understand its `elem_size` field yields the same result. (as you probably know `& ~(alignment-1) === % alignment` if `alignment % 2 == 0`)