### PR TITLE
ash-window: Bump MSRV to 1.64 to match `raw-window-handle 0.5.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           args: --workspace --all-targets --all-features
 
   check_msrv:
-    name: Check MSRV (1.60.0)
+    name: Check ash MSRV (1.60.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -27,7 +27,18 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: -p ash -p ash-window --all-features
+          args: -p ash --all-features
+
+  check_ash_window_msrv:
+    name: Check ash-window MSRV (1.64.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -p ash-window -p examples --all-features
 
   generated:
     name: Generated

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A very lightweight wrapper around Vulkan
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE-APACHE)
 [![Join the chat at https://gitter.im/MaikKlein/ash](https://badges.gitter.im/MaikKlein/ash.svg)](https://gitter.im/MaikKlein/ash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![MSRV](https://img.shields.io/badge/rustc-1.60.0+-ab6000.svg)](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html)
 
 ## Overview
 - [x] A true Vulkan API without compromises

--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-engines", "graphics"]
 exclude = [".github/*"]
 workspace = ".."
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [dependencies]
 ash = { path = "../ash", version = "0.37", default-features = false }

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased] - ReleaseDate
 
-- Bumped MSRV from 1.59 to 1.60 (#709)
+- Bumped MSRV from 1.59 to 1.64 for `winit 0.28` and `raw-window-handle 0.5.1`. (#709, #716)
 
 ## [0.12.0] - 2022-09-23
 

--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -8,6 +8,7 @@ Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-win
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
 [![Join the chat at https://gitter.im/MaikKlein/ash](https://badges.gitter.im/MaikKlein/ash.svg)](https://gitter.im/MaikKlein/ash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![MSRV](https://img.shields.io/badge/rustc-1.64.0+-ab6000.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
 
 ## Usage
 


### PR DESCRIPTION
`raw-window-handle 0.5.1` bumped from 1.60 to 1.64 in a semver-compatible release, failing our CI infrastructure overnight.

~Keep the `ash` version at `1.60` for now.~ Lower `ash` to 1.59 because the original bump in #709 was only to match `winit 0.28`/`objc`, both of which are not used by the `ash` crate.
