### PR TITLE
Add MSFT vendor tag for enum variants

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1463,6 +1463,7 @@ pub fn variant_ident(enum_name: &str, variant_name: &str) -> Ident {
         "_KHX",
         "_LUNARG",
         "_MESA",
+        "_MSFT",
         "_MVK",
         "_NN",
         "_NV",


### PR DESCRIPTION
Otherwise enums with the MSFT suffix fail to parse.