### PR TITLE
generator: Handle `<command>` via `vk-parse` types and `nom`

### DIFF
--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -12028,7 +12028,7 @@ pub type PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR = unsafe extern "system"
 pub type PFN_vkCmdSetFragmentShadingRateKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_fragment_size: *const Extent2D,
-    combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
+    combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2usize],
 );
 #[derive(Clone)]
 pub struct KhrFragmentShadingRateFn {
@@ -12069,7 +12069,7 @@ impl KhrFragmentShadingRateFn {
                 unsafe extern "system" fn cmd_set_fragment_shading_rate_khr(
                     _command_buffer: CommandBuffer,
                     _p_fragment_size: *const Extent2D,
-                    _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
+                    _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2usize],
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -15787,7 +15787,7 @@ impl NvFragmentShadingRateEnumsFn {
 pub type PFN_vkCmdSetFragmentShadingRateEnumNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     shading_rate: FragmentShadingRateNV,
-    combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
+    combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2usize],
 );
 #[derive(Clone)]
 pub struct NvFragmentShadingRateEnumsFn {
@@ -15805,7 +15805,7 @@ impl NvFragmentShadingRateEnumsFn {
                 unsafe extern "system" fn cmd_set_fragment_shading_rate_enum_nv(
                     _command_buffer: CommandBuffer,
                     _shading_rate: FragmentShadingRateNV,
-                    _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
+                    _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2usize],
                 ) {
                     panic!(concat!(
                         "Unable to load ",

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -999,7 +999,7 @@ pub type PFN_vkCmdSetDepthBias = unsafe extern "system" fn(
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetBlendConstants =
-    unsafe extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4]);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4usize]);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthBounds = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
@@ -2876,7 +2876,7 @@ impl DeviceFnV1_0 {
             cmd_set_blend_constants: unsafe {
                 unsafe extern "system" fn cmd_set_blend_constants(
                     _command_buffer: CommandBuffer,
-                    _blend_constants: *const [f32; 4],
+                    _blend_constants: *const [f32; 4usize],
                 ) {
                     panic!(concat!(
                         "Unable to load ",

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -13,7 +13,7 @@ once_cell = "1.7"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.4"
-vk-parse = { version = "0.7", features = ["vkxml-convert"] }
+vk-parse = { version = "0.9", features = ["vkxml-convert"] }
 vkxml = "0.3"
 
 [dependencies.syn]


### PR DESCRIPTION
For the upcoming `api` attribute in `vk.xml` commands also need to be processed through `vk-parse` which has support for all the new attributes, while `vkxml` is deprecated and completely untouched for years.  This conversion unfortunately requires whipping up yet another quick-and-dirty `nom` parser of a specific subset of C used in `vk.xml` to describe parameter signatures.  This PR shows that conversion is complete and provides no accidental semantic differences.

Also update `vk-parse` to `0.9` which contains a new `code` field on `CommandParam` (`<param>` element) to be able to inspect the code signature of individual parameters rather than parsing them out of (and matching them back to `vk-parse`'s `params` array!) the `<command>` / `CommandDefinition` as a whole:
https://github.com/krolli/vk-parse/issues/25#issuecomment-1246330001
https://github.com/krolli/vk-parse/commit/615ffb69eb6ffa5ac038974d3e3d3da0ac19fed8
