### PR TITLE
Allow building `Entry`/`Instance`/`Device` from handle+fns

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VK_EXT_shader_object` device extension (#732)
 - Added missing `Device::get_device_queue2()` wrapper (#736)
 - Exposed `FramebufferCreateInfo::attachment_count()` builder for `vk::FramebufferCreateFlags::IMAGELESS` (#747)
+- Allow building `Entry`/`Instance`/`Device` from handle+fns (#748)
 
 ### Changed
 

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -23,13 +23,30 @@ impl Device {
             mem::transmute((instance_fn.get_device_proc_addr)(device, name.as_ptr()))
         };
 
-        Self {
-            handle: device,
+        Self::from_parts_1_3(
+            device,
+            vk::DeviceFnV1_0::load(load_fn),
+            vk::DeviceFnV1_1::load(load_fn),
+            vk::DeviceFnV1_2::load(load_fn),
+            vk::DeviceFnV1_3::load(load_fn),
+        )
+    }
 
-            device_fn_1_0: vk::DeviceFnV1_0::load(load_fn),
-            device_fn_1_1: vk::DeviceFnV1_1::load(load_fn),
-            device_fn_1_2: vk::DeviceFnV1_2::load(load_fn),
-            device_fn_1_3: vk::DeviceFnV1_3::load(load_fn),
+    #[inline]
+    pub fn from_parts_1_3(
+        handle: vk::Device,
+        device_fn_1_0: vk::DeviceFnV1_0,
+        device_fn_1_1: vk::DeviceFnV1_1,
+        device_fn_1_2: vk::DeviceFnV1_2,
+        device_fn_1_3: vk::DeviceFnV1_3,
+    ) -> Self {
+        Self {
+            handle,
+
+            device_fn_1_0,
+            device_fn_1_1,
+            device_fn_1_2,
+            device_fn_1_3,
         }
     }
 

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -140,15 +140,26 @@ impl Entry {
     /// `static_fn` must contain valid function pointers that comply with the semantics specified by
     /// Vulkan 1.0, which must remain valid for at least the lifetime of the returned [`Entry`].
     pub unsafe fn from_static_fn(static_fn: vk::StaticFn) -> Self {
-        let load_fn = |name: &std::ffi::CStr| {
+        let load_fn = move |name: &std::ffi::CStr| {
             mem::transmute((static_fn.get_instance_proc_addr)(
                 vk::Instance::null(),
                 name.as_ptr(),
             ))
         };
-        let entry_fn_1_0 = vk::EntryFnV1_0::load(load_fn);
-        let entry_fn_1_1 = vk::EntryFnV1_1::load(load_fn);
 
+        Self::from_parts_1_1(
+            static_fn,
+            vk::EntryFnV1_0::load(load_fn),
+            vk::EntryFnV1_1::load(load_fn),
+        )
+    }
+
+    #[inline]
+    pub fn from_parts_1_1(
+        static_fn: vk::StaticFn,
+        entry_fn_1_0: vk::EntryFnV1_0,
+        entry_fn_1_1: vk::EntryFnV1_1,
+    ) -> Self {
         Self {
             static_fn,
             entry_fn_1_0,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -22,12 +22,27 @@ impl Instance {
             mem::transmute((static_fn.get_instance_proc_addr)(instance, name.as_ptr()))
         };
 
-        Self {
-            handle: instance,
+        Self::from_parts_1_3(
+            instance,
+            vk::InstanceFnV1_0::load(load_fn),
+            vk::InstanceFnV1_1::load(load_fn),
+            vk::InstanceFnV1_3::load(load_fn),
+        )
+    }
 
-            instance_fn_1_0: vk::InstanceFnV1_0::load(load_fn),
-            instance_fn_1_1: vk::InstanceFnV1_1::load(load_fn),
-            instance_fn_1_3: vk::InstanceFnV1_3::load(load_fn),
+    #[inline]
+    pub fn from_parts_1_3(
+        handle: vk::Instance,
+        instance_fn_1_0: vk::InstanceFnV1_0,
+        instance_fn_1_1: vk::InstanceFnV1_1,
+        instance_fn_1_3: vk::InstanceFnV1_3,
+    ) -> Self {
+        Self {
+            handle,
+
+            instance_fn_1_0,
+            instance_fn_1_1,
+            instance_fn_1_3,
         }
     }
 


### PR DESCRIPTION
Adds a constructor to build a device from a handle + functions. 
Helps with interoperability with other vulkan wrappers where the user might have loaded the functions already.