### PR TITLE
Convert `mem::zeroed()` / `0` to `MaybeUninit::uninit()`

### DIFF
--- a/ash-examples/src/bin/texture.rs
+++ b/ash-examples/src/bin/texture.rs
@@ -768,7 +768,6 @@ fn main() {
                     device.cmd_end_render_pass(draw_command_buffer);
                 },
             );
-            //let mut present_info_err = mem::zeroed();
             let present_info = vk::PresentInfoKHR {
                 wait_semaphore_count: 1,
                 p_wait_semaphores: &base.rendering_complete_semaphore,

--- a/ash-examples/src/bin/triangle.rs
+++ b/ash-examples/src/bin/triangle.rs
@@ -423,7 +423,6 @@ fn main() {
                     device.cmd_end_render_pass(draw_command_buffer);
                 },
             );
-            //let mut present_info_err = mem::zeroed();
             let wait_semaphors = [base.rendering_complete_semaphore];
             let swapchains = [base.swapchain];
             let image_indices = [present_index];

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -70,14 +70,14 @@ impl Device {
         create_info: &vk::PrivateDataSlotCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PrivateDataSlot> {
-        let mut private_data_slot = mem::zeroed();
+        let mut private_data_slot = mem::MaybeUninit::uninit();
         (self.device_fn_1_3.create_private_data_slot)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut private_data_slot,
+            private_data_slot.as_mut_ptr(),
         )
-        .result_with_success(private_data_slot)
+        .assume_init_on_success(private_data_slot)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyPrivateDataSlot.html>
@@ -119,15 +119,15 @@ impl Device {
         object: T,
         private_data_slot: vk::PrivateDataSlot,
     ) -> u64 {
-        let mut data = mem::zeroed();
+        let mut data = mem::MaybeUninit::uninit();
         (self.device_fn_1_3.get_private_data)(
             self.handle,
             T::TYPE,
             object.as_raw(),
             private_data_slot,
-            &mut data,
+            data.as_mut_ptr(),
         );
-        data
+        data.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdPipelineBarrier2.html>
@@ -511,16 +511,16 @@ impl Device {
         &self,
         memory_requirements: &vk::DeviceImageMemoryRequirements<'_>,
     ) -> usize {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self
             .device_fn_1_3
             .get_device_image_sparse_memory_requirements)(
             self.handle,
             memory_requirements,
-            &mut count,
+            count.as_mut_ptr(),
             ptr::null_mut(),
         );
-        count as usize
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageSparseMemoryRequirements.html>
@@ -606,14 +606,14 @@ impl Device {
         create_info: &vk::RenderPassCreateInfo2<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::RenderPass> {
-        let mut renderpass = mem::zeroed();
+        let mut renderpass = mem::MaybeUninit::uninit();
         (self.device_fn_1_2.create_render_pass2)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut renderpass,
+            renderpass.as_mut_ptr(),
         )
-        .result_with_success(renderpass)
+        .assume_init_on_success(renderpass)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdBeginRenderPass2.html>
@@ -670,9 +670,13 @@ impl Device {
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetSemaphoreCounterValue.html>
     #[inline]
     pub unsafe fn get_semaphore_counter_value(&self, semaphore: vk::Semaphore) -> VkResult<u64> {
-        let mut value = 0;
-        (self.device_fn_1_2.get_semaphore_counter_value)(self.handle(), semaphore, &mut value)
-            .result_with_success(value)
+        let mut value = mem::MaybeUninit::uninit();
+        (self.device_fn_1_2.get_semaphore_counter_value)(
+            self.handle(),
+            semaphore,
+            value.as_mut_ptr(),
+        )
+        .assume_init_on_success(value)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkWaitSemaphores.html>
@@ -765,15 +769,15 @@ impl Device {
         local_device_index: u32,
         remote_device_index: u32,
     ) -> vk::PeerMemoryFeatureFlags {
-        let mut peer_memory_features = mem::zeroed();
+        let mut peer_memory_features = mem::MaybeUninit::uninit();
         (self.device_fn_1_1.get_device_group_peer_memory_features)(
             self.handle(),
             heap_index,
             local_device_index,
             remote_device_index,
-            &mut peer_memory_features,
+            peer_memory_features.as_mut_ptr(),
         );
-        peer_memory_features
+        peer_memory_features.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetDeviceMask.html>
@@ -831,14 +835,14 @@ impl Device {
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2<'_>,
     ) -> usize {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self.device_fn_1_1.get_image_sparse_memory_requirements2)(
             self.handle(),
             info,
-            &mut count,
+            count.as_mut_ptr(),
             ptr::null_mut(),
         );
-        count as usize
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSparseMemoryRequirements2.html>
@@ -874,9 +878,9 @@ impl Device {
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceQueue2.html>
     #[inline]
     pub unsafe fn get_device_queue2(&self, queue_info: &vk::DeviceQueueInfo2<'_>) -> vk::Queue {
-        let mut queue = mem::zeroed();
-        (self.device_fn_1_1.get_device_queue2)(self.handle(), queue_info, &mut queue);
-        queue
+        let mut queue = mem::MaybeUninit::uninit();
+        (self.device_fn_1_1.get_device_queue2)(self.handle(), queue_info, queue.as_mut_ptr());
+        queue.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateSamplerYcbcrConversion.html>
@@ -886,14 +890,14 @@ impl Device {
         create_info: &vk::SamplerYcbcrConversionCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
-        let mut ycbcr_conversion = mem::zeroed();
+        let mut ycbcr_conversion = mem::MaybeUninit::uninit();
         (self.device_fn_1_1.create_sampler_ycbcr_conversion)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut ycbcr_conversion,
+            ycbcr_conversion.as_mut_ptr(),
         )
-        .result_with_success(ycbcr_conversion)
+        .assume_init_on_success(ycbcr_conversion)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroySamplerYcbcrConversion.html>
@@ -917,14 +921,14 @@ impl Device {
         create_info: &vk::DescriptorUpdateTemplateCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DescriptorUpdateTemplate> {
-        let mut descriptor_update_template = mem::zeroed();
+        let mut descriptor_update_template = mem::MaybeUninit::uninit();
         (self.device_fn_1_1.create_descriptor_update_template)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut descriptor_update_template,
+            descriptor_update_template.as_mut_ptr(),
         )
-        .result_with_success(descriptor_update_template)
+        .assume_init_on_success(descriptor_update_template)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyDescriptorUpdateTemplate.html>
@@ -1030,14 +1034,14 @@ impl Device {
         create_info: &vk::EventCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Event> {
-        let mut event = mem::zeroed();
+        let mut event = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_event)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut event,
+            event.as_mut_ptr(),
         )
-        .result_with_success(event)
+        .assume_init_on_success(event)
     }
 
     /// Returns [`true`] if the event was set, and [`false`] if the event was reset, otherwise it will
@@ -1363,14 +1367,14 @@ impl Device {
         create_info: &vk::SamplerCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Sampler> {
-        let mut sampler = mem::zeroed();
+        let mut sampler = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_sampler)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut sampler,
+            sampler.as_mut_ptr(),
         )
-        .result_with_success(sampler)
+        .assume_init_on_success(sampler)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdBlitImage.html>
@@ -1555,14 +1559,14 @@ impl Device {
         create_info: &vk::DescriptorSetLayoutCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DescriptorSetLayout> {
-        let mut layout = mem::zeroed();
+        let mut layout = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_descriptor_set_layout)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut layout,
+            layout.as_mut_ptr(),
         )
-        .result_with_success(layout)
+        .assume_init_on_success(layout)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDeviceWaitIdle.html>
@@ -1578,14 +1582,14 @@ impl Device {
         create_info: &vk::DescriptorPoolCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DescriptorPool> {
-        let mut pool = mem::zeroed();
+        let mut pool = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_descriptor_pool)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut pool,
+            pool.as_mut_ptr(),
         )
-        .result_with_success(pool)
+        .assume_init_on_success(pool)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkResetDescriptorPool.html>
@@ -2123,14 +2127,14 @@ impl Device {
         create_info: &vk::SemaphoreCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Semaphore> {
-        let mut semaphore = mem::zeroed();
+        let mut semaphore = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_semaphore)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut semaphore,
+            semaphore.as_mut_ptr(),
         )
-        .result_with_success(semaphore)
+        .assume_init_on_success(semaphore)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateGraphicsPipelines.html>
@@ -2188,14 +2192,14 @@ impl Device {
         create_info: &vk::BufferCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Buffer> {
-        let mut buffer = mem::zeroed();
+        let mut buffer = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_buffer)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut buffer,
+            buffer.as_mut_ptr(),
         )
-        .result_with_success(buffer)
+        .assume_init_on_success(buffer)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreatePipelineLayout.html>
@@ -2205,14 +2209,14 @@ impl Device {
         create_info: &vk::PipelineLayoutCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PipelineLayout> {
-        let mut pipeline_layout = mem::zeroed();
+        let mut pipeline_layout = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_pipeline_layout)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut pipeline_layout,
+            pipeline_layout.as_mut_ptr(),
         )
-        .result_with_success(pipeline_layout)
+        .assume_init_on_success(pipeline_layout)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreatePipelineCache.html>
@@ -2222,14 +2226,14 @@ impl Device {
         create_info: &vk::PipelineCacheCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PipelineCache> {
-        let mut pipeline_cache = mem::zeroed();
+        let mut pipeline_cache = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_pipeline_cache)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut pipeline_cache,
+            pipeline_cache.as_mut_ptr(),
         )
-        .result_with_success(pipeline_cache)
+        .assume_init_on_success(pipeline_cache)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPipelineCacheData.html>
@@ -2273,9 +2277,16 @@ impl Device {
         size: vk::DeviceSize,
         flags: vk::MemoryMapFlags,
     ) -> VkResult<*mut c_void> {
-        let mut data: *mut c_void = ptr::null_mut();
-        (self.device_fn_1_0.map_memory)(self.handle(), memory, offset, size, flags, &mut data)
-            .result_with_success(data)
+        let mut data = mem::MaybeUninit::uninit();
+        (self.device_fn_1_0.map_memory)(
+            self.handle(),
+            memory,
+            offset,
+            size,
+            flags,
+            data.as_mut_ptr(),
+        )
+        .assume_init_on_success(data)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkUnmapMemory.html>
@@ -2319,27 +2330,27 @@ impl Device {
         create_info: &vk::FramebufferCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Framebuffer> {
-        let mut framebuffer = mem::zeroed();
+        let mut framebuffer = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_framebuffer)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut framebuffer,
+            framebuffer.as_mut_ptr(),
         )
-        .result_with_success(framebuffer)
+        .assume_init_on_success(framebuffer)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceQueue.html>
     #[inline]
     pub unsafe fn get_device_queue(&self, queue_family_index: u32, queue_index: u32) -> vk::Queue {
-        let mut queue = mem::zeroed();
+        let mut queue = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.get_device_queue)(
             self.handle(),
             queue_family_index,
             queue_index,
-            &mut queue,
+            queue.as_mut_ptr(),
         );
-        queue
+        queue.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdPipelineBarrier.html>
@@ -2375,14 +2386,14 @@ impl Device {
         create_info: &vk::RenderPassCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::RenderPass> {
-        let mut renderpass = mem::zeroed();
+        let mut renderpass = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_render_pass)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut renderpass,
+            renderpass.as_mut_ptr(),
         )
-        .result_with_success(renderpass)
+        .assume_init_on_success(renderpass)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkBeginCommandBuffer.html>
@@ -2472,14 +2483,14 @@ impl Device {
         create_info: &vk::BufferViewCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::BufferView> {
-        let mut buffer_view = mem::zeroed();
+        let mut buffer_view = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_buffer_view)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut buffer_view,
+            buffer_view.as_mut_ptr(),
         )
-        .result_with_success(buffer_view)
+        .assume_init_on_success(buffer_view)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyBufferView.html>
@@ -2503,14 +2514,14 @@ impl Device {
         create_info: &vk::ImageViewCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::ImageView> {
-        let mut image_view = mem::zeroed();
+        let mut image_view = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_image_view)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut image_view,
+            image_view.as_mut_ptr(),
         )
-        .result_with_success(image_view)
+        .assume_init_on_success(image_view)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkAllocateCommandBuffers.html>
@@ -2537,14 +2548,14 @@ impl Device {
         create_info: &vk::CommandPoolCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::CommandPool> {
-        let mut pool = mem::zeroed();
+        let mut pool = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_command_pool)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut pool,
+            pool.as_mut_ptr(),
         )
-        .result_with_success(pool)
+        .assume_init_on_success(pool)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateQueryPool.html>
@@ -2554,14 +2565,14 @@ impl Device {
         create_info: &vk::QueryPoolCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::QueryPool> {
-        let mut pool = mem::zeroed();
+        let mut pool = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_query_pool)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut pool,
+            pool.as_mut_ptr(),
         )
-        .result_with_success(pool)
+        .assume_init_on_success(pool)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateImage.html>
@@ -2571,14 +2582,14 @@ impl Device {
         create_info: &vk::ImageCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Image> {
-        let mut image = mem::zeroed();
+        let mut image = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_image)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut image,
+            image.as_mut_ptr(),
         )
-        .result_with_success(image)
+        .assume_init_on_success(image)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSubresourceLayout.html>
@@ -2588,22 +2599,26 @@ impl Device {
         image: vk::Image,
         subresource: vk::ImageSubresource,
     ) -> vk::SubresourceLayout {
-        let mut layout = mem::zeroed();
+        let mut layout = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.get_image_subresource_layout)(
             self.handle(),
             image,
             &subresource,
-            &mut layout,
+            layout.as_mut_ptr(),
         );
-        layout
+        layout.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageMemoryRequirements.html>
     #[inline]
     pub unsafe fn get_image_memory_requirements(&self, image: vk::Image) -> vk::MemoryRequirements {
-        let mut mem_req = mem::zeroed();
-        (self.device_fn_1_0.get_image_memory_requirements)(self.handle(), image, &mut mem_req);
-        mem_req
+        let mut mem_req = mem::MaybeUninit::uninit();
+        (self.device_fn_1_0.get_image_memory_requirements)(
+            self.handle(),
+            image,
+            mem_req.as_mut_ptr(),
+        );
+        mem_req.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetBufferMemoryRequirements.html>
@@ -2612,9 +2627,13 @@ impl Device {
         &self,
         buffer: vk::Buffer,
     ) -> vk::MemoryRequirements {
-        let mut mem_req = mem::zeroed();
-        (self.device_fn_1_0.get_buffer_memory_requirements)(self.handle(), buffer, &mut mem_req);
-        mem_req
+        let mut mem_req = mem::MaybeUninit::uninit();
+        (self.device_fn_1_0.get_buffer_memory_requirements)(
+            self.handle(),
+            buffer,
+            mem_req.as_mut_ptr(),
+        );
+        mem_req.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkAllocateMemory.html>
@@ -2624,14 +2643,14 @@ impl Device {
         allocate_info: &vk::MemoryAllocateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DeviceMemory> {
-        let mut memory = mem::zeroed();
+        let mut memory = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.allocate_memory)(
             self.handle(),
             allocate_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut memory,
+            memory.as_mut_ptr(),
         )
-        .result_with_success(memory)
+        .assume_init_on_success(memory)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateShaderModule.html>
@@ -2641,14 +2660,14 @@ impl Device {
         create_info: &vk::ShaderModuleCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::ShaderModule> {
-        let mut shader = mem::zeroed();
+        let mut shader = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_shader_module)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut shader,
+            shader.as_mut_ptr(),
         )
-        .result_with_success(shader)
+        .assume_init_on_success(shader)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateFence.html>
@@ -2658,14 +2677,14 @@ impl Device {
         create_info: &vk::FenceCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Fence> {
-        let mut fence = mem::zeroed();
+        let mut fence = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_fence)(
             self.handle(),
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut fence,
+            fence.as_mut_ptr(),
         )
-        .result_with_success(fence)
+        .assume_init_on_success(fence)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkBindBufferMemory.html>
@@ -2694,25 +2713,25 @@ impl Device {
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetRenderAreaGranularity.html>
     #[inline]
     pub unsafe fn get_render_area_granularity(&self, render_pass: vk::RenderPass) -> vk::Extent2D {
-        let mut granularity = mem::zeroed();
+        let mut granularity = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.get_render_area_granularity)(
             self.handle(),
             render_pass,
-            &mut granularity,
+            granularity.as_mut_ptr(),
         );
-        granularity
+        granularity.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceMemoryCommitment.html>
     #[inline]
     pub unsafe fn get_device_memory_commitment(&self, memory: vk::DeviceMemory) -> vk::DeviceSize {
-        let mut committed_memory_in_bytes = 0;
+        let mut committed_memory_in_bytes = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.get_device_memory_commitment)(
             self.handle(),
             memory,
-            &mut committed_memory_in_bytes,
+            committed_memory_in_bytes.as_mut_ptr(),
         );
-        committed_memory_in_bytes
+        committed_memory_in_bytes.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSparseMemoryRequirements.html>

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1546,10 +1546,7 @@ impl Device {
             allocate_info,
             desc_set.as_mut_ptr(),
         )
-        .result()?;
-
-        desc_set.set_len(allocate_info.descriptor_set_count as usize);
-        Ok(desc_set)
+        .set_vec_len_on_success(desc_set, allocate_info.descriptor_set_count as usize)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateDescriptorSetLayout.html>
@@ -2536,9 +2533,7 @@ impl Device {
             allocate_info,
             buffers.as_mut_ptr(),
         )
-        .result()?;
-        buffers.set_len(allocate_info.command_buffer_count as usize);
-        Ok(buffers)
+        .set_vec_len_on_success(buffers, allocate_info.command_buffer_count as usize)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateCommandPool.html>

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -38,9 +38,7 @@ impl ShaderEnqueue {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         )
-        .result()?;
-        pipelines.set_len(create_infos.len());
-        Ok(pipelines)
+        .set_vec_len_on_success(pipelines, create_infos.len())
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetExecutionGraphPipelineScratchSizeAMDX.html>

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -63,14 +63,14 @@ impl ShaderEnqueue {
         execution_graph: vk::Pipeline,
         node_info: &vk::PipelineShaderStageNodeCreateInfoAMDX<'_>,
     ) -> VkResult<u32> {
-        let mut node_index = 0;
+        let mut node_index = mem::MaybeUninit::uninit();
         (self.fp.get_execution_graph_pipeline_node_index_amdx)(
             self.handle,
             execution_graph,
             node_info,
-            &mut node_index,
+            node_index.as_mut_ptr(),
         )
-        .result_with_success(node_index)
+        .assume_init_on_success(node_index)
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdInitializeGraphScratchMemoryAMDX.html>

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -29,7 +29,7 @@ impl ShaderEnqueue {
         create_infos: &[vk::ExecutionGraphPipelineCreateInfoAMDX<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::Pipeline>> {
-        let mut pipelines = vec![mem::zeroed(); create_infos.len()];
+        let mut pipelines = Vec::with_capacity(create_infos.len());
         (self.fp.create_execution_graph_pipelines_amdx)(
             self.handle,
             pipeline_cache,
@@ -38,7 +38,9 @@ impl ShaderEnqueue {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         )
-        .result_with_success(pipelines)
+        .result()?;
+        pipelines.set_len(create_infos.len());
+        Ok(pipelines)
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetExecutionGraphPipelineScratchSizeAMDX.html>

--- a/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
+++ b/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
@@ -37,9 +37,9 @@ impl ExternalMemoryAndroidHardwareBuffer {
         &self,
         info: &vk::MemoryGetAndroidHardwareBufferInfoANDROID<'_>,
     ) -> VkResult<*mut vk::AHardwareBuffer> {
-        let mut buffer = std::ptr::null_mut();
-        (self.fp.get_memory_android_hardware_buffer_android)(self.handle, info, &mut buffer)
-            .result_with_success(buffer)
+        let mut buffer = mem::MaybeUninit::uninit();
+        (self.fp.get_memory_android_hardware_buffer_android)(self.handle, info, buffer.as_mut_ptr())
+            .assume_init_on_success(buffer)
     }
 
     pub const NAME: &'static CStr = vk::AndroidExternalMemoryAndroidHardwareBufferFn::NAME;

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -43,17 +43,18 @@ impl CalibratedTimestamps {
         device: vk::Device,
         info: &[vk::CalibratedTimestampInfoEXT<'_>],
     ) -> VkResult<(Vec<u64>, u64)> {
-        let mut timestamps = vec![0u64; info.len()];
+        let mut timestamps = Vec::with_capacity(info.len());
         let mut max_deviation = mem::MaybeUninit::uninit();
-        (self.fp.get_calibrated_timestamps_ext)(
+        let max_deviation = (self.fp.get_calibrated_timestamps_ext)(
             device,
             info.len() as u32,
             info.as_ptr(),
             timestamps.as_mut_ptr(),
             max_deviation.as_mut_ptr(),
         )
-        .assume_init_on_success(max_deviation)
-        .map(|max_deviation| (timestamps, max_deviation))
+        .assume_init_on_success(max_deviation)?;
+        timestamps.set_len(info.len());
+        Ok((timestamps, max_deviation))
     }
 
     pub const NAME: &'static CStr = vk::ExtCalibratedTimestampsFn::NAME;

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -44,15 +44,16 @@ impl CalibratedTimestamps {
         info: &[vk::CalibratedTimestampInfoEXT<'_>],
     ) -> VkResult<(Vec<u64>, u64)> {
         let mut timestamps = vec![0u64; info.len()];
-        let mut max_deviation = 0u64;
+        let mut max_deviation = mem::MaybeUninit::uninit();
         (self.fp.get_calibrated_timestamps_ext)(
             device,
             info.len() as u32,
             info.as_ptr(),
             timestamps.as_mut_ptr(),
-            &mut max_deviation,
+            max_deviation.as_mut_ptr(),
         )
-        .result_with_success((timestamps, max_deviation))
+        .assume_init_on_success(max_deviation)
+        .map(|max_deviation| (timestamps, max_deviation))
     }
 
     pub const NAME: &'static CStr = vk::ExtCalibratedTimestampsFn::NAME;

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -41,14 +41,14 @@ impl DebugReport {
         create_info: &vk::DebugReportCallbackCreateInfoEXT<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DebugReportCallbackEXT> {
-        let mut debug_cb = mem::zeroed();
+        let mut debug_cb = mem::MaybeUninit::uninit();
         (self.fp.create_debug_report_callback_ext)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut debug_cb,
+            debug_cb.as_mut_ptr(),
         )
-        .result_with_success(debug_cb)
+        .assume_init_on_success(debug_cb)
     }
 
     pub const NAME: &'static CStr = vk::ExtDebugReportFn::NAME;

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -98,14 +98,14 @@ impl DebugUtils {
         create_info: &vk::DebugUtilsMessengerCreateInfoEXT<'_>,
         allocator: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DebugUtilsMessengerEXT> {
-        let mut messenger = mem::zeroed();
+        let mut messenger = mem::MaybeUninit::uninit();
         (self.fp.create_debug_utils_messenger_ext)(
             self.handle,
             create_info,
             allocator.as_raw_ptr(),
-            &mut messenger,
+            messenger.as_mut_ptr(),
         )
-        .result_with_success(messenger)
+        .assume_init_on_success(messenger)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyDebugUtilsMessengerEXT.html>

--- a/ash/src/extensions/ext/descriptor_buffer.rs
+++ b/ash/src/extensions/ext/descriptor_buffer.rs
@@ -26,9 +26,9 @@ impl DescriptorBuffer {
         &self,
         layout: vk::DescriptorSetLayout,
     ) -> vk::DeviceSize {
-        let mut count = 0;
-        (self.fp.get_descriptor_set_layout_size_ext)(self.handle, layout, &mut count);
-        count
+        let mut count = mem::MaybeUninit::uninit();
+        (self.fp.get_descriptor_set_layout_size_ext)(self.handle, layout, count.as_mut_ptr());
+        count.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDescriptorSetLayoutBindingOffsetEXT.html>
@@ -38,14 +38,14 @@ impl DescriptorBuffer {
         layout: vk::DescriptorSetLayout,
         binding: u32,
     ) -> vk::DeviceSize {
-        let mut offset = 0;
+        let mut offset = mem::MaybeUninit::uninit();
         (self.fp.get_descriptor_set_layout_binding_offset_ext)(
             self.handle,
             layout,
             binding,
-            &mut offset,
+            offset.as_mut_ptr(),
         );
-        offset
+        offset.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDescriptorEXT.html>

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -60,13 +60,13 @@ impl FullScreenExclusive {
         &self,
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
     ) -> VkResult<vk::DeviceGroupPresentModeFlagsKHR> {
-        let mut present_modes = mem::zeroed();
+        let mut present_modes = mem::MaybeUninit::uninit();
         (self.fp.get_device_group_surface_present_modes2_ext)(
             self.handle,
             surface_info,
-            &mut present_modes,
+            present_modes.as_mut_ptr(),
         )
-        .result_with_success(present_modes)
+        .assume_init_on_success(present_modes)
     }
 
     pub const NAME: &'static CStr = vk::ExtFullScreenExclusiveFn::NAME;

--- a/ash/src/extensions/ext/headless_surface.rs
+++ b/ash/src/extensions/ext/headless_surface.rs
@@ -28,14 +28,14 @@ impl HeadlessSurface {
         create_info: &vk::HeadlessSurfaceCreateInfoEXT<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_headless_surface_ext)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     pub const NAME: &'static CStr = vk::ExtHeadlessSurfaceFn::NAME;

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -27,14 +27,14 @@ impl MetalSurface {
         create_info: &vk::MetalSurfaceCreateInfoEXT<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_metal_surface_ext)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     pub const NAME: &'static CStr = vk::ExtMetalSurfaceFn::NAME;

--- a/ash/src/extensions/ext/private_data.rs
+++ b/ash/src/extensions/ext/private_data.rs
@@ -28,14 +28,14 @@ impl PrivateData {
         create_info: &vk::PrivateDataSlotCreateInfoEXT<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PrivateDataSlotEXT> {
-        let mut private_data_slot = mem::zeroed();
+        let mut private_data_slot = mem::MaybeUninit::uninit();
         (self.fp.create_private_data_slot_ext)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut private_data_slot,
+            private_data_slot.as_mut_ptr(),
         )
-        .result_with_success(private_data_slot)
+        .assume_init_on_success(private_data_slot)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyPrivateDataSlotEXT.html>
@@ -77,15 +77,15 @@ impl PrivateData {
         object: T,
         private_data_slot: vk::PrivateDataSlotEXT,
     ) -> u64 {
-        let mut data = mem::zeroed();
+        let mut data = mem::MaybeUninit::uninit();
         (self.fp.get_private_data_ext)(
             self.handle,
             T::TYPE,
             object.as_raw(),
             private_data_slot,
-            &mut data,
+            data.as_mut_ptr(),
         );
-        data
+        data.assume_init()
     }
 
     pub const NAME: &'static CStr = vk::ExtPrivateDataFn::NAME;

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -37,9 +37,7 @@ impl ShaderObject {
             allocator.as_raw_ptr(),
             shaders.as_mut_ptr(),
         )
-        .result()?;
-        shaders.set_len(create_infos.len());
-        Ok(shaders)
+        .set_vec_len_on_success(shaders, create_infos.len())
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyShaderEXT.html>

--- a/ash/src/extensions/google/display_timing.rs
+++ b/ash/src/extensions/google/display_timing.rs
@@ -37,9 +37,9 @@ impl DisplayTiming {
         &self,
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<vk::RefreshCycleDurationGOOGLE> {
-        let mut properties = mem::zeroed();
-        (self.fp.get_refresh_cycle_duration_google)(self.handle, swapchain, &mut properties)
-            .result_with_success(properties)
+        let mut properties = mem::MaybeUninit::uninit();
+        (self.fp.get_refresh_cycle_duration_google)(self.handle, swapchain, properties.as_mut_ptr())
+            .assume_init_on_success(properties)
     }
 
     pub const NAME: &'static CStr = vk::GoogleDisplayTimingFn::NAME;

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -28,14 +28,14 @@ impl AccelerationStructure {
         create_info: &vk::AccelerationStructureCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
-        let mut accel_struct = mem::zeroed();
+        let mut accel_struct = mem::MaybeUninit::uninit();
         (self.fp.create_acceleration_structure_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut accel_struct,
+            accel_struct.as_mut_ptr(),
         )
-        .result_with_success(accel_struct)
+        .assume_init_on_success(accel_struct)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyAccelerationStructureKHR.html>
@@ -259,15 +259,13 @@ impl AccelerationStructure {
         &self,
         version: &vk::AccelerationStructureVersionInfoKHR<'_>,
     ) -> vk::AccelerationStructureCompatibilityKHR {
-        let mut compatibility = mem::zeroed();
-
+        let mut compatibility = mem::MaybeUninit::uninit();
         (self.fp.get_device_acceleration_structure_compatibility_khr)(
             self.handle,
             version,
-            &mut compatibility,
+            compatibility.as_mut_ptr(),
         );
-
-        compatibility
+        compatibility.assume_init()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetAccelerationStructureBuildSizesKHR.html>

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -27,14 +27,14 @@ impl AndroidSurface {
         create_info: &vk::AndroidSurfaceCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_android_surface_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     pub const NAME: &'static CStr = vk::KhrAndroidSurfaceFn::NAME;

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -27,14 +27,14 @@ impl CreateRenderPass2 {
         create_info: &vk::RenderPassCreateInfo2<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::RenderPass> {
-        let mut renderpass = mem::zeroed();
+        let mut renderpass = mem::MaybeUninit::uninit();
         (self.fp.create_render_pass2_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut renderpass,
+            renderpass.as_mut_ptr(),
         )
-        .result_with_success(renderpass)
+        .assume_init_on_success(renderpass)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdBeginRenderPass2.html>

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -26,13 +26,13 @@ impl DeferredHostOperations {
         &self,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DeferredOperationKHR> {
-        let mut operation = mem::zeroed();
+        let mut operation = mem::MaybeUninit::uninit();
         (self.fp.create_deferred_operation_khr)(
             self.handle,
             allocation_callbacks.as_raw_ptr(),
-            &mut operation,
+            operation.as_mut_ptr(),
         )
-        .result_with_success(operation)
+        .assume_init_on_success(operation)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDeferredOperationJoinKHR.html>

--- a/ash/src/extensions/khr/device_group_creation.rs
+++ b/ash/src/extensions/khr/device_group_creation.rs
@@ -24,13 +24,14 @@ impl DeviceGroupCreation {
     /// Retrieve the number of elements to pass to [`enumerate_physical_device_groups()`][Self::enumerate_physical_device_groups()]
     #[inline]
     pub unsafe fn enumerate_physical_device_groups_len(&self) -> VkResult<usize> {
-        let mut group_count = 0;
+        let mut group_count = mem::MaybeUninit::uninit();
         (self.fp.enumerate_physical_device_groups_khr)(
             self.handle,
-            &mut group_count,
+            group_count.as_mut_ptr(),
             ptr::null_mut(),
         )
-        .result_with_success(group_count as usize)
+        .assume_init_on_success(group_count)
+        .map(|c| c as usize)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumeratePhysicalDeviceGroupsKHR.html>

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -80,7 +80,7 @@ impl Display {
         create_info: &vk::DisplayModeCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DisplayModeKHR> {
-        let mut display_mode = mem::MaybeUninit::zeroed();
+        let mut display_mode = mem::MaybeUninit::uninit();
         (self.fp.create_display_mode_khr)(
             physical_device,
             display,
@@ -99,7 +99,7 @@ impl Display {
         mode: vk::DisplayModeKHR,
         plane_index: u32,
     ) -> VkResult<vk::DisplayPlaneCapabilitiesKHR> {
-        let mut display_plane_capabilities = mem::MaybeUninit::zeroed();
+        let mut display_plane_capabilities = mem::MaybeUninit::uninit();
         (self.fp.get_display_plane_capabilities_khr)(
             physical_device,
             mode,
@@ -116,7 +116,7 @@ impl Display {
         create_info: &vk::DisplaySurfaceCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::MaybeUninit::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_display_plane_surface_khr)(
             self.handle,
             create_info,

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -35,9 +35,7 @@ impl DisplaySwapchain {
             allocation_callbacks.as_raw_ptr(),
             swapchains.as_mut_ptr(),
         )
-        .result()?;
-        swapchains.set_len(create_infos.len());
-        Ok(swapchains)
+        .set_vec_len_on_success(swapchains, create_infos.len())
     }
 
     pub const NAME: &'static CStr = vk::KhrDisplaySwapchainFn::NAME;

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -31,8 +31,9 @@ impl ExternalFenceFd {
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetFenceFdKHR.html>
     #[inline]
     pub unsafe fn get_fence_fd(&self, get_info: &vk::FenceGetFdInfoKHR<'_>) -> VkResult<i32> {
-        let mut fd = -1;
-        (self.fp.get_fence_fd_khr)(self.handle, get_info, &mut fd).result_with_success(fd)
+        let mut fd = mem::MaybeUninit::uninit();
+        (self.fp.get_fence_fd_khr)(self.handle, get_info, fd.as_mut_ptr())
+            .assume_init_on_success(fd)
     }
 
     pub const NAME: &'static CStr = vk::KhrExternalFenceFdFn::NAME;

--- a/ash/src/extensions/khr/external_fence_win32.rs
+++ b/ash/src/extensions/khr/external_fence_win32.rs
@@ -3,7 +3,6 @@ use crate::vk;
 use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
-use std::mem::MaybeUninit;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_fence_win32.html>
 #[derive(Clone)]
@@ -36,7 +35,7 @@ impl ExternalFenceWin32 {
         &self,
         get_info: &vk::FenceGetWin32HandleInfoKHR<'_>,
     ) -> VkResult<vk::HANDLE> {
-        let mut handle = MaybeUninit::uninit();
+        let mut handle = mem::MaybeUninit::uninit();
         (self.fp.get_fence_win32_handle_khr)(self.handle, get_info, handle.as_mut_ptr())
             .assume_init_on_success(handle)
     }

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -23,8 +23,9 @@ impl ExternalMemoryFd {
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryFdKHR.html>
     #[inline]
     pub unsafe fn get_memory_fd(&self, get_fd_info: &vk::MemoryGetFdInfoKHR<'_>) -> VkResult<i32> {
-        let mut fd = -1;
-        (self.fp.get_memory_fd_khr)(self.handle, get_fd_info, &mut fd).result_with_success(fd)
+        let mut fd = mem::MaybeUninit::uninit();
+        (self.fp.get_memory_fd_khr)(self.handle, get_fd_info, fd.as_mut_ptr())
+            .assume_init_on_success(fd)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -3,7 +3,6 @@ use crate::vk;
 use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
-use std::mem::MaybeUninit;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_memory_win32.html>
 #[derive(Clone)]
@@ -27,7 +26,7 @@ impl ExternalMemoryWin32 {
         &self,
         create_info: &vk::MemoryGetWin32HandleInfoKHR<'_>,
     ) -> VkResult<vk::HANDLE> {
-        let mut handle = MaybeUninit::uninit();
+        let mut handle = mem::MaybeUninit::uninit();
         (self.fp.get_memory_win32_handle_khr)(self.handle, create_info, handle.as_mut_ptr())
             .assume_init_on_success(handle)
     }

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -34,8 +34,9 @@ impl ExternalSemaphoreFd {
         &self,
         get_info: &vk::SemaphoreGetFdInfoKHR<'_>,
     ) -> VkResult<i32> {
-        let mut fd = -1;
-        (self.fp.get_semaphore_fd_khr)(self.handle, get_info, &mut fd).result_with_success(fd)
+        let mut fd = mem::MaybeUninit::uninit();
+        (self.fp.get_semaphore_fd_khr)(self.handle, get_info, fd.as_mut_ptr())
+            .assume_init_on_success(fd)
     }
 
     pub const NAME: &'static CStr = vk::KhrExternalSemaphoreFdFn::NAME;

--- a/ash/src/extensions/khr/external_semaphore_win32.rs
+++ b/ash/src/extensions/khr/external_semaphore_win32.rs
@@ -3,7 +3,6 @@ use crate::vk;
 use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
-use std::mem::MaybeUninit;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_semaphore_win32.html>
 #[derive(Clone)]
@@ -36,7 +35,7 @@ impl ExternalSemaphoreWin32 {
         &self,
         get_info: &vk::SemaphoreGetWin32HandleInfoKHR<'_>,
     ) -> VkResult<vk::HANDLE> {
-        let mut handle = MaybeUninit::uninit();
+        let mut handle = mem::MaybeUninit::uninit();
         (self.fp.get_semaphore_win32_handle_khr)(self.handle, get_info, handle.as_mut_ptr())
             .assume_init_on_success(handle)
     }

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -45,14 +45,14 @@ impl GetMemoryRequirements2 {
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2KHR<'_>,
     ) -> usize {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self.fp.get_image_sparse_memory_requirements2_khr)(
             self.handle,
             info,
-            &mut count,
+            count.as_mut_ptr(),
             ptr::null_mut(),
         );
-        count as usize
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSparseMemoryRequirements2KHR.html>

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -85,13 +85,13 @@ impl GetPhysicalDeviceProperties2 {
         &self,
         physical_device: vk::PhysicalDevice,
     ) -> usize {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self.fp.get_physical_device_queue_family_properties2_khr)(
             physical_device,
-            &mut count,
+            count.as_mut_ptr(),
             ptr::null_mut(),
         );
-        count as usize
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties2KHR.html>
@@ -120,16 +120,16 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR<'_>,
     ) -> usize {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self
             .fp
             .get_physical_device_sparse_image_format_properties2_khr)(
             physical_device,
             format_info,
-            &mut count,
+            count.as_mut_ptr(),
             ptr::null_mut(),
         );
-        count as usize
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties2KHR.html>

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -41,14 +41,14 @@ impl GetSurfaceCapabilities2 {
         physical_device: vk::PhysicalDevice,
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
     ) -> VkResult<usize> {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         let err_code = (self.fp.get_physical_device_surface_formats2_khr)(
             physical_device,
             surface_info,
-            &mut count,
+            count.as_mut_ptr(),
             std::ptr::null_mut(),
         );
-        err_code.result_with_success(count as usize)
+        err_code.assume_init_on_success(count).map(|c| c as usize)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfaceFormats2KHR.html>

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -45,14 +45,14 @@ impl Maintenance4 {
         &self,
         memory_requirements: &vk::DeviceImageMemoryRequirementsKHR<'_>,
     ) -> usize {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self.fp.get_device_image_sparse_memory_requirements_khr)(
             self.handle,
             memory_requirements,
-            &mut count,
+            count.as_mut_ptr(),
             std::ptr::null_mut(),
         );
-        count as usize
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageSparseMemoryRequirementsKHR.html>

--- a/ash/src/extensions/khr/maintenance5.rs
+++ b/ash/src/extensions/khr/maintenance5.rs
@@ -40,13 +40,13 @@ impl Maintenance5 {
         &self,
         rendering_area_info: &vk::RenderingAreaInfoKHR<'_>,
     ) -> vk::Extent2D {
-        let mut granularity = mem::zeroed();
+        let mut granularity = mem::MaybeUninit::uninit();
         (self.fp.get_rendering_area_granularity_khr)(
             self.handle,
             rendering_area_info,
-            &mut granularity,
+            granularity.as_mut_ptr(),
         );
-        granularity
+        granularity.assume_init()
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageSubresourceLayoutKHR.html>

--- a/ash/src/extensions/khr/performance_query.rs
+++ b/ash/src/extensions/khr/performance_query.rs
@@ -28,17 +28,18 @@ impl PerformanceQuery {
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
     ) -> VkResult<usize> {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self
             .fp
             .enumerate_physical_device_queue_family_performance_query_counters_khr)(
             physical_device,
             queue_family_index,
-            &mut count,
+            count.as_mut_ptr(),
             ptr::null_mut(),
             ptr::null_mut(),
         )
-        .result_with_success(count as usize)
+        .assume_init_on_success(count)
+        .map(|c| c as usize)
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR.html>
@@ -77,15 +78,15 @@ impl PerformanceQuery {
         physical_device: vk::PhysicalDevice,
         performance_query_create_info: &vk::QueryPoolPerformanceCreateInfoKHR<'_>,
     ) -> u32 {
-        let mut num_passes = 0;
+        let mut num_passes = mem::MaybeUninit::uninit();
         (self
             .fp
             .get_physical_device_queue_family_performance_query_passes_khr)(
             physical_device,
             performance_query_create_info,
-            &mut num_passes,
+            num_passes.as_mut_ptr(),
         );
-        num_passes
+        num_passes.assume_init()
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkAcquireProfilingLockKHR.html>

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -64,9 +64,7 @@ impl RayTracingPipeline {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         )
-        .result()?;
-        pipelines.set_len(create_info.len());
-        Ok(pipelines)
+        .set_vec_len_on_success(pipelines, create_info.len())
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetRayTracingShaderGroupHandlesKHR.html>
@@ -87,9 +85,7 @@ impl RayTracingPipeline {
             data_size,
             data.as_mut_ptr().cast(),
         )
-        .result()?;
-        data.set_len(data_size);
-        Ok(data)
+        .set_vec_len_on_success(data, data_size)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.html>
@@ -112,9 +108,7 @@ impl RayTracingPipeline {
             data_size,
             data.as_mut_ptr().cast(),
         )
-        .result()?;
-        data.set_len(data_size);
-        Ok(data)
+        .set_vec_len_on_success(data, data_size)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdTraceRaysIndirectKHR.html>

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -54,7 +54,7 @@ impl RayTracingPipeline {
         create_info: &[vk::RayTracingPipelineCreateInfoKHR<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::Pipeline>> {
-        let mut pipelines = vec![mem::zeroed(); create_info.len()];
+        let mut pipelines = Vec::with_capacity(create_info.len());
         (self.fp.create_ray_tracing_pipelines_khr)(
             self.handle,
             deferred_operation,
@@ -64,7 +64,9 @@ impl RayTracingPipeline {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         )
-        .result_with_success(pipelines)
+        .result()?;
+        pipelines.set_len(create_info.len());
+        Ok(pipelines)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetRayTracingShaderGroupHandlesKHR.html>

--- a/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
+++ b/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
@@ -28,14 +28,14 @@ impl SamplerYcbcrConversion {
         create_info: &vk::SamplerYcbcrConversionCreateInfo<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
-        let mut ycbcr_conversion = mem::zeroed();
+        let mut ycbcr_conversion = mem::MaybeUninit::uninit();
         (self.fp.create_sampler_ycbcr_conversion_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut ycbcr_conversion,
+            ycbcr_conversion.as_mut_ptr(),
         )
-        .result_with_success(ycbcr_conversion)
+        .assume_init_on_success(ycbcr_conversion)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroySamplerYcbcrConversion.html>

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -28,14 +28,15 @@ impl Surface {
         queue_family_index: u32,
         surface: vk::SurfaceKHR,
     ) -> VkResult<bool> {
-        let mut b = 0;
+        let mut b = mem::MaybeUninit::uninit();
         (self.fp.get_physical_device_surface_support_khr)(
             physical_device,
             queue_family_index,
             surface,
-            &mut b,
+            b.as_mut_ptr(),
         )
-        .result_with_success(b > 0)
+        .result()?;
+        Ok(b.assume_init() > 0)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>
@@ -62,13 +63,13 @@ impl Surface {
         physical_device: vk::PhysicalDevice,
         surface: vk::SurfaceKHR,
     ) -> VkResult<vk::SurfaceCapabilitiesKHR> {
-        let mut surface_capabilities = mem::zeroed();
+        let mut surface_capabilities = mem::MaybeUninit::uninit();
         (self.fp.get_physical_device_surface_capabilities_khr)(
             physical_device,
             surface,
-            &mut surface_capabilities,
+            surface_capabilities.as_mut_ptr(),
         )
-        .result_with_success(surface_capabilities)
+        .assume_init_on_success(surface_capabilities)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -22,9 +22,9 @@ impl TimelineSemaphore {
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetSemaphoreCounterValue.html>
     #[inline]
     pub unsafe fn get_semaphore_counter_value(&self, semaphore: vk::Semaphore) -> VkResult<u64> {
-        let mut value = 0;
-        (self.fp.get_semaphore_counter_value_khr)(self.handle, semaphore, &mut value)
-            .result_with_success(value)
+        let mut value = mem::MaybeUninit::uninit();
+        (self.fp.get_semaphore_counter_value_khr)(self.handle, semaphore, value.as_mut_ptr())
+            .assume_init_on_success(value)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkWaitSemaphores.html>

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -27,14 +27,14 @@ impl WaylandSurface {
         create_info: &vk::WaylandSurfaceCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_wayland_surface_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html>

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -27,14 +27,14 @@ impl Win32Surface {
         create_info: &vk::Win32SurfaceCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_win32_surface_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceWin32PresentationSupportKHR.html>

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -27,14 +27,14 @@ impl XcbSurface {
         create_info: &vk::XcbSurfaceCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_xcb_surface_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceXcbPresentationSupportKHR.html>

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -27,14 +27,14 @@ impl XlibSurface {
         create_info: &vk::XlibSurfaceCreateInfoKHR<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_xlib_surface_khr)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceXlibPresentationSupportKHR.html>

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -27,14 +27,14 @@ impl IOSSurface {
         create_info: &vk::IOSSurfaceCreateInfoMVK<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_ios_surface_mvk)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     pub const NAME: &'static CStr = vk::MvkIosSurfaceFn::NAME;

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -27,14 +27,14 @@ impl MacOSSurface {
         create_info: &vk::MacOSSurfaceCreateInfoMVK<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_mac_os_surface_mvk)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     pub const NAME: &'static CStr = vk::MvkMacosSurfaceFn::NAME;

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -27,14 +27,14 @@ impl ViSurface {
         create_info: &vk::ViSurfaceCreateInfoNN<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
-        let mut surface = mem::zeroed();
+        let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_vi_surface_nn)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut surface,
+            surface.as_mut_ptr(),
         )
-        .result_with_success(surface)
+        .assume_init_on_success(surface)
     }
 
     pub const NAME: &'static CStr = vk::NnViSurfaceFn::NAME;

--- a/ash/src/extensions/nv/coverage_reduction_mode.rs
+++ b/ash/src/extensions/nv/coverage_reduction_mode.rs
@@ -24,15 +24,16 @@ impl CoverageReductionMode {
         &self,
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<usize> {
-        let mut count = 0;
+        let mut count = mem::MaybeUninit::uninit();
         (self
             .fp
             .get_physical_device_supported_framebuffer_mixed_samples_combinations_nv)(
             physical_device,
-            &mut count,
+            count.as_mut_ptr(),
             std::ptr::null_mut(),
         )
-        .result_with_success(count as usize)
+        .assume_init_on_success(count)
+        .map(|c| c as usize)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV.html>

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -31,9 +31,9 @@ impl DeviceDiagnosticCheckpoints {
     /// Retrieve the number of elements to pass to [`get_queue_checkpoint_data()`][Self::get_queue_checkpoint_data()]
     #[inline]
     pub unsafe fn get_queue_checkpoint_data_len(&self, queue: vk::Queue) -> usize {
-        let mut count = 0;
-        (self.fp.get_queue_checkpoint_data_nv)(queue, &mut count, std::ptr::null_mut());
-        count as usize
+        let mut count = mem::MaybeUninit::uninit();
+        (self.fp.get_queue_checkpoint_data_nv)(queue, count.as_mut_ptr(), std::ptr::null_mut());
+        count.assume_init() as usize
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetQueueCheckpointDataNV.html>

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -166,7 +166,7 @@ impl RayTracing {
         create_info: &[vk::RayTracingPipelineCreateInfoNV<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::Pipeline>> {
-        let mut pipelines = vec![mem::zeroed(); create_info.len()];
+        let mut pipelines = Vec::with_capacity(create_info.len());
         (self.fp.create_ray_tracing_pipelines_nv)(
             self.handle,
             pipeline_cache,
@@ -175,7 +175,9 @@ impl RayTracing {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         )
-        .result_with_success(pipelines)
+        .result()?;
+        pipelines.set_len(create_info.len());
+        Ok(pipelines)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetRayTracingShaderGroupHandlesNV.html>

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -175,9 +175,7 @@ impl RayTracing {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         )
-        .result()?;
-        pipelines.set_len(create_info.len());
-        Ok(pipelines)
+        .set_vec_len_on_success(pipelines, create_info.len())
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetRayTracingShaderGroupHandlesNV.html>

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -27,14 +27,14 @@ impl RayTracing {
         create_info: &vk::AccelerationStructureCreateInfoNV<'_>,
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::AccelerationStructureNV> {
-        let mut accel_struct = mem::zeroed();
+        let mut accel_struct = mem::MaybeUninit::uninit();
         (self.fp.create_acceleration_structure_nv)(
             self.handle,
             create_info,
             allocation_callbacks.as_raw_ptr(),
-            &mut accel_struct,
+            accel_struct.as_mut_ptr(),
         )
-        .result_with_success(accel_struct)
+        .assume_init_on_success(accel_struct)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyAccelerationStructureNV.html>
@@ -204,15 +204,14 @@ impl RayTracing {
         &self,
         accel_struct: vk::AccelerationStructureNV,
     ) -> VkResult<u64> {
-        let mut handle: u64 = 0;
-        let handle_ptr: *mut u64 = &mut handle;
+        let mut handle = mem::MaybeUninit::<u64>::uninit();
         (self.fp.get_acceleration_structure_handle_nv)(
             self.handle,
             accel_struct,
-            std::mem::size_of::<u64>(),
-            handle_ptr.cast(),
+            std::mem::size_of_val(&handle),
+            handle.as_mut_ptr().cast(),
         )
-        .result_with_success(handle)
+        .assume_init_on_success(handle)
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdWriteAccelerationStructuresPropertiesNV.html>


### PR DESCRIPTION
As noted in #792 changes like this might help us more strictly identify and validate that the argument in question is only relevant as an output argument (i.e. structs with `sType` are read by the function call, even if the caller strictly expects return values there, so that it can fill in multiple structures in a `pNext` chain, and must hence be `Default`- initialized).

It does embed rather nicely with the `assume_init_on_success()` API, though.

---

Creating this as draft just to feel out where we stand with this; it might not net us too much, and doesn't seem like it would help us audit for accidental `sType` structs that are zero/uninit.  There was also the idea to initialize handles with `::null()` explicitly (instead of `mem::zeroed()` or the `MaybeUninit::uninit()` added here), but that also doesn't sound like much of an improvement.
