### PR TITLE
extensions/khr: Take the remaining `p_next`-containing structs as `&mut`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inlined struct setters (#602)
 - Bumped MSRV from 1.59 to 1.60 (#709)
 - Replaced `const fn name()` with associated `NAME` constants (#715)
+- extensions/khr: Take the remaining `p_next`-containing structs as `&mut` to allow chains (#744)
+  - `AccelerationStructure::get_acceleration_structure_build_sizes()`
+  - `ExternalMemoryFd::get_memory_fd_properties()`
+  - `ExternalMemoryWin32::get_memory_win32_handle_properties()`
+  - `GetSurfaceCapabilities2::get_physical_device_surface_capabilities2()`
 
 ### Removed
 

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -259,7 +259,7 @@ impl AccelerationStructure {
         &self,
         version: &vk::AccelerationStructureVersionInfoKHR,
     ) -> vk::AccelerationStructureCompatibilityKHR {
-        let mut compatibility = vk::AccelerationStructureCompatibilityKHR::default();
+        let mut compatibility = mem::zeroed();
 
         (self.fp.get_device_acceleration_structure_compatibility_khr)(
             self.handle,

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -5,6 +5,7 @@ use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
 
+/// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_acceleration_structure.html>
 #[derive(Clone)]
 pub struct AccelerationStructure {
     handle: vk::Device,
@@ -276,20 +277,17 @@ impl AccelerationStructure {
         build_type: vk::AccelerationStructureBuildTypeKHR,
         build_info: &vk::AccelerationStructureBuildGeometryInfoKHR,
         max_primitive_counts: &[u32],
-    ) -> vk::AccelerationStructureBuildSizesInfoKHR {
+        size_info: &mut vk::AccelerationStructureBuildSizesInfoKHR,
+    ) {
         assert_eq!(max_primitive_counts.len(), build_info.geometry_count as _);
-
-        let mut size_info = vk::AccelerationStructureBuildSizesInfoKHR::default();
 
         (self.fp.get_acceleration_structure_build_sizes_khr)(
             self.handle,
             build_type,
             build_info,
             max_primitive_counts.as_ptr(),
-            &mut size_info,
-        );
-
-        size_info
+            size_info,
+        )
     }
 
     pub const NAME: &'static CStr = vk::KhrAccelerationStructureFn::NAME;

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -4,6 +4,7 @@ use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
 
+/// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_memory_fd.html>
 #[derive(Clone)]
 pub struct ExternalMemoryFd {
     handle: vk::Device,
@@ -32,15 +33,10 @@ impl ExternalMemoryFd {
         &self,
         handle_type: vk::ExternalMemoryHandleTypeFlags,
         fd: i32,
-    ) -> VkResult<vk::MemoryFdPropertiesKHR> {
-        let mut memory_fd_properties = Default::default();
-        (self.fp.get_memory_fd_properties_khr)(
-            self.handle,
-            handle_type,
-            fd,
-            &mut memory_fd_properties,
-        )
-        .result_with_success(memory_fd_properties)
+        memory_fd_properties: &mut vk::MemoryFdPropertiesKHR,
+    ) -> VkResult<()> {
+        (self.fp.get_memory_fd_properties_khr)(self.handle, handle_type, fd, memory_fd_properties)
+            .result()
     }
 
     pub const NAME: &'static CStr = vk::KhrExternalMemoryFdFn::NAME;

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -38,15 +38,15 @@ impl ExternalMemoryWin32 {
         &self,
         handle_type: vk::ExternalMemoryHandleTypeFlags,
         handle: vk::HANDLE,
-    ) -> VkResult<vk::MemoryWin32HandlePropertiesKHR> {
-        let mut memory_win32_handle_properties = Default::default();
+        memory_win32_handle_properties: &mut vk::MemoryWin32HandlePropertiesKHR,
+    ) -> VkResult<()> {
         (self.fp.get_memory_win32_handle_properties_khr)(
             self.handle,
             handle_type,
             handle,
-            &mut memory_win32_handle_properties,
+            memory_win32_handle_properties,
         )
-        .result_with_success(memory_win32_handle_properties)
+        .result()
     }
 
     pub const NAME: &'static CStr = vk::KhrExternalMemoryWin32Fn::NAME;

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -4,6 +4,7 @@ use crate::{Entry, Instance};
 use std::ffi::CStr;
 use std::mem;
 
+/// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_get_surface_capabilities2.html>
 #[derive(Clone)]
 pub struct GetSurfaceCapabilities2 {
     fp: vk::KhrGetSurfaceCapabilities2Fn,
@@ -23,14 +24,14 @@ impl GetSurfaceCapabilities2 {
         &self,
         physical_device: vk::PhysicalDevice,
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
-    ) -> VkResult<vk::SurfaceCapabilities2KHR> {
-        let mut surface_capabilities = Default::default();
+        surface_capabilities: &mut vk::SurfaceCapabilities2KHR,
+    ) -> VkResult<()> {
         (self.fp.get_physical_device_surface_capabilities2_khr)(
             physical_device,
             surface_info,
-            &mut surface_capabilities,
+            surface_capabilities,
         )
-        .result_with_success(surface_capabilities)
+        .result()
     }
 
     /// Retrieve the number of elements to pass to [`get_physical_device_surface_formats2()`][Self::get_physical_device_surface_formats2()]


### PR DESCRIPTION
Fixes #740

Version 2 of `get_physical_device_surface_capabilities` and the matching `vk::SurfaceCapabilitiesKHR` struct exist solely to provide an `sType` and `pNext` field to allow extending the original query with additional data via extension structs.  However, this API when introduced in #530 only returns the `default()`-initialized struct making it just as constrained as `get_physical_device_surface_capabilities()`.  Solve this by taking `vk::SurfaceCapabilities2KHR` as `&mut` just like any similar API.

And just like this, do the same for the remaining:

- `AccelerationStructure::get_acceleration_structure_build_sizes()`
- `ExternalMemoryFd::get_memory_fd_properties()`
- `ExternalMemoryWin32::get_memory_win32_handle_properties()`

In case these structs get extended somewhere down the line, which the Vulkan API allows for.
