### PR TITLE
Rename some function arguments to match the vulkan spec

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -465,34 +465,42 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_buffer_memory_requirements(
         &self,
-        create_info: &vk::DeviceBufferMemoryRequirements,
+        memory_reqirements: &vk::DeviceBufferMemoryRequirements,
         out: &mut vk::MemoryRequirements2,
     ) {
-        (self.device_fn_1_3.get_device_buffer_memory_requirements)(self.handle, create_info, out)
+        (self.device_fn_1_3.get_device_buffer_memory_requirements)(
+            self.handle,
+            memory_reqirements,
+            out,
+        )
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageMemoryRequirements.html>
     #[inline]
     pub unsafe fn get_device_image_memory_requirements(
         &self,
-        create_info: &vk::DeviceImageMemoryRequirements,
+        memory_reqirements: &vk::DeviceImageMemoryRequirements,
         out: &mut vk::MemoryRequirements2,
     ) {
-        (self.device_fn_1_3.get_device_image_memory_requirements)(self.handle, create_info, out)
+        (self.device_fn_1_3.get_device_image_memory_requirements)(
+            self.handle,
+            memory_reqirements,
+            out,
+        )
     }
 
     /// Retrieve the number of elements to pass to [`get_device_image_sparse_memory_requirements()`][Self::get_device_image_sparse_memory_requirements()]
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements_len(
         &self,
-        create_info: &vk::DeviceImageMemoryRequirements,
+        memory_reqirements: &vk::DeviceImageMemoryRequirements,
     ) -> usize {
         let mut count = 0;
         (self
             .device_fn_1_3
             .get_device_image_sparse_memory_requirements)(
             self.handle,
-            create_info,
+            memory_reqirements,
             &mut count,
             std::ptr::null_mut(),
         );
@@ -506,7 +514,7 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements(
         &self,
-        create_info: &vk::DeviceImageMemoryRequirements,
+        memory_reqirements: &vk::DeviceImageMemoryRequirements,
         out: &mut [vk::SparseImageMemoryRequirements2],
     ) {
         let mut count = out.len() as u32;
@@ -514,7 +522,7 @@ impl Device {
             .device_fn_1_3
             .get_device_image_sparse_memory_requirements)(
             self.handle,
-            create_info,
+            memory_reqirements,
             &mut count,
             out.as_mut_ptr(),
         );
@@ -1499,17 +1507,17 @@ impl Device {
     #[inline]
     pub unsafe fn allocate_descriptor_sets(
         &self,
-        create_info: &vk::DescriptorSetAllocateInfo,
+        allocate_info: &vk::DescriptorSetAllocateInfo,
     ) -> VkResult<Vec<vk::DescriptorSet>> {
-        let mut desc_set = Vec::with_capacity(create_info.descriptor_set_count as usize);
+        let mut desc_set = Vec::with_capacity(allocate_info.descriptor_set_count as usize);
         (self.device_fn_1_0.allocate_descriptor_sets)(
             self.handle(),
-            create_info,
+            allocate_info,
             desc_set.as_mut_ptr(),
         )
         .result()?;
 
-        desc_set.set_len(create_info.descriptor_set_count as usize);
+        desc_set.set_len(allocate_info.descriptor_set_count as usize);
         Ok(desc_set)
     }
 
@@ -1786,10 +1794,10 @@ impl Device {
     pub unsafe fn cmd_begin_render_pass(
         &self,
         command_buffer: vk::CommandBuffer,
-        create_info: &vk::RenderPassBeginInfo,
+        render_pass_begin: &vk::RenderPassBeginInfo,
         contents: vk::SubpassContents,
     ) {
-        (self.device_fn_1_0.cmd_begin_render_pass)(command_buffer, create_info, contents);
+        (self.device_fn_1_0.cmd_begin_render_pass)(command_buffer, render_pass_begin, contents);
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdNextSubpass.html>
@@ -2482,16 +2490,16 @@ impl Device {
     #[inline]
     pub unsafe fn allocate_command_buffers(
         &self,
-        create_info: &vk::CommandBufferAllocateInfo,
+        allocate_info: &vk::CommandBufferAllocateInfo,
     ) -> VkResult<Vec<vk::CommandBuffer>> {
-        let mut buffers = Vec::with_capacity(create_info.command_buffer_count as usize);
+        let mut buffers = Vec::with_capacity(allocate_info.command_buffer_count as usize);
         (self.device_fn_1_0.allocate_command_buffers)(
             self.handle(),
-            create_info,
+            allocate_info,
             buffers.as_mut_ptr(),
         )
         .result()?;
-        buffers.set_len(create_info.command_buffer_count as usize);
+        buffers.set_len(allocate_info.command_buffer_count as usize);
         Ok(buffers)
     }
 
@@ -2586,13 +2594,13 @@ impl Device {
     #[inline]
     pub unsafe fn allocate_memory(
         &self,
-        create_info: &vk::MemoryAllocateInfo,
+        allocate_info: &vk::MemoryAllocateInfo,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DeviceMemory> {
         let mut memory = mem::zeroed();
         (self.device_fn_1_0.allocate_memory)(
             self.handle(),
-            create_info,
+            allocate_info,
             allocation_callbacks.as_raw_ptr(),
             &mut memory,
         )

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -21,9 +21,9 @@ impl ExternalMemoryFd {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryFdKHR.html>
     #[inline]
-    pub unsafe fn get_memory_fd(&self, create_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
+    pub unsafe fn get_memory_fd(&self, get_fd_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-        (self.fp.get_memory_fd_khr)(self.handle, create_info, &mut fd).result_with_success(fd)
+        (self.fp.get_memory_fd_khr)(self.handle, get_fd_info, &mut fd).result_with_success(fd)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -22,32 +22,32 @@ impl Maintenance4 {
     #[inline]
     pub unsafe fn get_device_buffer_memory_requirements(
         &self,
-        create_info: &vk::DeviceBufferMemoryRequirementsKHR,
+        memory_requirements: &vk::DeviceBufferMemoryRequirementsKHR,
         out: &mut vk::MemoryRequirements2,
     ) {
-        (self.fp.get_device_buffer_memory_requirements_khr)(self.handle, create_info, out)
+        (self.fp.get_device_buffer_memory_requirements_khr)(self.handle, memory_requirements, out)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageMemoryRequirementsKHR.html>
     #[inline]
     pub unsafe fn get_device_image_memory_requirements(
         &self,
-        create_info: &vk::DeviceImageMemoryRequirementsKHR,
+        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR,
         out: &mut vk::MemoryRequirements2,
     ) {
-        (self.fp.get_device_image_memory_requirements_khr)(self.handle, create_info, out)
+        (self.fp.get_device_image_memory_requirements_khr)(self.handle, memory_requirements, out)
     }
 
     /// Retrieve the number of elements to pass to [`get_device_image_sparse_memory_requirements()`][Self::get_device_image_sparse_memory_requirements()]
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements_len(
         &self,
-        create_info: &vk::DeviceImageMemoryRequirementsKHR,
+        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR,
     ) -> usize {
         let mut count = 0;
         (self.fp.get_device_image_sparse_memory_requirements_khr)(
             self.handle,
-            create_info,
+            memory_requirements,
             &mut count,
             std::ptr::null_mut(),
         );
@@ -61,13 +61,13 @@ impl Maintenance4 {
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements(
         &self,
-        create_info: &vk::DeviceImageMemoryRequirementsKHR,
+        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR,
         out: &mut [vk::SparseImageMemoryRequirements2],
     ) {
         let mut count = out.len() as u32;
         (self.fp.get_device_image_sparse_memory_requirements_khr)(
             self.handle,
-            create_info,
+            memory_requirements,
             &mut count,
             out.as_mut_ptr(),
         );


### PR DESCRIPTION
Found it annoying that some functions have arguments called `create_info` when the struct type isn't actually a `create_info` e.g.
```rust
    pub unsafe fn cmd_begin_render_pass(
        &self,
        command_buffer: vk::CommandBuffer,
        create_info: &vk::RenderPassBeginInfo,
        contents: vk::SubpassContents,
    )
```

So I looked through all the `create_info` function arguments and renamed the ones which didn't make sense to match whatever the vulkan spec calls them e.g. `memory_reqirements`