### PR TITLE
platform_types: Convert Windows `HANDLE` types to `isize`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Define `Display` as `c_void` instead of `*mut c_void` to match Xlib (#751)
 - `VK_KHR_device_group_creation`: Take borrow of `Entry` in `fn new()` (#753)
 - `VK_KHR_device_group_creation`: Rename `vk::Instance`-returning function from `device()` to `instance()` (#759)
+- Windows `HANDLE` types (`HWND`, `HINSTANCE`, `HMONITOR`) are now defined as `isize` instead of `*const c_void` (#797)
 
 ### Removed
 

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -42,8 +42,8 @@ pub unsafe fn create_surface(
     match (display_handle, window_handle) {
         (RawDisplayHandle::Windows(_), RawWindowHandle::Win32(window)) => {
             let surface_desc = vk::Win32SurfaceCreateInfoKHR::default()
-                .hinstance(window.hinstance)
-                .hwnd(window.hwnd);
+                .hinstance(window.hinstance as isize)
+                .hwnd(window.hwnd as isize);
             let surface_fn = khr::Win32Surface::new(entry, instance);
             surface_fn.create_win32_surface(&surface_desc, allocation_callbacks)
         }

--- a/ash/src/extensions/khr/external_fence_win32.rs
+++ b/ash/src/extensions/khr/external_fence_win32.rs
@@ -3,7 +3,7 @@ use crate::vk;
 use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
-use std::ptr;
+use std::mem::MaybeUninit;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_fence_win32.html>
 #[derive(Clone)]
@@ -36,9 +36,9 @@ impl ExternalFenceWin32 {
         &self,
         get_info: &vk::FenceGetWin32HandleInfoKHR,
     ) -> VkResult<vk::HANDLE> {
-        let mut handle = ptr::null_mut();
-        (self.fp.get_fence_win32_handle_khr)(self.handle, get_info, &mut handle)
-            .result_with_success(handle)
+        let mut handle = MaybeUninit::uninit();
+        (self.fp.get_fence_win32_handle_khr)(self.handle, get_info, handle.as_mut_ptr())
+            .assume_init_on_success(handle)
     }
 
     pub const NAME: &'static CStr = vk::KhrExternalFenceWin32Fn::NAME;

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -3,7 +3,7 @@ use crate::vk;
 use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
-use std::ptr;
+use std::mem::MaybeUninit;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_memory_win32.html>
 #[derive(Clone)]
@@ -27,9 +27,9 @@ impl ExternalMemoryWin32 {
         &self,
         create_info: &vk::MemoryGetWin32HandleInfoKHR,
     ) -> VkResult<vk::HANDLE> {
-        let mut handle = ptr::null_mut();
-        (self.fp.get_memory_win32_handle_khr)(self.handle, create_info, &mut handle)
-            .result_with_success(handle)
+        let mut handle = MaybeUninit::uninit();
+        (self.fp.get_memory_win32_handle_khr)(self.handle, create_info, handle.as_mut_ptr())
+            .assume_init_on_success(handle)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryWin32HandlePropertiesKHR.html>

--- a/ash/src/extensions/khr/external_semaphore_win32.rs
+++ b/ash/src/extensions/khr/external_semaphore_win32.rs
@@ -3,7 +3,7 @@ use crate::vk;
 use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
-use std::ptr;
+use std::mem::MaybeUninit;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_semaphore_win32.html>
 #[derive(Clone)]
@@ -36,9 +36,9 @@ impl ExternalSemaphoreWin32 {
         &self,
         get_info: &vk::SemaphoreGetWin32HandleInfoKHR,
     ) -> VkResult<vk::HANDLE> {
-        let mut handle = ptr::null_mut();
-        (self.fp.get_semaphore_win32_handle_khr)(self.handle, get_info, &mut handle)
-            .result_with_success(handle)
+        let mut handle = MaybeUninit::uninit();
+        (self.fp.get_semaphore_win32_handle_khr)(self.handle, get_info, handle.as_mut_ptr())
+            .assume_init_on_success(handle)
     }
 
     pub const NAME: &'static CStr = vk::KhrExternalSemaphoreWin32Fn::NAME;

--- a/ash/src/vk/platform_types.rs
+++ b/ash/src/vk/platform_types.rs
@@ -10,12 +10,16 @@ pub type xcb_window_t = u32;
 pub type xcb_visualid_t = u32;
 pub type MirConnection = *const c_void;
 pub type MirSurface = *const c_void;
-pub type HINSTANCE = *const c_void;
-pub type HWND = *const c_void;
+/// <https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Foundation/struct.HANDLE.html>
+pub type HANDLE = isize;
+/// <https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Foundation/struct.HINSTANCE.html>
+pub type HINSTANCE = HANDLE;
+/// <https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Foundation/struct.HWND.html>
+pub type HWND = HANDLE;
+/// <https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Graphics/Gdi/struct.HMONITOR.html>
+pub type HMONITOR = HANDLE;
 pub type wl_display = c_void;
 pub type wl_surface = c_void;
-pub type HANDLE = *mut c_void;
-pub type HMONITOR = HANDLE;
 pub type DWORD = c_ulong;
 pub type LPCWSTR = *const u16;
 pub type zx_handle_t = u32;


### PR DESCRIPTION
The `windows` crate treats these as `isize` rather than raw void pointers:
https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Foundation/struct.HWND.html

And `raw-window-handle 0.6` recently started to do the same:
https://github.com/rust-windowing/raw-window-handle/pull/136

However, the win32 documentation still states that these should be `PVOID`:
https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types

Hence I'm not super confident what the right step forward is: `isize` is a breaking change (we'll do a breaking release soon™™™ anyway) but plays more nicely with interop with other crates. @madsmtm was your motivation for `raw-window-handle` also the type representation in windows-rs?
