### PR TITLE
Bump `raw-window-handle` to `0.6.0`

### DIFF
--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.64.0"
 
 [dependencies]
 ash = { path = "../ash", version = "0.37", default-features = false }
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 raw-window-metal = "0.3"

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased] - ReleaseDate
 
-- Bumped MSRV from 1.59 to 1.64 for `winit 0.28` and `raw-window-handle 0.5.1`. (#709, #716)
+- Bumped 'raw-window-handle' to '0.6.0'. 
+- Bumped MSRV from 1.59 to 1.64 for `winit 0.28` and `raw-window-handle 0.6.0`. (#709, #716)
 
 ## [0.12.0] - 2022-09-23
 


### PR DESCRIPTION
Updated `raw-window-handle` to `0.6.0` and updated `Changelog.md`. 
Waiting for https://github.com/rust-windowing/winit/pull/3126 to update example using raw-window-handle