### PR TITLE
extensions/ext: Make `get_calibrated_timestamps()` return single value for `max_deviation`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped MSRV from 1.59 to 1.60 (#709)
 - Replaced `const fn name()` with associated `NAME` constants (#715)
 - Generic builders now automatically set `objecttype` to `<T as Handle>::ObjectType` (#724)
+- `get_calibrated_timestamps()` now returns a single value for `max_deviation` (#738)
 - extensions/khr: Take the remaining `p_next`-containing structs as `&mut` to allow chains (#744)
   - `AccelerationStructure::get_acceleration_structure_build_sizes()`
   - `ExternalMemoryFd::get_memory_fd_properties()`

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -42,15 +42,15 @@ impl CalibratedTimestamps {
         &self,
         device: vk::Device,
         info: &[vk::CalibratedTimestampInfoEXT],
-    ) -> VkResult<(Vec<u64>, Vec<u64>)> {
+    ) -> VkResult<(Vec<u64>, u64)> {
         let mut timestamps = vec![0u64; info.len()];
-        let mut max_deviation = vec![0u64; info.len()];
+        let mut max_deviation = 0u64;
         (self.fp.get_calibrated_timestamps_ext)(
             device,
             info.len() as u32,
             info.as_ptr(),
             timestamps.as_mut_ptr(),
-            max_deviation.as_mut_ptr(),
+            &mut max_deviation,
         )
         .result_with_success((timestamps, max_deviation))
     }


### PR DESCRIPTION
Per spec `max_deviation` is a single value, and not a vector.

Closes https://github.com/ash-rs/ash/issues/737