### PR TITLE
nv/ray_tracing: Initialize tagged struct with `default()`

### DIFF
--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -57,7 +57,7 @@ impl RayTracing {
         &self,
         info: &vk::AccelerationStructureMemoryRequirementsInfoNV,
     ) -> vk::MemoryRequirements2KHR {
-        let mut requirements = mem::zeroed();
+        let mut requirements = Default::default();
         (self.fp.get_acceleration_structure_memory_requirements_nv)(
             self.handle,
             info,


### PR DESCRIPTION
Old and probably unused/deprecated extension now that `VK_KHR_ray_tracing` exists and is stabilized for quite some time, but it's still wrong to zero-initialize `sType`.

Additionally checking all other `mem::zeroed()` calls made me stumble across another PR where `mem::MaybeUninit::zeroed()` was used and `assume_init()` after a function returned successfully.  Perhaps we should switch to that on all occasions (and possibly replace `zeroed()` with `uninit()`)?