### PR TITLE
Generate generic builder setters for fields taking an `objecttype`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inlined struct setters (#602)
 - Bumped MSRV from 1.59 to 1.60 (#709)
 - Replaced `const fn name()` with associated `NAME` constants (#715)
+- Generic builders now automatically set `objecttype` to `<T as Handle>::ObjectType` (#724)
 - extensions/khr: Take the remaining `p_next`-containing structs as `&mut` to allow chains (#744)
   - `AccelerationStructure::get_acceleration_structure_build_sizes()`
   - `ExternalMemoryFd::get_memory_fd_properties()`

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -17852,13 +17852,9 @@ unsafe impl<'a> TaggedStructure for DebugUtilsObjectNameInfoEXT<'a> {
 unsafe impl ExtendsPipelineShaderStageCreateInfo for DebugUtilsObjectNameInfoEXT<'_> {}
 impl<'a> DebugUtilsObjectNameInfoEXT<'a> {
     #[inline]
-    pub fn object_type(mut self, object_type: ObjectType) -> Self {
-        self.object_type = object_type;
-        self
-    }
-    #[inline]
-    pub fn object_handle(mut self, object_handle: u64) -> Self {
-        self.object_handle = object_handle;
+    pub fn object_handle<T: Handle>(mut self, object_handle: T) -> Self {
+        self.object_handle = object_handle.as_raw();
+        self.object_type = T::TYPE;
         self
     }
     #[inline]
@@ -17901,13 +17897,9 @@ unsafe impl<'a> TaggedStructure for DebugUtilsObjectTagInfoEXT<'a> {
 }
 impl<'a> DebugUtilsObjectTagInfoEXT<'a> {
     #[inline]
-    pub fn object_type(mut self, object_type: ObjectType) -> Self {
-        self.object_type = object_type;
-        self
-    }
-    #[inline]
-    pub fn object_handle(mut self, object_handle: u64) -> Self {
-        self.object_handle = object_handle;
+    pub fn object_handle<T: Handle>(mut self, object_handle: T) -> Self {
+        self.object_handle = object_handle.as_raw();
+        self.object_type = T::TYPE;
         self
     }
     #[inline]
@@ -18295,13 +18287,9 @@ impl<'a> DeviceMemoryReportCallbackDataEXT<'a> {
         self
     }
     #[inline]
-    pub fn object_type(mut self, object_type: ObjectType) -> Self {
-        self.object_type = object_type;
-        self
-    }
-    #[inline]
-    pub fn object_handle(mut self, object_handle: u64) -> Self {
-        self.object_handle = object_handle;
+    pub fn object_handle<T: Handle>(mut self, object_handle: T) -> Self {
+        self.object_handle = object_handle.as_raw();
+        self.object_type = T::TYPE;
         self
     }
     #[inline]


### PR DESCRIPTION
We already do this for hand-written extension functions but can now also implement it for setters since `vk_parse` fields are available within the builder generator code: when a field refers to another field for setting its `objecttype`, that `VkObjectType` field setter is omitted and instead assigned when the object is set, based on a type generic that implements the `Handle` trait instead of an untyped `u64`.

---

Note that most of this diff is merely code motion: some necessary cleanups such as replacing tuples with infinitely-more-self-descriptive structs.
