### PR TITLE
README: Remove deprecated `builder()` snippets and guidelines

### DIFF
--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -32,6 +32,7 @@ The library exposes two functions:
 [`RawWindowHandle`]: https://docs.rs/raw-window-handle/latest/raw_window_handle/enum.RawWindowHandle.html
 
 ## Versions
+
 ```toml
 ash = "0.37"
 ```
@@ -47,8 +48,8 @@ ash = "0.37"
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 


### PR DESCRIPTION
Fixes #742

#602 introduced builder functions directly on the raw Vulkan struct types by using lifetime borrows which are FFI compatible (ABI is identical) wuth raw pointers, simplifying the whole system and protecting the user against losing lifetimes upon calling `.build()`.  However, this change wasn't propagated through to the `README` so the code snippets were still showcasing removed `::builder()` and `.build()` functions and documenting "the `.build()` footgun" which doesn't even exist anymore 🎉
