### PR TITLE
CI: Cross-lint for Mac, iOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,30 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-ios
     steps:
       - uses: actions/checkout@v1
+      - name: Add Rust target ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
       - name: Clippy lint without features
         # Only test the core ash, ash-rewrite and ash-window crate, where features reside.
         # The examples crate would otherwise enable all default features again,
         # making this test moot.
-        run: cargo clippy -p ash -p ash-rewrite -p ash-window --no-default-features -- -D warnings
+        run: cargo clippy --target ${{ matrix.target }} -p ash -p ash-rewrite -p ash-window --no-default-features -- -D warnings
       - name: Clippy lint with all features
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        # Examples don't compile for iOS currently due to lacking run_return()
+        if: ${{ matrix.target != 'aarch64-apple-ios' }}
+        run: cargo clippy --target ${{ matrix.target }} --workspace --all-targets --all-features -- -D warnings
       - name: Clippy lint with default features
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        # Examples don't compile for iOS currently due to lacking run_return()
+        if: ${{ matrix.target != 'aarch64-apple-ios' }}
+        run: cargo clippy --target ${{ matrix.target }} --workspace --all-targets -- -D warnings
 
   docs:
     name: Build-test docs

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -305,7 +305,7 @@ pub trait ConstantExt {
     fn variant_ident(&self, enum_name: &str) -> Ident;
     fn notation(&self) -> Option<&str>;
     fn formatted_notation(&self) -> Option<Cow<'_, str>> {
-        static DOC_LINK: Lazy<Regex> = Lazy::new(|| Regex::new(r#"<<([\w-]+)>>"#).unwrap());
+        static DOC_LINK: Lazy<Regex> = Lazy::new(|| Regex::new(r"<<([\w-]+)>>").unwrap());
         self.notation().map(|n| {
             DOC_LINK.replace(
                 n,
@@ -2968,13 +2968,13 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let mut has_lifetimes = definitions
         .iter()
         .filter_map(get_variant!(vkxml::DefinitionsElement::Struct))
-        .filter_map(|s| {
+        .filter(|&s| {
             s.elements
                 .iter()
                 .filter_map(get_variant!(vkxml::StructElement::Member))
                 .any(|x| x.reference.is_some())
-                .then(|| name_to_tokens(&s.name))
         })
+        .map(|s| name_to_tokens(&s.name))
         .collect::<HashSet<Ident>>();
     for def in &definitions {
         match def {


### PR DESCRIPTION
We have some conditional code specific to Mac and iOS which is currently untested in the CI, allowing non-compiling code in PRs like https://github.com/ash-rs/ash/pull/795 to go unnoticed.

Additionally, fix the clippy lints pointed out by new Rust versions.