### PR TITLE
extensions/khr/device_group_creation: Take borrow of `Entry` in `new()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ExternalMemoryFd::get_memory_fd_properties()`
   - `ExternalMemoryWin32::get_memory_win32_handle_properties()`
   - `GetSurfaceCapabilities2::get_physical_device_surface_capabilities2()`
+- `VK_KHR_device_group_creation`: Take borrow of `Entry` in `fn new()` (#753)
 
 ### Removed
 

--- a/ash/src/extensions/khr/device_group_creation.rs
+++ b/ash/src/extensions/khr/device_group_creation.rs
@@ -13,7 +13,7 @@ pub struct DeviceGroupCreation {
 }
 
 impl DeviceGroupCreation {
-    pub fn new(entry: Entry, instance: &Instance) -> Self {
+    pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
         let fp = vk::KhrDeviceGroupCreationFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))


### PR DESCRIPTION
Looks like #630 typo'd the argument for `DeviceGroupCreation::new()` by unnecessarily requiring a move (`Clone`) of `Entry` just to call `get_instance_proc_addr()` on it.  Replace this with a borrow to match all other extensions.
