### PR TITLE
Rename `vk::Instance`-returning function from `device()` to `instance()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `GetSurfaceCapabilities2::get_physical_device_surface_capabilities2()`
 - Define `Display` as `c_void` instead of `*mut c_void` to match Xlib (#751)
 - `VK_KHR_device_group_creation`: Take borrow of `Entry` in `fn new()` (#753)
+- `VK_KHR_device_group_creation`: Rename `vk::Instance`-returning function from `device()` to `instance()` (#759)
 
 ### Removed
 

--- a/ash/src/extensions/khr/device_group_creation.rs
+++ b/ash/src/extensions/khr/device_group_creation.rs
@@ -57,7 +57,7 @@ impl DeviceGroupCreation {
     }
 
     #[inline]
-    pub fn device(&self) -> vk::Instance {
+    pub fn instance(&self) -> vk::Instance {
         self.handle
     }
 }


### PR DESCRIPTION
I ended up fixing this via deprecation on the `0.37-stable` branch, but forgot to fix it on `master` (and it doesn't seem to have slipped into any other (open) PR).
