### PR TITLE
entry: Mark `Entry::from_parts_1_1()` as `unsafe`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VK_EXT_shader_object` device extension (#732)
 - Added missing `Device::get_device_queue2()` wrapper (#736)
 - Exposed `FramebufferCreateInfo::attachment_count()` builder for `vk::FramebufferCreateFlags::IMAGELESS` (#747)
-- Allow building `Entry`/`Instance`/`Device` from handle+fns (#748)
+- Allow building `Entry`/`Instance`/`Device` from handle+fns (see their `from_parts_1_x()` associated functions) (#748)
 
 ### Changed
 


### PR DESCRIPTION
We don't mark any of the extern calls to Vulkan function-pointers safe except for a few `Entry` functions.  Their safety contract was easy to validate, but now that we exposed a constructor function to let the user provide function pointers in the form of `Entry::from_parts_1_1()` it is no longer safe to assume that we are calling the function that adheres to the contract specified in the Vulkan reference.

Because we don't rigorously do this validation and safe-marking anywhere else either, mark these function calls as `unsafe`.

Related discussion chain: https://github.com/ash-rs/ash/pull/748#discussion_r1186794284