### PR TITLE
Expose `FramebufferCreateInfo::attachment_count` builder for `IMAGELESS`

### DIFF
--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -7276,6 +7276,11 @@ impl<'a> FramebufferCreateInfo<'a> {
         self
     }
     #[inline]
+    pub fn attachment_count(mut self, attachment_count: u32) -> Self {
+        self.attachment_count = attachment_count;
+        self
+    }
+    #[inline]
     pub fn attachments(mut self, attachments: &'a [ImageView]) -> Self {
         self.attachment_count = attachments.len() as _;
         self.p_attachments = attachments.as_ptr();

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1796,28 +1796,21 @@ pub fn derive_setters(
         // No ImageView attachments when VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT is set
         ("VkFramebufferCreateInfo", "attachmentCount"),
     ];
-    let filter_members: Vec<String> = members
+    let filter_members = members
         .iter()
         .filter_map(|(field, _)| {
-            let field_name = field.name.as_ref().unwrap();
-
             // Associated _count members
             if field.array.is_some() {
-                if let Some(ref array_size) = field.size {
+                if let Some(array_size) = &field.size {
                     if !allowed_count_members.contains(&(&struct_.name, array_size)) {
-                        return Some((*array_size).clone());
+                        return Some(array_size);
                     }
                 }
             }
 
-            // VkShaderModuleCreateInfo requires a custom setter
-            if field_name == "codeSize" {
-                return Some(field_name.clone());
-            }
-
             None
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     let setters = members.iter().filter_map(|(field, deprecated)| {
         let deprecated = deprecated.as_ref().map(|d| quote!(#d #[allow(deprecated)]));
@@ -1836,12 +1829,15 @@ pub fn derive_setters(
         let mut param_ident_short = format_ident!("{}", param_ident_short);
 
         if let Some(name) = field.name.as_ref() {
-            // Filter
-            if filter_members.iter().any(|n| *n == *name) {
+            if filter_members.contains(&name) {
                 return None;
             }
 
             // Unique cases
+            if struct_.name == "VkShaderModuleCreateInfo" && name == "codeSize" {
+                return None;
+            }
+
             if struct_.name == "VkShaderModuleCreateInfo" && name == "pCode" {
                 return Some(quote!{
                     #[inline]


### PR DESCRIPTION
Fixes #450

Don't omit the `attachment_count()` builder method, because it is valid to set the number of attachments without providing attachments in the `IMAGELESS` case.

Also change the generator array lookup to use the name of the count field that is allowed to have a builder method, rather than the name of the field that would use this as `len` field and hence cause it to be skipped.
