### PR TITLE
Add ash_window::get_present_support to 0.37-stable

### DIFF
--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -233,7 +233,7 @@ pub fn get_present_support(
             Ok(ext.get_physical_device_xlib_presentation_support(
                 physical_device,
                 queue_family_index,
-                h.display,
+                &mut *h.display.cast(),
                 h.screen as _,
             ))
         },


### PR DESCRIPTION
This fulfills the same purpose as #774, but for the 0.37-stable branch, which is probably the more important one...