### PR TITLE
Resolve lint warnings for `deprecated_in_future`, `rust_2018_idioms` and `unused_qualifications`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The Vulkan Video bindings are experimental and still seeing breaking changes in 
 ```rust
 // function signature
 pub fn create_instance(&self,
-                       create_info: &vk::InstanceCreateInfo,
-                       allocation_callbacks: Option<&vk::AllocationCallbacks>)
+                       create_info: &vk::InstanceCreateInfo<'_>,
+                       allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>)
                        -> Result<Instance, InstanceError> { .. }
 let instance = entry.create_instance(&create_info, None)
     .expect("Instance creation error");
@@ -59,9 +59,9 @@ pub fn cmd_pipeline_barrier(&self,
                             src_stage_mask: vk::PipelineStageFlags,
                             dst_stage_mask: vk::PipelineStageFlags,
                             dependency_flags: vk::DependencyFlags,
-                            memory_barriers: &[vk::MemoryBarrier],
-                            buffer_memory_barriers: &[vk::BufferMemoryBarrier],
-                            image_memory_barriers: &[vk::ImageMemoryBarrier]);
+                            memory_barriers: &[vk::MemoryBarrier<'_>],
+                            buffer_memory_barriers: &[vk::BufferMemoryBarrier<'_>],
+                            image_memory_barriers: &[vk::ImageMemoryBarrier<'_>]);
 ```
 
 ### Strongly typed handles
@@ -181,7 +181,7 @@ Handles from Instance or Device are passed implicitly.
 
 ```rust
 pub fn create_command_pool(&self,
-                           create_info: &vk::CommandPoolCreateInfo)
+                           create_info: &vk::CommandPoolCreateInfo<'_>)
                            -> VkResult<vk::CommandPool>;
 
 let pool = device.create_command_pool(&pool_create_info).unwrap();

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -37,7 +37,7 @@ pub unsafe fn create_surface(
     instance: &Instance,
     display_handle: RawDisplayHandle,
     window_handle: RawWindowHandle,
-    allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
 ) -> VkResult<vk::SurfaceKHR> {
     match (display_handle, window_handle) {
         (RawDisplayHandle::Windows(_), RawWindowHandle::Win32(window)) => {

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -167,7 +167,7 @@ impl Device {
     pub unsafe fn cmd_wait_events2(
         &self,
         command_buffer: vk::CommandBuffer,
-        events: &[vk::Event<'_>],
+        events: &[vk::Event],
         dependency_infos: &[vk::DependencyInfo<'_>],
     ) {
         assert_eq!(events.len(), dependency_infos.len());
@@ -309,7 +309,7 @@ impl Device {
     pub unsafe fn cmd_set_viewport_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        viewports: &[vk::Viewport<'_>],
+        viewports: &[vk::Viewport],
     ) {
         (self.device_fn_1_3.cmd_set_viewport_with_count)(
             command_buffer,
@@ -323,7 +323,7 @@ impl Device {
     pub unsafe fn cmd_set_scissor_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        scissors: &[vk::Rect2D<'_>],
+        scissors: &[vk::Rect2D],
     ) {
         (self.device_fn_1_3.cmd_set_scissor_with_count)(
             command_buffer,
@@ -338,10 +338,10 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer<'_>],
-        offsets: &[vk::DeviceSize<'_>],
-        sizes: Option<&[vk::DeviceSize<'_>]>,
-        strides: Option<&[vk::DeviceSize<'_>]>,
+        buffers: &[vk::Buffer],
+        offsets: &[vk::DeviceSize],
+        sizes: Option<&[vk::DeviceSize]>,
+        strides: Option<&[vk::DeviceSize]>,
     ) {
         assert_eq!(offsets.len(), buffers.len());
         let p_sizes = if let Some(sizes) = sizes {
@@ -1013,7 +1013,7 @@ impl Device {
     pub unsafe fn free_command_buffers(
         &self,
         command_pool: vk::CommandPool,
-        command_buffers: &[vk::CommandBuffer<'_>],
+        command_buffers: &[vk::CommandBuffer],
     ) {
         (self.device_fn_1_0.free_command_buffers)(
             self.handle(),
@@ -1090,7 +1090,7 @@ impl Device {
     pub unsafe fn cmd_wait_events(
         &self,
         command_buffer: vk::CommandBuffer,
-        events: &[vk::Event<'_>],
+        events: &[vk::Event],
         src_stage_mask: vk::PipelineStageFlags,
         dst_stage_mask: vk::PipelineStageFlags,
         memory_barriers: &[vk::MemoryBarrier<'_>],
@@ -1329,7 +1329,7 @@ impl Device {
     pub unsafe fn free_descriptor_sets(
         &self,
         pool: vk::DescriptorPool,
-        descriptor_sets: &[vk::DescriptorSet<'_>],
+        descriptor_sets: &[vk::DescriptorSet],
     ) -> VkResult<()> {
         (self.device_fn_1_0.free_descriptor_sets)(
             self.handle(),
@@ -1382,7 +1382,7 @@ impl Device {
         src_image_layout: vk::ImageLayout,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::ImageBlit<'_>],
+        regions: &[vk::ImageBlit],
         filter: vk::Filter,
     ) {
         (self.device_fn_1_0.cmd_blit_image)(
@@ -1406,7 +1406,7 @@ impl Device {
         src_image_layout: vk::ImageLayout,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::ImageResolve<'_>],
+        regions: &[vk::ImageResolve],
     ) {
         (self.device_fn_1_0.cmd_resolve_image)(
             command_buffer,
@@ -1457,7 +1457,7 @@ impl Device {
         command_buffer: vk::CommandBuffer,
         src_buffer: vk::Buffer,
         dst_buffer: vk::Buffer,
-        regions: &[vk::BufferCopy<'_>],
+        regions: &[vk::BufferCopy],
     ) {
         (self.device_fn_1_0.cmd_copy_buffer)(
             command_buffer,
@@ -1476,7 +1476,7 @@ impl Device {
         src_image: vk::Image,
         src_image_layout: vk::ImageLayout,
         dst_buffer: vk::Buffer,
-        regions: &[vk::BufferImageCopy<'_>],
+        regions: &[vk::BufferImageCopy],
     ) {
         (self.device_fn_1_0.cmd_copy_image_to_buffer)(
             command_buffer,
@@ -1496,7 +1496,7 @@ impl Device {
         src_buffer: vk::Buffer,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::BufferImageCopy<'_>],
+        regions: &[vk::BufferImageCopy],
     ) {
         (self.device_fn_1_0.cmd_copy_buffer_to_image)(
             command_buffer,
@@ -1517,7 +1517,7 @@ impl Device {
         src_image_layout: vk::ImageLayout,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::ImageCopy<'_>],
+        regions: &[vk::ImageCopy],
     ) {
         (self.device_fn_1_0.cmd_copy_image)(
             command_buffer,
@@ -1620,7 +1620,7 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkResetFences.html>
     #[inline]
-    pub unsafe fn reset_fences(&self, fences: &[vk::Fence<'_>]) -> VkResult<()> {
+    pub unsafe fn reset_fences(&self, fences: &[vk::Fence]) -> VkResult<()> {
         (self.device_fn_1_0.reset_fences)(self.handle(), fences.len() as u32, fences.as_ptr())
             .result()
     }
@@ -1644,8 +1644,8 @@ impl Device {
         command_buffer: vk::CommandBuffer,
         image: vk::Image,
         image_layout: vk::ImageLayout,
-        clear_color_value: &vk::ClearColorValue<'_>,
-        ranges: &[vk::ImageSubresourceRange<'_>],
+        clear_color_value: &vk::ClearColorValue,
+        ranges: &[vk::ImageSubresourceRange],
     ) {
         (self.device_fn_1_0.cmd_clear_color_image)(
             command_buffer,
@@ -1664,8 +1664,8 @@ impl Device {
         command_buffer: vk::CommandBuffer,
         image: vk::Image,
         image_layout: vk::ImageLayout,
-        clear_depth_stencil_value: &vk::ClearDepthStencilValue<'_>,
-        ranges: &[vk::ImageSubresourceRange<'_>],
+        clear_depth_stencil_value: &vk::ClearDepthStencilValue,
+        ranges: &[vk::ImageSubresourceRange],
     ) {
         (self.device_fn_1_0.cmd_clear_depth_stencil_image)(
             command_buffer,
@@ -1682,8 +1682,8 @@ impl Device {
     pub unsafe fn cmd_clear_attachments(
         &self,
         command_buffer: vk::CommandBuffer,
-        attachments: &[vk::ClearAttachment<'_>],
-        rects: &[vk::ClearRect<'_>],
+        attachments: &[vk::ClearAttachment],
+        rects: &[vk::ClearRect],
     ) {
         (self.device_fn_1_0.cmd_clear_attachments)(
             command_buffer,
@@ -1739,7 +1739,7 @@ impl Device {
     pub unsafe fn cmd_execute_commands(
         &self,
         primary_command_buffer: vk::CommandBuffer,
-        secondary_command_buffers: &[vk::CommandBuffer<'_>],
+        secondary_command_buffers: &[vk::CommandBuffer],
     ) {
         (self.device_fn_1_0.cmd_execute_commands)(
             primary_command_buffer,
@@ -1756,7 +1756,7 @@ impl Device {
         pipeline_bind_point: vk::PipelineBindPoint,
         layout: vk::PipelineLayout,
         first_set: u32,
-        descriptor_sets: &[vk::DescriptorSet<'_>],
+        descriptor_sets: &[vk::DescriptorSet],
         dynamic_offsets: &[u32],
     ) {
         (self.device_fn_1_0.cmd_bind_descriptor_sets)(
@@ -1854,7 +1854,7 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_scissor: u32,
-        scissors: &[vk::Rect2D<'_>],
+        scissors: &[vk::Rect2D],
     ) {
         (self.device_fn_1_0.cmd_set_scissor)(
             command_buffer,
@@ -1876,8 +1876,8 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer<'_>],
-        offsets: &[vk::DeviceSize<'_>],
+        buffers: &[vk::Buffer],
+        offsets: &[vk::DeviceSize],
     ) {
         debug_assert_eq!(buffers.len(), offsets.len());
         (self.device_fn_1_0.cmd_bind_vertex_buffers)(
@@ -1961,7 +1961,7 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_viewport: u32,
-        viewports: &[vk::Viewport<'_>],
+        viewports: &[vk::Viewport],
     ) {
         (self.device_fn_1_0.cmd_set_viewport)(
             command_buffer,
@@ -2253,7 +2253,7 @@ impl Device {
     pub unsafe fn merge_pipeline_caches(
         &self,
         dst_cache: vk::PipelineCache,
-        src_caches: &[vk::PipelineCache<'_>],
+        src_caches: &[vk::PipelineCache],
     ) -> VkResult<()> {
         (self.device_fn_1_0.merge_pipeline_caches)(
             self.handle(),
@@ -2405,7 +2405,7 @@ impl Device {
     #[inline]
     pub unsafe fn wait_for_fences(
         &self,
-        fences: &[vk::Fence<'_>],
+        fences: &[vk::Fence],
         wait_all: bool,
         timeout: u64,
     ) -> VkResult<()> {

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -67,8 +67,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_private_data_slot(
         &self,
-        create_info: &vk::PrivateDataSlotCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::PrivateDataSlotCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PrivateDataSlot> {
         let mut private_data_slot = mem::zeroed();
         (self.device_fn_1_3.create_private_data_slot)(
@@ -85,7 +85,7 @@ impl Device {
     pub unsafe fn destroy_private_data_slot(
         &self,
         private_data_slot: vk::PrivateDataSlot,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_3.destroy_private_data_slot)(
             self.handle,
@@ -135,7 +135,7 @@ impl Device {
     pub unsafe fn cmd_pipeline_barrier2(
         &self,
         command_buffer: vk::CommandBuffer,
-        dependency_info: &vk::DependencyInfo,
+        dependency_info: &vk::DependencyInfo<'_>,
     ) {
         (self.device_fn_1_3.cmd_pipeline_barrier2)(command_buffer, dependency_info)
     }
@@ -157,7 +157,7 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         event: vk::Event,
-        dependency_info: &vk::DependencyInfo,
+        dependency_info: &vk::DependencyInfo<'_>,
     ) {
         (self.device_fn_1_3.cmd_set_event2)(command_buffer, event, dependency_info)
     }
@@ -167,8 +167,8 @@ impl Device {
     pub unsafe fn cmd_wait_events2(
         &self,
         command_buffer: vk::CommandBuffer,
-        events: &[vk::Event],
-        dependency_infos: &[vk::DependencyInfo],
+        events: &[vk::Event<'_>],
+        dependency_infos: &[vk::DependencyInfo<'_>],
     ) {
         assert_eq!(events.len(), dependency_infos.len());
         (self.device_fn_1_3.cmd_wait_events2)(
@@ -196,7 +196,7 @@ impl Device {
     pub unsafe fn queue_submit2(
         &self,
         queue: vk::Queue,
-        submits: &[vk::SubmitInfo2],
+        submits: &[vk::SubmitInfo2<'_>],
         fence: vk::Fence,
     ) -> VkResult<()> {
         (self.device_fn_1_3.queue_submit2)(queue, submits.len() as u32, submits.as_ptr(), fence)
@@ -208,7 +208,7 @@ impl Device {
     pub unsafe fn cmd_copy_buffer2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_buffer_info: &vk::CopyBufferInfo2,
+        copy_buffer_info: &vk::CopyBufferInfo2<'_>,
     ) {
         (self.device_fn_1_3.cmd_copy_buffer2)(command_buffer, copy_buffer_info)
     }
@@ -217,7 +217,7 @@ impl Device {
     pub unsafe fn cmd_copy_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_image_info: &vk::CopyImageInfo2,
+        copy_image_info: &vk::CopyImageInfo2<'_>,
     ) {
         (self.device_fn_1_3.cmd_copy_image2)(command_buffer, copy_image_info)
     }
@@ -226,7 +226,7 @@ impl Device {
     pub unsafe fn cmd_copy_buffer_to_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_buffer_to_image_info: &vk::CopyBufferToImageInfo2,
+        copy_buffer_to_image_info: &vk::CopyBufferToImageInfo2<'_>,
     ) {
         (self.device_fn_1_3.cmd_copy_buffer_to_image2)(command_buffer, copy_buffer_to_image_info)
     }
@@ -235,7 +235,7 @@ impl Device {
     pub unsafe fn cmd_copy_image_to_buffer2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_image_to_buffer_info: &vk::CopyImageToBufferInfo2,
+        copy_image_to_buffer_info: &vk::CopyImageToBufferInfo2<'_>,
     ) {
         (self.device_fn_1_3.cmd_copy_image_to_buffer2)(command_buffer, copy_image_to_buffer_info)
     }
@@ -244,7 +244,7 @@ impl Device {
     pub unsafe fn cmd_blit_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        blit_image_info: &vk::BlitImageInfo2,
+        blit_image_info: &vk::BlitImageInfo2<'_>,
     ) {
         (self.device_fn_1_3.cmd_blit_image2)(command_buffer, blit_image_info)
     }
@@ -253,7 +253,7 @@ impl Device {
     pub unsafe fn cmd_resolve_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        resolve_image_info: &vk::ResolveImageInfo2,
+        resolve_image_info: &vk::ResolveImageInfo2<'_>,
     ) {
         (self.device_fn_1_3.cmd_resolve_image2)(command_buffer, resolve_image_info)
     }
@@ -263,7 +263,7 @@ impl Device {
     pub unsafe fn cmd_begin_rendering(
         &self,
         command_buffer: vk::CommandBuffer,
-        rendering_info: &vk::RenderingInfo,
+        rendering_info: &vk::RenderingInfo<'_>,
     ) {
         (self.device_fn_1_3.cmd_begin_rendering)(command_buffer, rendering_info)
     }
@@ -309,7 +309,7 @@ impl Device {
     pub unsafe fn cmd_set_viewport_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        viewports: &[vk::Viewport],
+        viewports: &[vk::Viewport<'_>],
     ) {
         (self.device_fn_1_3.cmd_set_viewport_with_count)(
             command_buffer,
@@ -323,7 +323,7 @@ impl Device {
     pub unsafe fn cmd_set_scissor_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        scissors: &[vk::Rect2D],
+        scissors: &[vk::Rect2D<'_>],
     ) {
         (self.device_fn_1_3.cmd_set_scissor_with_count)(
             command_buffer,
@@ -338,10 +338,10 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer],
-        offsets: &[vk::DeviceSize],
-        sizes: Option<&[vk::DeviceSize]>,
-        strides: Option<&[vk::DeviceSize]>,
+        buffers: &[vk::Buffer<'_>],
+        offsets: &[vk::DeviceSize<'_>],
+        sizes: Option<&[vk::DeviceSize<'_>]>,
+        strides: Option<&[vk::DeviceSize<'_>]>,
     ) {
         assert_eq!(offsets.len(), buffers.len());
         let p_sizes = if let Some(sizes) = sizes {
@@ -481,8 +481,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_buffer_memory_requirements(
         &self,
-        memory_requirements: &vk::DeviceBufferMemoryRequirements,
-        out: &mut vk::MemoryRequirements2,
+        memory_requirements: &vk::DeviceBufferMemoryRequirements<'_>,
+        out: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.device_fn_1_3.get_device_buffer_memory_requirements)(
             self.handle,
@@ -495,8 +495,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_image_memory_requirements(
         &self,
-        memory_requirements: &vk::DeviceImageMemoryRequirements,
-        out: &mut vk::MemoryRequirements2,
+        memory_requirements: &vk::DeviceImageMemoryRequirements<'_>,
+        out: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.device_fn_1_3.get_device_image_memory_requirements)(
             self.handle,
@@ -509,7 +509,7 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements_len(
         &self,
-        memory_requirements: &vk::DeviceImageMemoryRequirements,
+        memory_requirements: &vk::DeviceImageMemoryRequirements<'_>,
     ) -> usize {
         let mut count = 0;
         (self
@@ -530,8 +530,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements(
         &self,
-        memory_requirements: &vk::DeviceImageMemoryRequirements,
-        out: &mut [vk::SparseImageMemoryRequirements2],
+        memory_requirements: &vk::DeviceImageMemoryRequirements<'_>,
+        out: &mut [vk::SparseImageMemoryRequirements2<'_>],
     ) {
         let mut count = out.len() as u32;
         (self
@@ -603,8 +603,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_render_pass2(
         &self,
-        create_info: &vk::RenderPassCreateInfo2,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::RenderPassCreateInfo2<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
         (self.device_fn_1_2.create_render_pass2)(
@@ -621,8 +621,8 @@ impl Device {
     pub unsafe fn cmd_begin_render_pass2(
         &self,
         command_buffer: vk::CommandBuffer,
-        render_pass_begin_info: &vk::RenderPassBeginInfo,
-        subpass_begin_info: &vk::SubpassBeginInfo,
+        render_pass_begin_info: &vk::RenderPassBeginInfo<'_>,
+        subpass_begin_info: &vk::SubpassBeginInfo<'_>,
     ) {
         (self.device_fn_1_2.cmd_begin_render_pass2)(
             command_buffer,
@@ -636,8 +636,8 @@ impl Device {
     pub unsafe fn cmd_next_subpass2(
         &self,
         command_buffer: vk::CommandBuffer,
-        subpass_begin_info: &vk::SubpassBeginInfo,
-        subpass_end_info: &vk::SubpassEndInfo,
+        subpass_begin_info: &vk::SubpassBeginInfo<'_>,
+        subpass_end_info: &vk::SubpassEndInfo<'_>,
     ) {
         (self.device_fn_1_2.cmd_next_subpass2)(
             command_buffer,
@@ -651,7 +651,7 @@ impl Device {
     pub unsafe fn cmd_end_render_pass2(
         &self,
         command_buffer: vk::CommandBuffer,
-        subpass_end_info: &vk::SubpassEndInfo,
+        subpass_end_info: &vk::SubpassEndInfo<'_>,
     ) {
         (self.device_fn_1_2.cmd_end_render_pass2)(command_buffer, subpass_end_info);
     }
@@ -679,7 +679,7 @@ impl Device {
     #[inline]
     pub unsafe fn wait_semaphores(
         &self,
-        wait_info: &vk::SemaphoreWaitInfo,
+        wait_info: &vk::SemaphoreWaitInfo<'_>,
         timeout: u64,
     ) -> VkResult<()> {
         (self.device_fn_1_2.wait_semaphores)(self.handle(), wait_info, timeout).result()
@@ -687,7 +687,10 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSignalSemaphore.html>
     #[inline]
-    pub unsafe fn signal_semaphore(&self, signal_info: &vk::SemaphoreSignalInfo) -> VkResult<()> {
+    pub unsafe fn signal_semaphore(
+        &self,
+        signal_info: &vk::SemaphoreSignalInfo<'_>,
+    ) -> VkResult<()> {
         (self.device_fn_1_2.signal_semaphore)(self.handle(), signal_info).result()
     }
 
@@ -695,7 +698,7 @@ impl Device {
     #[inline]
     pub unsafe fn get_buffer_device_address(
         &self,
-        info: &vk::BufferDeviceAddressInfo,
+        info: &vk::BufferDeviceAddressInfo<'_>,
     ) -> vk::DeviceAddress {
         (self.device_fn_1_2.get_buffer_device_address)(self.handle(), info)
     }
@@ -704,7 +707,7 @@ impl Device {
     #[inline]
     pub unsafe fn get_buffer_opaque_capture_address(
         &self,
-        info: &vk::BufferDeviceAddressInfo,
+        info: &vk::BufferDeviceAddressInfo<'_>,
     ) -> u64 {
         (self.device_fn_1_2.get_buffer_opaque_capture_address)(self.handle(), info)
     }
@@ -713,7 +716,7 @@ impl Device {
     #[inline]
     pub unsafe fn get_device_memory_opaque_capture_address(
         &self,
-        info: &vk::DeviceMemoryOpaqueCaptureAddressInfo,
+        info: &vk::DeviceMemoryOpaqueCaptureAddressInfo<'_>,
     ) -> u64 {
         (self.device_fn_1_2.get_device_memory_opaque_capture_address)(self.handle(), info)
     }
@@ -730,7 +733,7 @@ impl Device {
     #[inline]
     pub unsafe fn bind_buffer_memory2(
         &self,
-        bind_infos: &[vk::BindBufferMemoryInfo],
+        bind_infos: &[vk::BindBufferMemoryInfo<'_>],
     ) -> VkResult<()> {
         (self.device_fn_1_1.bind_buffer_memory2)(
             self.handle(),
@@ -744,7 +747,7 @@ impl Device {
     #[inline]
     pub unsafe fn bind_image_memory2(
         &self,
-        bind_infos: &[vk::BindImageMemoryInfo],
+        bind_infos: &[vk::BindImageMemoryInfo<'_>],
     ) -> VkResult<()> {
         (self.device_fn_1_1.bind_image_memory2)(
             self.handle(),
@@ -806,8 +809,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_image_memory_requirements2(
         &self,
-        info: &vk::ImageMemoryRequirementsInfo2,
-        out: &mut vk::MemoryRequirements2,
+        info: &vk::ImageMemoryRequirementsInfo2<'_>,
+        out: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.device_fn_1_1.get_image_memory_requirements2)(self.handle(), info, out);
     }
@@ -816,8 +819,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_buffer_memory_requirements2(
         &self,
-        info: &vk::BufferMemoryRequirementsInfo2,
-        out: &mut vk::MemoryRequirements2,
+        info: &vk::BufferMemoryRequirementsInfo2<'_>,
+        out: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.device_fn_1_1.get_buffer_memory_requirements2)(self.handle(), info, out);
     }
@@ -826,7 +829,7 @@ impl Device {
     #[inline]
     pub unsafe fn get_image_sparse_memory_requirements2_len(
         &self,
-        info: &vk::ImageSparseMemoryRequirementsInfo2,
+        info: &vk::ImageSparseMemoryRequirementsInfo2<'_>,
     ) -> usize {
         let mut count = 0;
         (self.device_fn_1_1.get_image_sparse_memory_requirements2)(
@@ -845,8 +848,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_image_sparse_memory_requirements2(
         &self,
-        info: &vk::ImageSparseMemoryRequirementsInfo2,
-        out: &mut [vk::SparseImageMemoryRequirements2],
+        info: &vk::ImageSparseMemoryRequirementsInfo2<'_>,
+        out: &mut [vk::SparseImageMemoryRequirements2<'_>],
     ) {
         let mut count = out.len() as u32;
         (self.device_fn_1_1.get_image_sparse_memory_requirements2)(
@@ -870,7 +873,7 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceQueue2.html>
     #[inline]
-    pub unsafe fn get_device_queue2(&self, queue_info: &vk::DeviceQueueInfo2) -> vk::Queue {
+    pub unsafe fn get_device_queue2(&self, queue_info: &vk::DeviceQueueInfo2<'_>) -> vk::Queue {
         let mut queue = mem::zeroed();
         (self.device_fn_1_1.get_device_queue2)(self.handle(), queue_info, &mut queue);
         queue
@@ -880,8 +883,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_sampler_ycbcr_conversion(
         &self,
-        create_info: &vk::SamplerYcbcrConversionCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::SamplerYcbcrConversionCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
         let mut ycbcr_conversion = mem::zeroed();
         (self.device_fn_1_1.create_sampler_ycbcr_conversion)(
@@ -898,7 +901,7 @@ impl Device {
     pub unsafe fn destroy_sampler_ycbcr_conversion(
         &self,
         ycbcr_conversion: vk::SamplerYcbcrConversion,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_1.destroy_sampler_ycbcr_conversion)(
             self.handle(),
@@ -911,8 +914,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_descriptor_update_template(
         &self,
-        create_info: &vk::DescriptorUpdateTemplateCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DescriptorUpdateTemplateCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DescriptorUpdateTemplate> {
         let mut descriptor_update_template = mem::zeroed();
         (self.device_fn_1_1.create_descriptor_update_template)(
@@ -929,7 +932,7 @@ impl Device {
     pub unsafe fn destroy_descriptor_update_template(
         &self,
         descriptor_update_template: vk::DescriptorUpdateTemplate,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_1.destroy_descriptor_update_template)(
             self.handle(),
@@ -958,8 +961,8 @@ impl Device {
     #[inline]
     pub unsafe fn get_descriptor_set_layout_support(
         &self,
-        create_info: &vk::DescriptorSetLayoutCreateInfo,
-        out: &mut vk::DescriptorSetLayoutSupport,
+        create_info: &vk::DescriptorSetLayoutCreateInfo<'_>,
+        out: &mut vk::DescriptorSetLayoutSupport<'_>,
     ) {
         (self.device_fn_1_1.get_descriptor_set_layout_support)(self.handle(), create_info, out);
     }
@@ -974,7 +977,10 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyDevice.html>
     #[inline]
-    pub unsafe fn destroy_device(&self, allocation_callbacks: Option<&vk::AllocationCallbacks>) {
+    pub unsafe fn destroy_device(
+        &self,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+    ) {
         (self.device_fn_1_0.destroy_device)(self.handle(), allocation_callbacks.as_raw_ptr());
     }
 
@@ -983,7 +989,7 @@ impl Device {
     pub unsafe fn destroy_sampler(
         &self,
         sampler: vk::Sampler,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_sampler)(
             self.handle(),
@@ -997,7 +1003,7 @@ impl Device {
     pub unsafe fn free_memory(
         &self,
         memory: vk::DeviceMemory,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.free_memory)(self.handle(), memory, allocation_callbacks.as_raw_ptr());
     }
@@ -1007,7 +1013,7 @@ impl Device {
     pub unsafe fn free_command_buffers(
         &self,
         command_pool: vk::CommandPool,
-        command_buffers: &[vk::CommandBuffer],
+        command_buffers: &[vk::CommandBuffer<'_>],
     ) {
         (self.device_fn_1_0.free_command_buffers)(
             self.handle(),
@@ -1021,8 +1027,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_event(
         &self,
-        create_info: &vk::EventCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::EventCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Event> {
         let mut event = mem::zeroed();
         (self.device_fn_1_0.create_event)(
@@ -1084,12 +1090,12 @@ impl Device {
     pub unsafe fn cmd_wait_events(
         &self,
         command_buffer: vk::CommandBuffer,
-        events: &[vk::Event],
+        events: &[vk::Event<'_>],
         src_stage_mask: vk::PipelineStageFlags,
         dst_stage_mask: vk::PipelineStageFlags,
-        memory_barriers: &[vk::MemoryBarrier],
-        buffer_memory_barriers: &[vk::BufferMemoryBarrier],
-        image_memory_barriers: &[vk::ImageMemoryBarrier],
+        memory_barriers: &[vk::MemoryBarrier<'_>],
+        buffer_memory_barriers: &[vk::BufferMemoryBarrier<'_>],
+        image_memory_barriers: &[vk::ImageMemoryBarrier<'_>],
     ) {
         (self.device_fn_1_0.cmd_wait_events)(
             command_buffer,
@@ -1111,7 +1117,7 @@ impl Device {
     pub unsafe fn destroy_fence(
         &self,
         fence: vk::Fence,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_fence)(self.handle(), fence, allocation_callbacks.as_raw_ptr());
     }
@@ -1121,7 +1127,7 @@ impl Device {
     pub unsafe fn destroy_event(
         &self,
         event: vk::Event,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_event)(self.handle(), event, allocation_callbacks.as_raw_ptr());
     }
@@ -1131,7 +1137,7 @@ impl Device {
     pub unsafe fn destroy_image(
         &self,
         image: vk::Image,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_image)(self.handle(), image, allocation_callbacks.as_raw_ptr());
     }
@@ -1141,7 +1147,7 @@ impl Device {
     pub unsafe fn destroy_command_pool(
         &self,
         pool: vk::CommandPool,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_command_pool)(
             self.handle(),
@@ -1155,7 +1161,7 @@ impl Device {
     pub unsafe fn destroy_image_view(
         &self,
         image_view: vk::ImageView,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_image_view)(
             self.handle(),
@@ -1169,7 +1175,7 @@ impl Device {
     pub unsafe fn destroy_render_pass(
         &self,
         renderpass: vk::RenderPass,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_render_pass)(
             self.handle(),
@@ -1183,7 +1189,7 @@ impl Device {
     pub unsafe fn destroy_framebuffer(
         &self,
         framebuffer: vk::Framebuffer,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_framebuffer)(
             self.handle(),
@@ -1197,7 +1203,7 @@ impl Device {
     pub unsafe fn destroy_pipeline_layout(
         &self,
         pipeline_layout: vk::PipelineLayout,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_pipeline_layout)(
             self.handle(),
@@ -1211,7 +1217,7 @@ impl Device {
     pub unsafe fn destroy_pipeline_cache(
         &self,
         pipeline_cache: vk::PipelineCache,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_pipeline_cache)(
             self.handle(),
@@ -1225,7 +1231,7 @@ impl Device {
     pub unsafe fn destroy_buffer(
         &self,
         buffer: vk::Buffer,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_buffer)(
             self.handle(),
@@ -1239,7 +1245,7 @@ impl Device {
     pub unsafe fn destroy_shader_module(
         &self,
         shader: vk::ShaderModule,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_shader_module)(
             self.handle(),
@@ -1253,7 +1259,7 @@ impl Device {
     pub unsafe fn destroy_pipeline(
         &self,
         pipeline: vk::Pipeline,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_pipeline)(
             self.handle(),
@@ -1267,7 +1273,7 @@ impl Device {
     pub unsafe fn destroy_semaphore(
         &self,
         semaphore: vk::Semaphore,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_semaphore)(
             self.handle(),
@@ -1281,7 +1287,7 @@ impl Device {
     pub unsafe fn destroy_descriptor_pool(
         &self,
         pool: vk::DescriptorPool,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_descriptor_pool)(
             self.handle(),
@@ -1295,7 +1301,7 @@ impl Device {
     pub unsafe fn destroy_query_pool(
         &self,
         pool: vk::QueryPool,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_query_pool)(
             self.handle(),
@@ -1309,7 +1315,7 @@ impl Device {
     pub unsafe fn destroy_descriptor_set_layout(
         &self,
         layout: vk::DescriptorSetLayout,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_descriptor_set_layout)(
             self.handle(),
@@ -1323,7 +1329,7 @@ impl Device {
     pub unsafe fn free_descriptor_sets(
         &self,
         pool: vk::DescriptorPool,
-        descriptor_sets: &[vk::DescriptorSet],
+        descriptor_sets: &[vk::DescriptorSet<'_>],
     ) -> VkResult<()> {
         (self.device_fn_1_0.free_descriptor_sets)(
             self.handle(),
@@ -1338,8 +1344,8 @@ impl Device {
     #[inline]
     pub unsafe fn update_descriptor_sets(
         &self,
-        descriptor_writes: &[vk::WriteDescriptorSet],
-        descriptor_copies: &[vk::CopyDescriptorSet],
+        descriptor_writes: &[vk::WriteDescriptorSet<'_>],
+        descriptor_copies: &[vk::CopyDescriptorSet<'_>],
     ) {
         (self.device_fn_1_0.update_descriptor_sets)(
             self.handle(),
@@ -1354,8 +1360,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_sampler(
         &self,
-        create_info: &vk::SamplerCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::SamplerCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Sampler> {
         let mut sampler = mem::zeroed();
         (self.device_fn_1_0.create_sampler)(
@@ -1376,7 +1382,7 @@ impl Device {
         src_image_layout: vk::ImageLayout,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::ImageBlit],
+        regions: &[vk::ImageBlit<'_>],
         filter: vk::Filter,
     ) {
         (self.device_fn_1_0.cmd_blit_image)(
@@ -1400,7 +1406,7 @@ impl Device {
         src_image_layout: vk::ImageLayout,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::ImageResolve],
+        regions: &[vk::ImageResolve<'_>],
     ) {
         (self.device_fn_1_0.cmd_resolve_image)(
             command_buffer,
@@ -1451,7 +1457,7 @@ impl Device {
         command_buffer: vk::CommandBuffer,
         src_buffer: vk::Buffer,
         dst_buffer: vk::Buffer,
-        regions: &[vk::BufferCopy],
+        regions: &[vk::BufferCopy<'_>],
     ) {
         (self.device_fn_1_0.cmd_copy_buffer)(
             command_buffer,
@@ -1470,7 +1476,7 @@ impl Device {
         src_image: vk::Image,
         src_image_layout: vk::ImageLayout,
         dst_buffer: vk::Buffer,
-        regions: &[vk::BufferImageCopy],
+        regions: &[vk::BufferImageCopy<'_>],
     ) {
         (self.device_fn_1_0.cmd_copy_image_to_buffer)(
             command_buffer,
@@ -1490,7 +1496,7 @@ impl Device {
         src_buffer: vk::Buffer,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::BufferImageCopy],
+        regions: &[vk::BufferImageCopy<'_>],
     ) {
         (self.device_fn_1_0.cmd_copy_buffer_to_image)(
             command_buffer,
@@ -1511,7 +1517,7 @@ impl Device {
         src_image_layout: vk::ImageLayout,
         dst_image: vk::Image,
         dst_image_layout: vk::ImageLayout,
-        regions: &[vk::ImageCopy],
+        regions: &[vk::ImageCopy<'_>],
     ) {
         (self.device_fn_1_0.cmd_copy_image)(
             command_buffer,
@@ -1528,7 +1534,7 @@ impl Device {
     #[inline]
     pub unsafe fn allocate_descriptor_sets(
         &self,
-        allocate_info: &vk::DescriptorSetAllocateInfo,
+        allocate_info: &vk::DescriptorSetAllocateInfo<'_>,
     ) -> VkResult<Vec<vk::DescriptorSet>> {
         let mut desc_set = Vec::with_capacity(allocate_info.descriptor_set_count as usize);
         (self.device_fn_1_0.allocate_descriptor_sets)(
@@ -1546,8 +1552,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_descriptor_set_layout(
         &self,
-        create_info: &vk::DescriptorSetLayoutCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DescriptorSetLayoutCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DescriptorSetLayout> {
         let mut layout = mem::zeroed();
         (self.device_fn_1_0.create_descriptor_set_layout)(
@@ -1569,8 +1575,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_descriptor_pool(
         &self,
-        create_info: &vk::DescriptorPoolCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DescriptorPoolCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DescriptorPool> {
         let mut pool = mem::zeroed();
         (self.device_fn_1_0.create_descriptor_pool)(
@@ -1614,7 +1620,7 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkResetFences.html>
     #[inline]
-    pub unsafe fn reset_fences(&self, fences: &[vk::Fence]) -> VkResult<()> {
+    pub unsafe fn reset_fences(&self, fences: &[vk::Fence<'_>]) -> VkResult<()> {
         (self.device_fn_1_0.reset_fences)(self.handle(), fences.len() as u32, fences.as_ptr())
             .result()
     }
@@ -1638,8 +1644,8 @@ impl Device {
         command_buffer: vk::CommandBuffer,
         image: vk::Image,
         image_layout: vk::ImageLayout,
-        clear_color_value: &vk::ClearColorValue,
-        ranges: &[vk::ImageSubresourceRange],
+        clear_color_value: &vk::ClearColorValue<'_>,
+        ranges: &[vk::ImageSubresourceRange<'_>],
     ) {
         (self.device_fn_1_0.cmd_clear_color_image)(
             command_buffer,
@@ -1658,8 +1664,8 @@ impl Device {
         command_buffer: vk::CommandBuffer,
         image: vk::Image,
         image_layout: vk::ImageLayout,
-        clear_depth_stencil_value: &vk::ClearDepthStencilValue,
-        ranges: &[vk::ImageSubresourceRange],
+        clear_depth_stencil_value: &vk::ClearDepthStencilValue<'_>,
+        ranges: &[vk::ImageSubresourceRange<'_>],
     ) {
         (self.device_fn_1_0.cmd_clear_depth_stencil_image)(
             command_buffer,
@@ -1676,8 +1682,8 @@ impl Device {
     pub unsafe fn cmd_clear_attachments(
         &self,
         command_buffer: vk::CommandBuffer,
-        attachments: &[vk::ClearAttachment],
-        rects: &[vk::ClearRect],
+        attachments: &[vk::ClearAttachment<'_>],
+        rects: &[vk::ClearRect<'_>],
     ) {
         (self.device_fn_1_0.cmd_clear_attachments)(
             command_buffer,
@@ -1733,7 +1739,7 @@ impl Device {
     pub unsafe fn cmd_execute_commands(
         &self,
         primary_command_buffer: vk::CommandBuffer,
-        secondary_command_buffers: &[vk::CommandBuffer],
+        secondary_command_buffers: &[vk::CommandBuffer<'_>],
     ) {
         (self.device_fn_1_0.cmd_execute_commands)(
             primary_command_buffer,
@@ -1750,7 +1756,7 @@ impl Device {
         pipeline_bind_point: vk::PipelineBindPoint,
         layout: vk::PipelineLayout,
         first_set: u32,
-        descriptor_sets: &[vk::DescriptorSet],
+        descriptor_sets: &[vk::DescriptorSet<'_>],
         dynamic_offsets: &[u32],
     ) {
         (self.device_fn_1_0.cmd_bind_descriptor_sets)(
@@ -1815,7 +1821,7 @@ impl Device {
     pub unsafe fn cmd_begin_render_pass(
         &self,
         command_buffer: vk::CommandBuffer,
-        render_pass_begin: &vk::RenderPassBeginInfo,
+        render_pass_begin: &vk::RenderPassBeginInfo<'_>,
         contents: vk::SubpassContents,
     ) {
         (self.device_fn_1_0.cmd_begin_render_pass)(command_buffer, render_pass_begin, contents);
@@ -1848,7 +1854,7 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_scissor: u32,
-        scissors: &[vk::Rect2D],
+        scissors: &[vk::Rect2D<'_>],
     ) {
         (self.device_fn_1_0.cmd_set_scissor)(
             command_buffer,
@@ -1870,8 +1876,8 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer],
-        offsets: &[vk::DeviceSize],
+        buffers: &[vk::Buffer<'_>],
+        offsets: &[vk::DeviceSize<'_>],
     ) {
         debug_assert_eq!(buffers.len(), offsets.len());
         (self.device_fn_1_0.cmd_bind_vertex_buffers)(
@@ -1955,7 +1961,7 @@ impl Device {
         &self,
         command_buffer: vk::CommandBuffer,
         first_viewport: u32,
-        viewports: &[vk::Viewport],
+        viewports: &[vk::Viewport<'_>],
     ) {
         (self.device_fn_1_0.cmd_set_viewport)(
             command_buffer,
@@ -2114,8 +2120,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_semaphore(
         &self,
-        create_info: &vk::SemaphoreCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::SemaphoreCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Semaphore> {
         let mut semaphore = mem::zeroed();
         (self.device_fn_1_0.create_semaphore)(
@@ -2132,8 +2138,8 @@ impl Device {
     pub unsafe fn create_graphics_pipelines(
         &self,
         pipeline_cache: vk::PipelineCache,
-        create_infos: &[vk::GraphicsPipelineCreateInfo],
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_infos: &[vk::GraphicsPipelineCreateInfo<'_>],
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.device_fn_1_0.create_graphics_pipelines)(
@@ -2156,8 +2162,8 @@ impl Device {
     pub unsafe fn create_compute_pipelines(
         &self,
         pipeline_cache: vk::PipelineCache,
-        create_infos: &[vk::ComputePipelineCreateInfo],
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_infos: &[vk::ComputePipelineCreateInfo<'_>],
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.device_fn_1_0.create_compute_pipelines)(
@@ -2179,8 +2185,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_buffer(
         &self,
-        create_info: &vk::BufferCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::BufferCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Buffer> {
         let mut buffer = mem::zeroed();
         (self.device_fn_1_0.create_buffer)(
@@ -2196,8 +2202,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_pipeline_layout(
         &self,
-        create_info: &vk::PipelineLayoutCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::PipelineLayoutCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PipelineLayout> {
         let mut pipeline_layout = mem::zeroed();
         (self.device_fn_1_0.create_pipeline_layout)(
@@ -2213,8 +2219,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_pipeline_cache(
         &self,
-        create_info: &vk::PipelineCacheCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::PipelineCacheCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PipelineCache> {
         let mut pipeline_cache = mem::zeroed();
         (self.device_fn_1_0.create_pipeline_cache)(
@@ -2247,7 +2253,7 @@ impl Device {
     pub unsafe fn merge_pipeline_caches(
         &self,
         dst_cache: vk::PipelineCache,
-        src_caches: &[vk::PipelineCache],
+        src_caches: &[vk::PipelineCache<'_>],
     ) -> VkResult<()> {
         (self.device_fn_1_0.merge_pipeline_caches)(
             self.handle(),
@@ -2282,7 +2288,7 @@ impl Device {
     #[inline]
     pub unsafe fn invalidate_mapped_memory_ranges(
         &self,
-        ranges: &[vk::MappedMemoryRange],
+        ranges: &[vk::MappedMemoryRange<'_>],
     ) -> VkResult<()> {
         (self.device_fn_1_0.invalidate_mapped_memory_ranges)(
             self.handle(),
@@ -2296,7 +2302,7 @@ impl Device {
     #[inline]
     pub unsafe fn flush_mapped_memory_ranges(
         &self,
-        ranges: &[vk::MappedMemoryRange],
+        ranges: &[vk::MappedMemoryRange<'_>],
     ) -> VkResult<()> {
         (self.device_fn_1_0.flush_mapped_memory_ranges)(
             self.handle(),
@@ -2310,8 +2316,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_framebuffer(
         &self,
-        create_info: &vk::FramebufferCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::FramebufferCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Framebuffer> {
         let mut framebuffer = mem::zeroed();
         (self.device_fn_1_0.create_framebuffer)(
@@ -2344,9 +2350,9 @@ impl Device {
         src_stage_mask: vk::PipelineStageFlags,
         dst_stage_mask: vk::PipelineStageFlags,
         dependency_flags: vk::DependencyFlags,
-        memory_barriers: &[vk::MemoryBarrier],
-        buffer_memory_barriers: &[vk::BufferMemoryBarrier],
-        image_memory_barriers: &[vk::ImageMemoryBarrier],
+        memory_barriers: &[vk::MemoryBarrier<'_>],
+        buffer_memory_barriers: &[vk::BufferMemoryBarrier<'_>],
+        image_memory_barriers: &[vk::ImageMemoryBarrier<'_>],
     ) {
         (self.device_fn_1_0.cmd_pipeline_barrier)(
             command_buffer,
@@ -2366,8 +2372,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_render_pass(
         &self,
-        create_info: &vk::RenderPassCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::RenderPassCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
         (self.device_fn_1_0.create_render_pass)(
@@ -2384,7 +2390,7 @@ impl Device {
     pub unsafe fn begin_command_buffer(
         &self,
         command_buffer: vk::CommandBuffer,
-        begin_info: &vk::CommandBufferBeginInfo,
+        begin_info: &vk::CommandBufferBeginInfo<'_>,
     ) -> VkResult<()> {
         (self.device_fn_1_0.begin_command_buffer)(command_buffer, begin_info).result()
     }
@@ -2399,7 +2405,7 @@ impl Device {
     #[inline]
     pub unsafe fn wait_for_fences(
         &self,
-        fences: &[vk::Fence],
+        fences: &[vk::Fence<'_>],
         wait_all: bool,
         timeout: u64,
     ) -> VkResult<()> {
@@ -2435,7 +2441,7 @@ impl Device {
     pub unsafe fn queue_submit(
         &self,
         queue: vk::Queue,
-        submits: &[vk::SubmitInfo],
+        submits: &[vk::SubmitInfo<'_>],
         fence: vk::Fence,
     ) -> VkResult<()> {
         (self.device_fn_1_0.queue_submit)(queue, submits.len() as u32, submits.as_ptr(), fence)
@@ -2447,7 +2453,7 @@ impl Device {
     pub unsafe fn queue_bind_sparse(
         &self,
         queue: vk::Queue,
-        bind_info: &[vk::BindSparseInfo],
+        bind_info: &[vk::BindSparseInfo<'_>],
         fence: vk::Fence,
     ) -> VkResult<()> {
         (self.device_fn_1_0.queue_bind_sparse)(
@@ -2463,8 +2469,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_buffer_view(
         &self,
-        create_info: &vk::BufferViewCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::BufferViewCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::BufferView> {
         let mut buffer_view = mem::zeroed();
         (self.device_fn_1_0.create_buffer_view)(
@@ -2481,7 +2487,7 @@ impl Device {
     pub unsafe fn destroy_buffer_view(
         &self,
         buffer_view: vk::BufferView,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.device_fn_1_0.destroy_buffer_view)(
             self.handle(),
@@ -2494,8 +2500,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_image_view(
         &self,
-        create_info: &vk::ImageViewCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::ImageViewCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::ImageView> {
         let mut image_view = mem::zeroed();
         (self.device_fn_1_0.create_image_view)(
@@ -2511,7 +2517,7 @@ impl Device {
     #[inline]
     pub unsafe fn allocate_command_buffers(
         &self,
-        allocate_info: &vk::CommandBufferAllocateInfo,
+        allocate_info: &vk::CommandBufferAllocateInfo<'_>,
     ) -> VkResult<Vec<vk::CommandBuffer>> {
         let mut buffers = Vec::with_capacity(allocate_info.command_buffer_count as usize);
         (self.device_fn_1_0.allocate_command_buffers)(
@@ -2528,8 +2534,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_command_pool(
         &self,
-        create_info: &vk::CommandPoolCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::CommandPoolCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::CommandPool> {
         let mut pool = mem::zeroed();
         (self.device_fn_1_0.create_command_pool)(
@@ -2545,8 +2551,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_query_pool(
         &self,
-        create_info: &vk::QueryPoolCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::QueryPoolCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::QueryPool> {
         let mut pool = mem::zeroed();
         (self.device_fn_1_0.create_query_pool)(
@@ -2562,8 +2568,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_image(
         &self,
-        create_info: &vk::ImageCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::ImageCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Image> {
         let mut image = mem::zeroed();
         (self.device_fn_1_0.create_image)(
@@ -2615,8 +2621,8 @@ impl Device {
     #[inline]
     pub unsafe fn allocate_memory(
         &self,
-        allocate_info: &vk::MemoryAllocateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocate_info: &vk::MemoryAllocateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DeviceMemory> {
         let mut memory = mem::zeroed();
         (self.device_fn_1_0.allocate_memory)(
@@ -2632,8 +2638,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_shader_module(
         &self,
-        create_info: &vk::ShaderModuleCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::ShaderModuleCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::ShaderModule> {
         let mut shader = mem::zeroed();
         (self.device_fn_1_0.create_shader_module)(
@@ -2649,8 +2655,8 @@ impl Device {
     #[inline]
     pub unsafe fn create_fence(
         &self,
-        create_info: &vk::FenceCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::FenceCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::Fence> {
         let mut fence = mem::zeroed();
         (self.device_fn_1_0.create_fence)(

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -246,8 +246,8 @@ impl Entry {
     #[inline]
     pub unsafe fn create_instance(
         &self,
-        create_info: &vk::InstanceCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::InstanceCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Instance> {
         let mut instance = mem::zeroed();
         (self.entry_fn_1_0.create_instance)(

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -26,8 +26,8 @@ impl ShaderEnqueue {
     pub unsafe fn create_execution_graph_pipelines(
         &self,
         pipeline_cache: vk::PipelineCache,
-        create_infos: &[vk::ExecutionGraphPipelineCreateInfoAMDX],
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_infos: &[vk::ExecutionGraphPipelineCreateInfoAMDX<'_>],
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_infos.len()];
         (self.fp.create_execution_graph_pipelines_amdx)(
@@ -46,7 +46,7 @@ impl ShaderEnqueue {
     pub unsafe fn get_execution_graph_pipeline_scratch_size(
         &self,
         execution_graph: vk::Pipeline,
-        size_info: &mut vk::ExecutionGraphPipelineScratchSizeAMDX,
+        size_info: &mut vk::ExecutionGraphPipelineScratchSizeAMDX<'_>,
     ) -> VkResult<()> {
         (self.fp.get_execution_graph_pipeline_scratch_size_amdx)(
             self.handle,
@@ -61,7 +61,7 @@ impl ShaderEnqueue {
     pub unsafe fn get_execution_graph_pipeline_node_index(
         &self,
         execution_graph: vk::Pipeline,
-        node_info: &vk::PipelineShaderStageNodeCreateInfoAMDX,
+        node_info: &vk::PipelineShaderStageNodeCreateInfoAMDX<'_>,
     ) -> VkResult<u32> {
         let mut node_index = 0;
         (self.fp.get_execution_graph_pipeline_node_index_amdx)(
@@ -89,7 +89,7 @@ impl ShaderEnqueue {
         &self,
         command_buffer: vk::CommandBuffer,
         scratch: vk::DeviceAddress,
-        count_info: &vk::DispatchGraphCountInfoAMDX,
+        count_info: &vk::DispatchGraphCountInfoAMDX<'_>,
     ) {
         (self.fp.cmd_dispatch_graph_amdx)(command_buffer, scratch, count_info)
     }
@@ -100,7 +100,7 @@ impl ShaderEnqueue {
         &self,
         command_buffer: vk::CommandBuffer,
         scratch: vk::DeviceAddress,
-        count_info: &vk::DispatchGraphCountInfoAMDX,
+        count_info: &vk::DispatchGraphCountInfoAMDX<'_>,
     ) {
         (self.fp.cmd_dispatch_graph_indirect_amdx)(command_buffer, scratch, count_info)
     }

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -89,7 +89,7 @@ impl ShaderEnqueue {
         &self,
         command_buffer: vk::CommandBuffer,
         scratch: vk::DeviceAddress,
-        count_info: &vk::DispatchGraphCountInfoAMDX<'_>,
+        count_info: &vk::DispatchGraphCountInfoAMDX,
     ) {
         (self.fp.cmd_dispatch_graph_amdx)(command_buffer, scratch, count_info)
     }
@@ -100,7 +100,7 @@ impl ShaderEnqueue {
         &self,
         command_buffer: vk::CommandBuffer,
         scratch: vk::DeviceAddress,
-        count_info: &vk::DispatchGraphCountInfoAMDX<'_>,
+        count_info: &vk::DispatchGraphCountInfoAMDX,
     ) {
         (self.fp.cmd_dispatch_graph_indirect_amdx)(command_buffer, scratch, count_info)
     }

--- a/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
+++ b/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
@@ -25,7 +25,7 @@ impl ExternalMemoryAndroidHardwareBuffer {
     pub unsafe fn get_android_hardware_buffer_properties(
         &self,
         buffer: *const vk::AHardwareBuffer,
-        properties: &mut vk::AndroidHardwareBufferPropertiesANDROID,
+        properties: &mut vk::AndroidHardwareBufferPropertiesANDROID<'_>,
     ) -> VkResult<()> {
         (self.fp.get_android_hardware_buffer_properties_android)(self.handle, buffer, properties)
             .result()
@@ -35,7 +35,7 @@ impl ExternalMemoryAndroidHardwareBuffer {
     #[inline]
     pub unsafe fn get_memory_android_hardware_buffer(
         &self,
-        info: &vk::MemoryGetAndroidHardwareBufferInfoANDROID,
+        info: &vk::MemoryGetAndroidHardwareBufferInfoANDROID<'_>,
     ) -> VkResult<*mut vk::AHardwareBuffer> {
         let mut buffer = std::ptr::null_mut();
         (self.fp.get_memory_android_hardware_buffer_android)(self.handle, info, &mut buffer)

--- a/ash/src/extensions/ext/buffer_device_address.rs
+++ b/ash/src/extensions/ext/buffer_device_address.rs
@@ -22,7 +22,7 @@ impl BufferDeviceAddress {
     #[inline]
     pub unsafe fn get_buffer_device_address(
         &self,
-        info: &vk::BufferDeviceAddressInfoEXT,
+        info: &vk::BufferDeviceAddressInfoEXT<'_>,
     ) -> vk::DeviceAddress {
         (self.fp.get_buffer_device_address_ext)(self.handle, info)
     }

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -41,7 +41,7 @@ impl CalibratedTimestamps {
     pub unsafe fn get_calibrated_timestamps(
         &self,
         device: vk::Device,
-        info: &[vk::CalibratedTimestampInfoEXT],
+        info: &[vk::CalibratedTimestampInfoEXT<'_>],
     ) -> VkResult<(Vec<u64>, u64)> {
         let mut timestamps = vec![0u64; info.len()];
         let mut max_deviation = 0u64;

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -23,7 +23,7 @@ impl DebugMarker {
     #[inline]
     pub unsafe fn debug_marker_set_object_name(
         &self,
-        name_info: &vk::DebugMarkerObjectNameInfoEXT,
+        name_info: &vk::DebugMarkerObjectNameInfoEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.debug_marker_set_object_name_ext)(self.handle, name_info).result()
     }
@@ -33,7 +33,7 @@ impl DebugMarker {
     pub unsafe fn cmd_debug_marker_begin(
         &self,
         command_buffer: vk::CommandBuffer,
-        marker_info: &vk::DebugMarkerMarkerInfoEXT,
+        marker_info: &vk::DebugMarkerMarkerInfoEXT<'_>,
     ) {
         (self.fp.cmd_debug_marker_begin_ext)(command_buffer, marker_info);
     }
@@ -49,7 +49,7 @@ impl DebugMarker {
     pub unsafe fn cmd_debug_marker_insert(
         &self,
         command_buffer: vk::CommandBuffer,
-        marker_info: &vk::DebugMarkerMarkerInfoEXT,
+        marker_info: &vk::DebugMarkerMarkerInfoEXT<'_>,
     ) {
         (self.fp.cmd_debug_marker_insert_ext)(command_buffer, marker_info);
     }

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -25,7 +25,7 @@ impl DebugReport {
     pub unsafe fn destroy_debug_report_callback(
         &self,
         debug: vk::DebugReportCallbackEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_debug_report_callback_ext)(
             self.handle,
@@ -38,8 +38,8 @@ impl DebugReport {
     #[inline]
     pub unsafe fn create_debug_report_callback(
         &self,
-        create_info: &vk::DebugReportCallbackCreateInfoEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DebugReportCallbackCreateInfoEXT<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DebugReportCallbackEXT> {
         let mut debug_cb = mem::zeroed();
         (self.fp.create_debug_report_callback_ext)(

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -24,7 +24,7 @@ impl DebugUtils {
     pub unsafe fn set_debug_utils_object_name(
         &self,
         device: vk::Device,
-        name_info: &vk::DebugUtilsObjectNameInfoEXT,
+        name_info: &vk::DebugUtilsObjectNameInfoEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.set_debug_utils_object_name_ext)(device, name_info).result()
     }
@@ -34,7 +34,7 @@ impl DebugUtils {
     pub unsafe fn set_debug_utils_object_tag(
         &self,
         device: vk::Device,
-        tag_info: &vk::DebugUtilsObjectTagInfoEXT,
+        tag_info: &vk::DebugUtilsObjectTagInfoEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.set_debug_utils_object_tag_ext)(device, tag_info).result()
     }
@@ -44,7 +44,7 @@ impl DebugUtils {
     pub unsafe fn cmd_begin_debug_utils_label(
         &self,
         command_buffer: vk::CommandBuffer,
-        label: &vk::DebugUtilsLabelEXT,
+        label: &vk::DebugUtilsLabelEXT<'_>,
     ) {
         (self.fp.cmd_begin_debug_utils_label_ext)(command_buffer, label);
     }
@@ -60,7 +60,7 @@ impl DebugUtils {
     pub unsafe fn cmd_insert_debug_utils_label(
         &self,
         command_buffer: vk::CommandBuffer,
-        label: &vk::DebugUtilsLabelEXT,
+        label: &vk::DebugUtilsLabelEXT<'_>,
     ) {
         (self.fp.cmd_insert_debug_utils_label_ext)(command_buffer, label);
     }
@@ -70,7 +70,7 @@ impl DebugUtils {
     pub unsafe fn queue_begin_debug_utils_label(
         &self,
         queue: vk::Queue,
-        label: &vk::DebugUtilsLabelEXT,
+        label: &vk::DebugUtilsLabelEXT<'_>,
     ) {
         (self.fp.queue_begin_debug_utils_label_ext)(queue, label);
     }
@@ -86,7 +86,7 @@ impl DebugUtils {
     pub unsafe fn queue_insert_debug_utils_label(
         &self,
         queue: vk::Queue,
-        label: &vk::DebugUtilsLabelEXT,
+        label: &vk::DebugUtilsLabelEXT<'_>,
     ) {
         (self.fp.queue_insert_debug_utils_label_ext)(queue, label);
     }
@@ -95,8 +95,8 @@ impl DebugUtils {
     #[inline]
     pub unsafe fn create_debug_utils_messenger(
         &self,
-        create_info: &vk::DebugUtilsMessengerCreateInfoEXT,
-        allocator: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DebugUtilsMessengerCreateInfoEXT<'_>,
+        allocator: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DebugUtilsMessengerEXT> {
         let mut messenger = mem::zeroed();
         (self.fp.create_debug_utils_messenger_ext)(
@@ -113,7 +113,7 @@ impl DebugUtils {
     pub unsafe fn destroy_debug_utils_messenger(
         &self,
         messenger: vk::DebugUtilsMessengerEXT,
-        allocator: Option<&vk::AllocationCallbacks>,
+        allocator: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_debug_utils_messenger_ext)(self.handle, messenger, allocator.as_raw_ptr());
     }
@@ -124,7 +124,7 @@ impl DebugUtils {
         &self,
         message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
         message_types: vk::DebugUtilsMessageTypeFlagsEXT,
-        callback_data: &vk::DebugUtilsMessengerCallbackDataEXT,
+        callback_data: &vk::DebugUtilsMessengerCallbackDataEXT<'_>,
     ) {
         (self.fp.submit_debug_utils_message_ext)(
             self.handle,

--- a/ash/src/extensions/ext/descriptor_buffer.rs
+++ b/ash/src/extensions/ext/descriptor_buffer.rs
@@ -52,7 +52,7 @@ impl DescriptorBuffer {
     #[inline]
     pub unsafe fn get_descriptor(
         &self,
-        descriptor_info: &vk::DescriptorGetInfoEXT,
+        descriptor_info: &vk::DescriptorGetInfoEXT<'_>,
         descriptor: &mut [u8],
     ) {
         (self.fp.get_descriptor_ext)(
@@ -68,7 +68,7 @@ impl DescriptorBuffer {
     pub unsafe fn cmd_bind_descriptor_buffers(
         &self,
         command_buffer: vk::CommandBuffer,
-        binding_info: &[vk::DescriptorBufferBindingInfoEXT],
+        binding_info: &[vk::DescriptorBufferBindingInfoEXT<'_>],
     ) {
         (self.fp.cmd_bind_descriptor_buffers_ext)(
             command_buffer,
@@ -86,7 +86,7 @@ impl DescriptorBuffer {
         layout: vk::PipelineLayout,
         first_set: u32,
         buffer_indices: &[u32],
-        offsets: &[vk::DeviceSize],
+        offsets: &[vk::DeviceSize<'_>],
     ) {
         assert_eq!(buffer_indices.len(), offsets.len());
         (self.fp.cmd_set_descriptor_buffer_offsets_ext)(
@@ -121,7 +121,7 @@ impl DescriptorBuffer {
     #[inline]
     pub unsafe fn get_buffer_opaque_capture_descriptor_data(
         &self,
-        info: &vk::BufferCaptureDescriptorDataInfoEXT,
+        info: &vk::BufferCaptureDescriptorDataInfoEXT<'_>,
         data: &mut [u8],
     ) -> VkResult<()> {
         (self.fp.get_buffer_opaque_capture_descriptor_data_ext)(
@@ -136,7 +136,7 @@ impl DescriptorBuffer {
     #[inline]
     pub unsafe fn get_image_opaque_capture_descriptor_data(
         &self,
-        info: &vk::ImageCaptureDescriptorDataInfoEXT,
+        info: &vk::ImageCaptureDescriptorDataInfoEXT<'_>,
         data: &mut [u8],
     ) -> VkResult<()> {
         (self.fp.get_image_opaque_capture_descriptor_data_ext)(
@@ -151,7 +151,7 @@ impl DescriptorBuffer {
     #[inline]
     pub unsafe fn get_image_view_opaque_capture_descriptor_data(
         &self,
-        info: &vk::ImageViewCaptureDescriptorDataInfoEXT,
+        info: &vk::ImageViewCaptureDescriptorDataInfoEXT<'_>,
         data: &mut [u8],
     ) -> VkResult<()> {
         (self.fp.get_image_view_opaque_capture_descriptor_data_ext)(
@@ -166,7 +166,7 @@ impl DescriptorBuffer {
     #[inline]
     pub unsafe fn get_sampler_opaque_capture_descriptor_data(
         &self,
-        info: &vk::SamplerCaptureDescriptorDataInfoEXT,
+        info: &vk::SamplerCaptureDescriptorDataInfoEXT<'_>,
         data: &mut [u8],
     ) -> VkResult<()> {
         (self.fp.get_sampler_opaque_capture_descriptor_data_ext)(
@@ -181,7 +181,7 @@ impl DescriptorBuffer {
     #[inline]
     pub unsafe fn get_acceleration_structure_opaque_capture_descriptor_data(
         &self,
-        info: &vk::AccelerationStructureCaptureDescriptorDataInfoEXT,
+        info: &vk::AccelerationStructureCaptureDescriptorDataInfoEXT<'_>,
         data: &mut [u8],
     ) -> VkResult<()> {
         (self

--- a/ash/src/extensions/ext/descriptor_buffer.rs
+++ b/ash/src/extensions/ext/descriptor_buffer.rs
@@ -86,7 +86,7 @@ impl DescriptorBuffer {
         layout: vk::PipelineLayout,
         first_set: u32,
         buffer_indices: &[u32],
-        offsets: &[vk::DeviceSize<'_>],
+        offsets: &[vk::DeviceSize],
     ) {
         assert_eq!(buffer_indices.len(), offsets.len());
         (self.fp.cmd_set_descriptor_buffer_offsets_ext)(

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -52,7 +52,7 @@ impl ExtendedDynamicState {
     pub unsafe fn cmd_set_viewport_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        viewports: &[vk::Viewport],
+        viewports: &[vk::Viewport<'_>],
     ) {
         (self.fp.cmd_set_viewport_with_count_ext)(
             command_buffer,
@@ -66,7 +66,7 @@ impl ExtendedDynamicState {
     pub unsafe fn cmd_set_scissor_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        scissors: &[vk::Rect2D],
+        scissors: &[vk::Rect2D<'_>],
     ) {
         (self.fp.cmd_set_scissor_with_count_ext)(
             command_buffer,
@@ -81,10 +81,10 @@ impl ExtendedDynamicState {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer],
-        offsets: &[vk::DeviceSize],
-        sizes: Option<&[vk::DeviceSize]>,
-        strides: Option<&[vk::DeviceSize]>,
+        buffers: &[vk::Buffer<'_>],
+        offsets: &[vk::DeviceSize<'_>],
+        sizes: Option<&[vk::DeviceSize<'_>]>,
+        strides: Option<&[vk::DeviceSize<'_>]>,
     ) {
         assert_eq!(offsets.len(), buffers.len());
         let p_sizes = if let Some(sizes) = sizes {

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -52,7 +52,7 @@ impl ExtendedDynamicState {
     pub unsafe fn cmd_set_viewport_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        viewports: &[vk::Viewport<'_>],
+        viewports: &[vk::Viewport],
     ) {
         (self.fp.cmd_set_viewport_with_count_ext)(
             command_buffer,
@@ -66,7 +66,7 @@ impl ExtendedDynamicState {
     pub unsafe fn cmd_set_scissor_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        scissors: &[vk::Rect2D<'_>],
+        scissors: &[vk::Rect2D],
     ) {
         (self.fp.cmd_set_scissor_with_count_ext)(
             command_buffer,
@@ -81,10 +81,10 @@ impl ExtendedDynamicState {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer<'_>],
-        offsets: &[vk::DeviceSize<'_>],
-        sizes: Option<&[vk::DeviceSize<'_>]>,
-        strides: Option<&[vk::DeviceSize<'_>]>,
+        buffers: &[vk::Buffer],
+        offsets: &[vk::DeviceSize],
+        sizes: Option<&[vk::DeviceSize]>,
+        strides: Option<&[vk::DeviceSize]>,
     ) {
         assert_eq!(offsets.len(), buffers.len());
         let p_sizes = if let Some(sizes) = sizes {

--- a/ash/src/extensions/ext/extended_dynamic_state3.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state3.rs
@@ -63,7 +63,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         samples: vk::SampleCountFlags,
-        sample_mask: &[vk::SampleMask],
+        sample_mask: &[vk::SampleMask<'_>],
     ) {
         assert!(
             samples.as_raw().is_power_of_two(),
@@ -112,7 +112,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_enables: &[vk::Bool32],
+        color_blend_enables: &[vk::Bool32<'_>],
     ) {
         (self.fp.cmd_set_color_blend_enable_ext)(
             command_buffer,
@@ -128,7 +128,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_equations: &[vk::ColorBlendEquationEXT],
+        color_blend_equations: &[vk::ColorBlendEquationEXT<'_>],
     ) {
         (self.fp.cmd_set_color_blend_equation_ext)(
             command_buffer,
@@ -144,7 +144,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_write_masks: &[vk::ColorComponentFlags],
+        color_write_masks: &[vk::ColorComponentFlags<'_>],
     ) {
         (self.fp.cmd_set_color_write_mask_ext)(
             command_buffer,
@@ -219,7 +219,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_advanced: &[vk::ColorBlendAdvancedEXT],
+        color_blend_advanced: &[vk::ColorBlendAdvancedEXT<'_>],
     ) {
         (self.fp.cmd_set_color_blend_advanced_ext)(
             command_buffer,
@@ -291,7 +291,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        viewport_swizzles: &[vk::ViewportSwizzleNV],
+        viewport_swizzles: &[vk::ViewportSwizzleNV<'_>],
     ) {
         (self.fp.cmd_set_viewport_swizzle_nv)(
             command_buffer,

--- a/ash/src/extensions/ext/extended_dynamic_state3.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state3.rs
@@ -63,7 +63,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         samples: vk::SampleCountFlags,
-        sample_mask: &[vk::SampleMask<'_>],
+        sample_mask: &[vk::SampleMask],
     ) {
         assert!(
             samples.as_raw().is_power_of_two(),
@@ -112,7 +112,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_enables: &[vk::Bool32<'_>],
+        color_blend_enables: &[vk::Bool32],
     ) {
         (self.fp.cmd_set_color_blend_enable_ext)(
             command_buffer,
@@ -128,7 +128,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_equations: &[vk::ColorBlendEquationEXT<'_>],
+        color_blend_equations: &[vk::ColorBlendEquationEXT],
     ) {
         (self.fp.cmd_set_color_blend_equation_ext)(
             command_buffer,
@@ -144,7 +144,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_write_masks: &[vk::ColorComponentFlags<'_>],
+        color_write_masks: &[vk::ColorComponentFlags],
     ) {
         (self.fp.cmd_set_color_write_mask_ext)(
             command_buffer,
@@ -219,7 +219,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_advanced: &[vk::ColorBlendAdvancedEXT<'_>],
+        color_blend_advanced: &[vk::ColorBlendAdvancedEXT],
     ) {
         (self.fp.cmd_set_color_blend_advanced_ext)(
             command_buffer,
@@ -291,7 +291,7 @@ impl ExtendedDynamicState3 {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        viewport_swizzles: &[vk::ViewportSwizzleNV<'_>],
+        viewport_swizzles: &[vk::ViewportSwizzleNV],
     ) {
         (self.fp.cmd_set_viewport_swizzle_nv)(
             command_buffer,

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -33,7 +33,7 @@ impl FullScreenExclusive {
     pub unsafe fn get_physical_device_surface_present_modes2(
         &self,
         physical_device: vk::PhysicalDevice,
-        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
+        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
             (self.fp.get_physical_device_surface_present_modes2_ext)(
@@ -58,7 +58,7 @@ impl FullScreenExclusive {
     #[inline]
     pub unsafe fn get_device_group_surface_present_modes2(
         &self,
-        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
+        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
     ) -> VkResult<vk::DeviceGroupPresentModeFlagsKHR> {
         let mut present_modes = mem::zeroed();
         (self.fp.get_device_group_surface_present_modes2_ext)(

--- a/ash/src/extensions/ext/headless_surface.rs
+++ b/ash/src/extensions/ext/headless_surface.rs
@@ -25,8 +25,8 @@ impl HeadlessSurface {
     #[inline]
     pub unsafe fn create_headless_surface(
         &self,
-        create_info: &vk::HeadlessSurfaceCreateInfoEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::HeadlessSurfaceCreateInfoEXT<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_headless_surface_ext)(

--- a/ash/src/extensions/ext/host_image_copy.rs
+++ b/ash/src/extensions/ext/host_image_copy.rs
@@ -26,7 +26,7 @@ impl HostImageCopy {
     #[inline]
     pub unsafe fn copy_memory_to_image(
         &self,
-        copy_memory_to_image_info: &vk::CopyMemoryToImageInfoEXT,
+        copy_memory_to_image_info: &vk::CopyMemoryToImageInfoEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.copy_memory_to_image_ext)(self.handle, copy_memory_to_image_info).result()
     }
@@ -35,7 +35,7 @@ impl HostImageCopy {
     #[inline]
     pub unsafe fn copy_image_to_memory(
         &self,
-        copy_image_to_memory_info: &vk::CopyImageToMemoryInfoEXT,
+        copy_image_to_memory_info: &vk::CopyImageToMemoryInfoEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.copy_image_to_memory_ext)(self.handle, copy_image_to_memory_info).result()
     }
@@ -44,7 +44,7 @@ impl HostImageCopy {
     #[inline]
     pub unsafe fn copy_image_to_image(
         &self,
-        copy_image_to_image_info: &vk::CopyImageToImageInfoEXT,
+        copy_image_to_image_info: &vk::CopyImageToImageInfoEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.copy_image_to_image_ext)(self.handle, copy_image_to_image_info).result()
     }
@@ -53,7 +53,7 @@ impl HostImageCopy {
     #[inline]
     pub unsafe fn transition_image_layout(
         &self,
-        transitions: &[vk::HostImageLayoutTransitionInfoEXT],
+        transitions: &[vk::HostImageLayoutTransitionInfoEXT<'_>],
     ) -> VkResult<()> {
         (self.fp.transition_image_layout_ext)(
             self.handle,
@@ -77,8 +77,8 @@ impl HostImageCopy {
     pub unsafe fn get_image_subresource_layout2(
         &self,
         image: vk::Image,
-        subresource: &vk::ImageSubresource2EXT,
-        layout: &mut vk::SubresourceLayout2EXT,
+        subresource: &vk::ImageSubresource2EXT<'_>,
+        layout: &mut vk::SubresourceLayout2EXT<'_>,
     ) {
         (self.fp.get_image_subresource_layout2_ext)(self.handle, image, subresource, layout)
     }

--- a/ash/src/extensions/ext/image_compression_control.rs
+++ b/ash/src/extensions/ext/image_compression_control.rs
@@ -35,8 +35,8 @@ impl ImageCompressionControl {
     pub unsafe fn get_image_subresource_layout2(
         &self,
         image: vk::Image,
-        subresource: &vk::ImageSubresource2EXT,
-        layout: &mut vk::SubresourceLayout2EXT,
+        subresource: &vk::ImageSubresource2EXT<'_>,
+        layout: &mut vk::SubresourceLayout2EXT<'_>,
     ) {
         (self.fp.get_image_subresource_layout2_ext)(self.handle, image, subresource, layout)
     }

--- a/ash/src/extensions/ext/image_drm_format_modifier.rs
+++ b/ash/src/extensions/ext/image_drm_format_modifier.rs
@@ -25,7 +25,7 @@ impl ImageDrmFormatModifier {
     pub unsafe fn get_image_drm_format_modifier_properties(
         &self,
         image: vk::Image,
-        properties: &mut vk::ImageDrmFormatModifierPropertiesEXT,
+        properties: &mut vk::ImageDrmFormatModifierPropertiesEXT<'_>,
     ) -> VkResult<()> {
         (self.fp.get_image_drm_format_modifier_properties_ext)(self.handle, image, properties)
             .result()

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -24,8 +24,8 @@ impl MetalSurface {
     #[inline]
     pub unsafe fn create_metal_surface(
         &self,
-        create_info: &vk::MetalSurfaceCreateInfoEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::MetalSurfaceCreateInfoEXT<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_metal_surface_ext)(

--- a/ash/src/extensions/ext/pipeline_properties.rs
+++ b/ash/src/extensions/ext/pipeline_properties.rs
@@ -24,7 +24,7 @@ impl PipelineProperties {
     #[inline]
     pub unsafe fn get_pipeline_properties(
         &self,
-        pipeline_info: &vk::PipelineInfoEXT,
+        pipeline_info: &vk::PipelineInfoEXT<'_>,
         pipeline_properties: &mut impl vk::GetPipelinePropertiesEXTParamPipelineProperties,
     ) -> VkResult<()> {
         (self.fp.get_pipeline_properties_ext)(

--- a/ash/src/extensions/ext/private_data.rs
+++ b/ash/src/extensions/ext/private_data.rs
@@ -25,8 +25,8 @@ impl PrivateData {
     #[inline]
     pub unsafe fn create_private_data_slot(
         &self,
-        create_info: &vk::PrivateDataSlotCreateInfoEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::PrivateDataSlotCreateInfoEXT<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::PrivateDataSlotEXT> {
         let mut private_data_slot = mem::zeroed();
         (self.fp.create_private_data_slot_ext)(
@@ -43,7 +43,7 @@ impl PrivateData {
     pub unsafe fn destroy_private_data_slot(
         &self,
         private_data_slot: vk::PrivateDataSlotEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_private_data_slot_ext)(
             self.handle,

--- a/ash/src/extensions/ext/sample_locations.rs
+++ b/ash/src/extensions/ext/sample_locations.rs
@@ -23,7 +23,7 @@ impl SampleLocations {
         &self,
         physical_device: vk::PhysicalDevice,
         samples: vk::SampleCountFlags,
-        multisample_properties: &mut vk::MultisamplePropertiesEXT,
+        multisample_properties: &mut vk::MultisamplePropertiesEXT<'_>,
     ) {
         (self.fp.get_physical_device_multisample_properties_ext)(
             physical_device,
@@ -37,7 +37,7 @@ impl SampleLocations {
     pub unsafe fn cmd_set_sample_locations(
         &self,
         command_buffer: vk::CommandBuffer,
-        sample_locations_info: &vk::SampleLocationsInfoEXT,
+        sample_locations_info: &vk::SampleLocationsInfoEXT<'_>,
     ) {
         (self.fp.cmd_set_sample_locations_ext)(command_buffer, sample_locations_info)
     }

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -26,8 +26,8 @@ impl ShaderObject {
     #[inline]
     pub unsafe fn create_shaders(
         &self,
-        create_infos: &[vk::ShaderCreateInfoEXT],
-        allocator: Option<&vk::AllocationCallbacks>,
+        create_infos: &[vk::ShaderCreateInfoEXT<'_>],
+        allocator: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::ShaderEXT>> {
         let mut shaders = Vec::with_capacity(create_infos.len());
         (self.fp.create_shaders_ext)(
@@ -47,7 +47,7 @@ impl ShaderObject {
     pub unsafe fn destroy_shader(
         &self,
         shader: vk::ShaderEXT,
-        allocator: Option<&vk::AllocationCallbacks>,
+        allocator: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_shader_ext)(self.handle, shader, allocator.as_raw_ptr())
     }
@@ -65,8 +65,8 @@ impl ShaderObject {
     pub unsafe fn cmd_bind_shaders(
         &self,
         command_buffer: vk::CommandBuffer,
-        stages: &[vk::ShaderStageFlags],
-        shaders: &[vk::ShaderEXT],
+        stages: &[vk::ShaderStageFlags<'_>],
+        shaders: &[vk::ShaderEXT<'_>],
     ) {
         assert_eq!(stages.len(), shaders.len());
         (self.fp.cmd_bind_shaders_ext)(
@@ -82,8 +82,8 @@ impl ShaderObject {
     pub unsafe fn cmd_set_vertex_input(
         &self,
         command_buffer: vk::CommandBuffer,
-        vertex_binding_descriptions: &[vk::VertexInputBindingDescription2EXT],
-        vertex_attribute_descriptions: &[vk::VertexInputAttributeDescription2EXT],
+        vertex_binding_descriptions: &[vk::VertexInputBindingDescription2EXT<'_>],
+        vertex_attribute_descriptions: &[vk::VertexInputAttributeDescription2EXT<'_>],
     ) {
         (self.fp.cmd_set_vertex_input_ext)(
             command_buffer,
@@ -131,7 +131,7 @@ impl ShaderObject {
     pub unsafe fn cmd_set_viewport_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        viewports: &[vk::Viewport],
+        viewports: &[vk::Viewport<'_>],
     ) {
         (self.fp.cmd_set_viewport_with_count_ext)(
             command_buffer,
@@ -145,7 +145,7 @@ impl ShaderObject {
     pub unsafe fn cmd_set_scissor_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        scissors: &[vk::Rect2D],
+        scissors: &[vk::Rect2D<'_>],
     ) {
         (self.fp.cmd_set_scissor_with_count_ext)(
             command_buffer,
@@ -160,10 +160,10 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer],
-        offsets: &[vk::DeviceSize],
-        sizes: Option<&[vk::DeviceSize]>,
-        strides: Option<&[vk::DeviceSize]>,
+        buffers: &[vk::Buffer<'_>],
+        offsets: &[vk::DeviceSize<'_>],
+        sizes: Option<&[vk::DeviceSize<'_>]>,
+        strides: Option<&[vk::DeviceSize<'_>]>,
     ) {
         assert_eq!(offsets.len(), buffers.len());
         let p_sizes = if let Some(sizes) = sizes {
@@ -369,7 +369,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         samples: vk::SampleCountFlags,
-        sample_mask: &[vk::SampleMask],
+        sample_mask: &[vk::SampleMask<'_>],
     ) {
         assert!(
             samples.as_raw().is_power_of_two(),
@@ -418,7 +418,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_enables: &[vk::Bool32],
+        color_blend_enables: &[vk::Bool32<'_>],
     ) {
         (self.fp.cmd_set_color_blend_enable_ext)(
             command_buffer,
@@ -434,7 +434,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_equations: &[vk::ColorBlendEquationEXT],
+        color_blend_equations: &[vk::ColorBlendEquationEXT<'_>],
     ) {
         (self.fp.cmd_set_color_blend_equation_ext)(
             command_buffer,
@@ -450,7 +450,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_write_masks: &[vk::ColorComponentFlags],
+        color_write_masks: &[vk::ColorComponentFlags<'_>],
     ) {
         (self.fp.cmd_set_color_write_mask_ext)(
             command_buffer,
@@ -525,7 +525,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_advanced: &[vk::ColorBlendAdvancedEXT],
+        color_blend_advanced: &[vk::ColorBlendAdvancedEXT<'_>],
     ) {
         (self.fp.cmd_set_color_blend_advanced_ext)(
             command_buffer,
@@ -597,7 +597,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        viewport_swizzles: &[vk::ViewportSwizzleNV],
+        viewport_swizzles: &[vk::ViewportSwizzleNV<'_>],
     ) {
         (self.fp.cmd_set_viewport_swizzle_nv)(
             command_buffer,

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -65,8 +65,8 @@ impl ShaderObject {
     pub unsafe fn cmd_bind_shaders(
         &self,
         command_buffer: vk::CommandBuffer,
-        stages: &[vk::ShaderStageFlags<'_>],
-        shaders: &[vk::ShaderEXT<'_>],
+        stages: &[vk::ShaderStageFlags],
+        shaders: &[vk::ShaderEXT],
     ) {
         assert_eq!(stages.len(), shaders.len());
         (self.fp.cmd_bind_shaders_ext)(
@@ -131,7 +131,7 @@ impl ShaderObject {
     pub unsafe fn cmd_set_viewport_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        viewports: &[vk::Viewport<'_>],
+        viewports: &[vk::Viewport],
     ) {
         (self.fp.cmd_set_viewport_with_count_ext)(
             command_buffer,
@@ -145,7 +145,7 @@ impl ShaderObject {
     pub unsafe fn cmd_set_scissor_with_count(
         &self,
         command_buffer: vk::CommandBuffer,
-        scissors: &[vk::Rect2D<'_>],
+        scissors: &[vk::Rect2D],
     ) {
         (self.fp.cmd_set_scissor_with_count_ext)(
             command_buffer,
@@ -160,10 +160,10 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_binding: u32,
-        buffers: &[vk::Buffer<'_>],
-        offsets: &[vk::DeviceSize<'_>],
-        sizes: Option<&[vk::DeviceSize<'_>]>,
-        strides: Option<&[vk::DeviceSize<'_>]>,
+        buffers: &[vk::Buffer],
+        offsets: &[vk::DeviceSize],
+        sizes: Option<&[vk::DeviceSize]>,
+        strides: Option<&[vk::DeviceSize]>,
     ) {
         assert_eq!(offsets.len(), buffers.len());
         let p_sizes = if let Some(sizes) = sizes {
@@ -369,7 +369,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         samples: vk::SampleCountFlags,
-        sample_mask: &[vk::SampleMask<'_>],
+        sample_mask: &[vk::SampleMask],
     ) {
         assert!(
             samples.as_raw().is_power_of_two(),
@@ -418,7 +418,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_enables: &[vk::Bool32<'_>],
+        color_blend_enables: &[vk::Bool32],
     ) {
         (self.fp.cmd_set_color_blend_enable_ext)(
             command_buffer,
@@ -434,7 +434,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_equations: &[vk::ColorBlendEquationEXT<'_>],
+        color_blend_equations: &[vk::ColorBlendEquationEXT],
     ) {
         (self.fp.cmd_set_color_blend_equation_ext)(
             command_buffer,
@@ -450,7 +450,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_write_masks: &[vk::ColorComponentFlags<'_>],
+        color_write_masks: &[vk::ColorComponentFlags],
     ) {
         (self.fp.cmd_set_color_write_mask_ext)(
             command_buffer,
@@ -525,7 +525,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        color_blend_advanced: &[vk::ColorBlendAdvancedEXT<'_>],
+        color_blend_advanced: &[vk::ColorBlendAdvancedEXT],
     ) {
         (self.fp.cmd_set_color_blend_advanced_ext)(
             command_buffer,
@@ -597,7 +597,7 @@ impl ShaderObject {
         &self,
         command_buffer: vk::CommandBuffer,
         first_attachment: u32,
-        viewport_swizzles: &[vk::ViewportSwizzleNV<'_>],
+        viewport_swizzles: &[vk::ViewportSwizzleNV],
     ) {
         (self.fp.cmd_set_viewport_swizzle_nv)(
             command_buffer,

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -22,7 +22,7 @@ impl ToolingInfo {
     pub unsafe fn get_physical_device_tool_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-    ) -> VkResult<Vec<vk::PhysicalDeviceToolPropertiesEXT>> {
+    ) -> VkResult<Vec<vk::PhysicalDeviceToolPropertiesEXT<'_>>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_physical_device_tool_properties_ext)(physical_device, count, data)
         })

--- a/ash/src/extensions/ext/vertex_input_dynamic_state.rs
+++ b/ash/src/extensions/ext/vertex_input_dynamic_state.rs
@@ -22,8 +22,8 @@ impl VertexInputDynamicState {
     pub unsafe fn cmd_set_vertex_input(
         &self,
         command_buffer: vk::CommandBuffer,
-        vertex_binding_descriptions: &[vk::VertexInputBindingDescription2EXT],
-        vertex_attribute_descriptions: &[vk::VertexInputAttributeDescription2EXT],
+        vertex_binding_descriptions: &[vk::VertexInputBindingDescription2EXT<'_>],
+        vertex_attribute_descriptions: &[vk::VertexInputAttributeDescription2EXT<'_>],
     ) {
         (self.fp.cmd_set_vertex_input_ext)(
             command_buffer,

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -25,8 +25,8 @@ impl AccelerationStructure {
     #[inline]
     pub unsafe fn create_acceleration_structure(
         &self,
-        create_info: &vk::AccelerationStructureCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::AccelerationStructureCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
         let mut accel_struct = mem::zeroed();
         (self.fp.create_acceleration_structure_khr)(
@@ -43,7 +43,7 @@ impl AccelerationStructure {
     pub unsafe fn destroy_acceleration_structure(
         &self,
         accel_struct: vk::AccelerationStructureKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_acceleration_structure_khr)(
             self.handle,
@@ -57,8 +57,8 @@ impl AccelerationStructure {
     pub unsafe fn cmd_build_acceleration_structures(
         &self,
         command_buffer: vk::CommandBuffer,
-        infos: &[vk::AccelerationStructureBuildGeometryInfoKHR],
-        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR]],
+        infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
+        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR<'_>]],
     ) {
         assert_eq!(infos.len(), build_range_infos.len());
 
@@ -84,8 +84,8 @@ impl AccelerationStructure {
     pub unsafe fn cmd_build_acceleration_structures_indirect(
         &self,
         command_buffer: vk::CommandBuffer,
-        infos: &[vk::AccelerationStructureBuildGeometryInfoKHR],
-        indirect_device_addresses: &[vk::DeviceAddress],
+        infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
+        indirect_device_addresses: &[vk::DeviceAddress<'_>],
         indirect_strides: &[u32],
         max_primitive_counts: &[&[u32]],
     ) {
@@ -117,8 +117,8 @@ impl AccelerationStructure {
     pub unsafe fn build_acceleration_structures(
         &self,
         deferred_operation: vk::DeferredOperationKHR,
-        infos: &[vk::AccelerationStructureBuildGeometryInfoKHR],
-        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR]],
+        infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
+        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR<'_>]],
     ) -> VkResult<()> {
         assert_eq!(infos.len(), build_range_infos.len());
 
@@ -146,7 +146,7 @@ impl AccelerationStructure {
     pub unsafe fn copy_acceleration_structure(
         &self,
         deferred_operation: vk::DeferredOperationKHR,
-        info: &vk::CopyAccelerationStructureInfoKHR,
+        info: &vk::CopyAccelerationStructureInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.copy_acceleration_structure_khr)(self.handle, deferred_operation, info).result()
     }
@@ -156,7 +156,7 @@ impl AccelerationStructure {
     pub unsafe fn copy_acceleration_structure_to_memory(
         &self,
         deferred_operation: vk::DeferredOperationKHR,
-        info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
+        info: &vk::CopyAccelerationStructureToMemoryInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.copy_acceleration_structure_to_memory_khr)(self.handle, deferred_operation, info)
             .result()
@@ -167,7 +167,7 @@ impl AccelerationStructure {
     pub unsafe fn copy_memory_to_acceleration_structure(
         &self,
         deferred_operation: vk::DeferredOperationKHR,
-        info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
+        info: &vk::CopyMemoryToAccelerationStructureInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.copy_memory_to_acceleration_structure_khr)(self.handle, deferred_operation, info)
             .result()
@@ -177,7 +177,7 @@ impl AccelerationStructure {
     #[inline]
     pub unsafe fn write_acceleration_structures_properties(
         &self,
-        acceleration_structures: &[vk::AccelerationStructureKHR],
+        acceleration_structures: &[vk::AccelerationStructureKHR<'_>],
         query_type: vk::QueryType,
         data: &mut [u8],
         stride: usize,
@@ -199,7 +199,7 @@ impl AccelerationStructure {
     pub unsafe fn cmd_copy_acceleration_structure(
         &self,
         command_buffer: vk::CommandBuffer,
-        info: &vk::CopyAccelerationStructureInfoKHR,
+        info: &vk::CopyAccelerationStructureInfoKHR<'_>,
     ) {
         (self.fp.cmd_copy_acceleration_structure_khr)(command_buffer, info);
     }
@@ -209,7 +209,7 @@ impl AccelerationStructure {
     pub unsafe fn cmd_copy_acceleration_structure_to_memory(
         &self,
         command_buffer: vk::CommandBuffer,
-        info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
+        info: &vk::CopyAccelerationStructureToMemoryInfoKHR<'_>,
     ) {
         (self.fp.cmd_copy_acceleration_structure_to_memory_khr)(command_buffer, info);
     }
@@ -219,7 +219,7 @@ impl AccelerationStructure {
     pub unsafe fn cmd_copy_memory_to_acceleration_structure(
         &self,
         command_buffer: vk::CommandBuffer,
-        info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
+        info: &vk::CopyMemoryToAccelerationStructureInfoKHR<'_>,
     ) {
         (self.fp.cmd_copy_memory_to_acceleration_structure_khr)(command_buffer, info);
     }
@@ -228,7 +228,7 @@ impl AccelerationStructure {
     #[inline]
     pub unsafe fn get_acceleration_structure_device_address(
         &self,
-        info: &vk::AccelerationStructureDeviceAddressInfoKHR,
+        info: &vk::AccelerationStructureDeviceAddressInfoKHR<'_>,
     ) -> vk::DeviceAddress {
         (self.fp.get_acceleration_structure_device_address_khr)(self.handle, info)
     }
@@ -238,7 +238,7 @@ impl AccelerationStructure {
     pub unsafe fn cmd_write_acceleration_structures_properties(
         &self,
         command_buffer: vk::CommandBuffer,
-        structures: &[vk::AccelerationStructureKHR],
+        structures: &[vk::AccelerationStructureKHR<'_>],
         query_type: vk::QueryType,
         query_pool: vk::QueryPool,
         first_query: u32,
@@ -257,7 +257,7 @@ impl AccelerationStructure {
     #[inline]
     pub unsafe fn get_device_acceleration_structure_compatibility(
         &self,
-        version: &vk::AccelerationStructureVersionInfoKHR,
+        version: &vk::AccelerationStructureVersionInfoKHR<'_>,
     ) -> vk::AccelerationStructureCompatibilityKHR {
         let mut compatibility = mem::zeroed();
 
@@ -275,9 +275,9 @@ impl AccelerationStructure {
     pub unsafe fn get_acceleration_structure_build_sizes(
         &self,
         build_type: vk::AccelerationStructureBuildTypeKHR,
-        build_info: &vk::AccelerationStructureBuildGeometryInfoKHR,
+        build_info: &vk::AccelerationStructureBuildGeometryInfoKHR<'_>,
         max_primitive_counts: &[u32],
-        size_info: &mut vk::AccelerationStructureBuildSizesInfoKHR,
+        size_info: &mut vk::AccelerationStructureBuildSizesInfoKHR<'_>,
     ) {
         assert_eq!(max_primitive_counts.len(), build_info.geometry_count as _);
 

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -58,7 +58,7 @@ impl AccelerationStructure {
         &self,
         command_buffer: vk::CommandBuffer,
         infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
-        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR<'_>]],
+        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR]],
     ) {
         assert_eq!(infos.len(), build_range_infos.len());
 
@@ -85,7 +85,7 @@ impl AccelerationStructure {
         &self,
         command_buffer: vk::CommandBuffer,
         infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
-        indirect_device_addresses: &[vk::DeviceAddress<'_>],
+        indirect_device_addresses: &[vk::DeviceAddress],
         indirect_strides: &[u32],
         max_primitive_counts: &[&[u32]],
     ) {
@@ -118,7 +118,7 @@ impl AccelerationStructure {
         &self,
         deferred_operation: vk::DeferredOperationKHR,
         infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
-        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR<'_>]],
+        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR]],
     ) -> VkResult<()> {
         assert_eq!(infos.len(), build_range_infos.len());
 
@@ -177,7 +177,7 @@ impl AccelerationStructure {
     #[inline]
     pub unsafe fn write_acceleration_structures_properties(
         &self,
-        acceleration_structures: &[vk::AccelerationStructureKHR<'_>],
+        acceleration_structures: &[vk::AccelerationStructureKHR],
         query_type: vk::QueryType,
         data: &mut [u8],
         stride: usize,
@@ -238,7 +238,7 @@ impl AccelerationStructure {
     pub unsafe fn cmd_write_acceleration_structures_properties(
         &self,
         command_buffer: vk::CommandBuffer,
-        structures: &[vk::AccelerationStructureKHR<'_>],
+        structures: &[vk::AccelerationStructureKHR],
         query_type: vk::QueryType,
         query_pool: vk::QueryPool,
         first_query: u32,

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -24,8 +24,8 @@ impl AndroidSurface {
     #[inline]
     pub unsafe fn create_android_surface(
         &self,
-        create_info: &vk::AndroidSurfaceCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::AndroidSurfaceCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_android_surface_khr)(

--- a/ash/src/extensions/khr/buffer_device_address.rs
+++ b/ash/src/extensions/khr/buffer_device_address.rs
@@ -22,7 +22,7 @@ impl BufferDeviceAddress {
     #[inline]
     pub unsafe fn get_buffer_device_address(
         &self,
-        info: &vk::BufferDeviceAddressInfoKHR,
+        info: &vk::BufferDeviceAddressInfoKHR<'_>,
     ) -> vk::DeviceAddress {
         (self.fp.get_buffer_device_address_khr)(self.handle, info)
     }
@@ -31,7 +31,7 @@ impl BufferDeviceAddress {
     #[inline]
     pub unsafe fn get_buffer_opaque_capture_address(
         &self,
-        info: &vk::BufferDeviceAddressInfoKHR,
+        info: &vk::BufferDeviceAddressInfoKHR<'_>,
     ) -> u64 {
         (self.fp.get_buffer_opaque_capture_address_khr)(self.handle, info)
     }
@@ -40,7 +40,7 @@ impl BufferDeviceAddress {
     #[inline]
     pub unsafe fn get_device_memory_opaque_capture_address(
         &self,
-        info: &vk::DeviceMemoryOpaqueCaptureAddressInfoKHR,
+        info: &vk::DeviceMemoryOpaqueCaptureAddressInfoKHR<'_>,
     ) -> u64 {
         (self.fp.get_device_memory_opaque_capture_address_khr)(self.handle, info)
     }

--- a/ash/src/extensions/khr/cooperative_matrix.rs
+++ b/ash/src/extensions/khr/cooperative_matrix.rs
@@ -24,7 +24,7 @@ impl CooperativeMatrix {
     pub unsafe fn get_physical_device_cooperative_matrix_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-    ) -> VkResult<Vec<vk::CooperativeMatrixPropertiesKHR>> {
+    ) -> VkResult<Vec<vk::CooperativeMatrixPropertiesKHR<'_>>> {
         read_into_defaulted_vector(|count, data| {
             (self
                 .fp

--- a/ash/src/extensions/khr/copy_commands2.rs
+++ b/ash/src/extensions/khr/copy_commands2.rs
@@ -22,7 +22,7 @@ impl CopyCommands2 {
     pub unsafe fn cmd_copy_buffer2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_buffer_info: &vk::CopyBufferInfo2KHR,
+        copy_buffer_info: &vk::CopyBufferInfo2KHR<'_>,
     ) {
         (self.fp.cmd_copy_buffer2_khr)(command_buffer, copy_buffer_info)
     }
@@ -31,7 +31,7 @@ impl CopyCommands2 {
     pub unsafe fn cmd_copy_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_image_info: &vk::CopyImageInfo2KHR,
+        copy_image_info: &vk::CopyImageInfo2KHR<'_>,
     ) {
         (self.fp.cmd_copy_image2_khr)(command_buffer, copy_image_info)
     }
@@ -40,7 +40,7 @@ impl CopyCommands2 {
     pub unsafe fn cmd_copy_buffer_to_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_buffer_to_image_info: &vk::CopyBufferToImageInfo2KHR,
+        copy_buffer_to_image_info: &vk::CopyBufferToImageInfo2KHR<'_>,
     ) {
         (self.fp.cmd_copy_buffer_to_image2_khr)(command_buffer, copy_buffer_to_image_info)
     }
@@ -49,7 +49,7 @@ impl CopyCommands2 {
     pub unsafe fn cmd_copy_image_to_buffer2(
         &self,
         command_buffer: vk::CommandBuffer,
-        copy_image_to_buffer_info: &vk::CopyImageToBufferInfo2KHR,
+        copy_image_to_buffer_info: &vk::CopyImageToBufferInfo2KHR<'_>,
     ) {
         (self.fp.cmd_copy_image_to_buffer2_khr)(command_buffer, copy_image_to_buffer_info)
     }
@@ -58,7 +58,7 @@ impl CopyCommands2 {
     pub unsafe fn cmd_blit_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        blit_image_info: &vk::BlitImageInfo2KHR,
+        blit_image_info: &vk::BlitImageInfo2KHR<'_>,
     ) {
         (self.fp.cmd_blit_image2_khr)(command_buffer, blit_image_info)
     }
@@ -67,7 +67,7 @@ impl CopyCommands2 {
     pub unsafe fn cmd_resolve_image2(
         &self,
         command_buffer: vk::CommandBuffer,
-        resolve_image_info: &vk::ResolveImageInfo2KHR,
+        resolve_image_info: &vk::ResolveImageInfo2KHR<'_>,
     ) {
         (self.fp.cmd_resolve_image2_khr)(command_buffer, resolve_image_info)
     }

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -24,8 +24,8 @@ impl CreateRenderPass2 {
     #[inline]
     pub unsafe fn create_render_pass2(
         &self,
-        create_info: &vk::RenderPassCreateInfo2,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::RenderPassCreateInfo2<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
         (self.fp.create_render_pass2_khr)(
@@ -42,8 +42,8 @@ impl CreateRenderPass2 {
     pub unsafe fn cmd_begin_render_pass2(
         &self,
         command_buffer: vk::CommandBuffer,
-        render_pass_begin_info: &vk::RenderPassBeginInfo,
-        subpass_begin_info: &vk::SubpassBeginInfo,
+        render_pass_begin_info: &vk::RenderPassBeginInfo<'_>,
+        subpass_begin_info: &vk::SubpassBeginInfo<'_>,
     ) {
         (self.fp.cmd_begin_render_pass2_khr)(
             command_buffer,
@@ -57,8 +57,8 @@ impl CreateRenderPass2 {
     pub unsafe fn cmd_next_subpass2(
         &self,
         command_buffer: vk::CommandBuffer,
-        subpass_begin_info: &vk::SubpassBeginInfo,
-        subpass_end_info: &vk::SubpassEndInfo,
+        subpass_begin_info: &vk::SubpassBeginInfo<'_>,
+        subpass_end_info: &vk::SubpassEndInfo<'_>,
     ) {
         (self.fp.cmd_next_subpass2_khr)(command_buffer, subpass_begin_info, subpass_end_info);
     }
@@ -68,7 +68,7 @@ impl CreateRenderPass2 {
     pub unsafe fn cmd_end_render_pass2(
         &self,
         command_buffer: vk::CommandBuffer,
-        subpass_end_info: &vk::SubpassEndInfo,
+        subpass_end_info: &vk::SubpassEndInfo<'_>,
     ) {
         (self.fp.cmd_end_render_pass2_khr)(command_buffer, subpass_end_info);
     }

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -24,7 +24,7 @@ impl DeferredHostOperations {
     #[inline]
     pub unsafe fn create_deferred_operation(
         &self,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DeferredOperationKHR> {
         let mut operation = mem::zeroed();
         (self.fp.create_deferred_operation_khr)(
@@ -49,7 +49,7 @@ impl DeferredHostOperations {
     pub unsafe fn destroy_deferred_operation(
         &self,
         operation: vk::DeferredOperationKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_deferred_operation_khr)(
             self.handle,

--- a/ash/src/extensions/khr/device_group.rs
+++ b/ash/src/extensions/khr/device_group.rs
@@ -77,7 +77,7 @@ impl DeviceGroup {
     #[inline]
     pub unsafe fn get_device_group_present_capabilities(
         &self,
-        device_group_present_capabilities: &mut vk::DeviceGroupPresentCapabilitiesKHR,
+        device_group_present_capabilities: &mut vk::DeviceGroupPresentCapabilitiesKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.get_device_group_present_capabilities_khr)(
             self.handle,
@@ -141,7 +141,7 @@ impl DeviceGroup {
     #[inline]
     pub unsafe fn acquire_next_image2(
         &self,
-        acquire_info: &vk::AcquireNextImageInfoKHR,
+        acquire_info: &vk::AcquireNextImageInfoKHR<'_>,
     ) -> VkResult<(u32, bool)> {
         let mut index = 0;
         let err_code = (self.fp.acquire_next_image2_khr)(self.handle, acquire_info, &mut index);

--- a/ash/src/extensions/khr/device_group_creation.rs
+++ b/ash/src/extensions/khr/device_group_creation.rs
@@ -40,7 +40,7 @@ impl DeviceGroupCreation {
     #[inline]
     pub unsafe fn enumerate_physical_device_groups(
         &self,
-        out: &mut [vk::PhysicalDeviceGroupProperties],
+        out: &mut [vk::PhysicalDeviceGroupProperties<'_>],
     ) -> VkResult<()> {
         let mut count = out.len() as u32;
         (self.fp.enumerate_physical_device_groups_khr)(self.handle, &mut count, out.as_mut_ptr())

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -77,8 +77,8 @@ impl Display {
         &self,
         physical_device: vk::PhysicalDevice,
         display: vk::DisplayKHR,
-        create_info: &vk::DisplayModeCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DisplayModeCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::DisplayModeKHR> {
         let mut display_mode = mem::MaybeUninit::zeroed();
         (self.fp.create_display_mode_khr)(
@@ -113,8 +113,8 @@ impl Display {
     #[inline]
     pub unsafe fn create_display_plane_surface(
         &self,
-        create_info: &vk::DisplaySurfaceCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DisplaySurfaceCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::zeroed();
         (self.fp.create_display_plane_surface_khr)(

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -25,7 +25,7 @@ impl Display {
     pub unsafe fn get_physical_device_display_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-    ) -> VkResult<Vec<vk::DisplayPropertiesKHR>> {
+    ) -> VkResult<Vec<vk::DisplayPropertiesKHR<'_>>> {
         read_into_uninitialized_vector(|count, data| {
             (self.fp.get_physical_device_display_properties_khr)(physical_device, count, data)
         })

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -24,8 +24,8 @@ impl DisplaySwapchain {
     #[inline]
     pub unsafe fn create_shared_swapchains(
         &self,
-        create_infos: &[vk::SwapchainCreateInfoKHR],
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_infos: &[vk::SwapchainCreateInfoKHR<'_>],
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::SwapchainKHR>> {
         let mut swapchains = Vec::with_capacity(create_infos.len());
         (self.fp.create_shared_swapchains_khr)(

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -21,7 +21,7 @@ impl DynamicRendering {
     pub unsafe fn cmd_begin_rendering(
         &self,
         command_buffer: vk::CommandBuffer,
-        rendering_info: &vk::RenderingInfoKHR,
+        rendering_info: &vk::RenderingInfoKHR<'_>,
     ) {
         (self.fp.cmd_begin_rendering_khr)(command_buffer, rendering_info)
     }

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -21,13 +21,16 @@ impl ExternalFenceFd {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkImportFenceFdKHR.html>
     #[inline]
-    pub unsafe fn import_fence_fd(&self, import_info: &vk::ImportFenceFdInfoKHR) -> VkResult<()> {
+    pub unsafe fn import_fence_fd(
+        &self,
+        import_info: &vk::ImportFenceFdInfoKHR<'_>,
+    ) -> VkResult<()> {
         (self.fp.import_fence_fd_khr)(self.handle, import_info).result()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetFenceFdKHR.html>
     #[inline]
-    pub unsafe fn get_fence_fd(&self, get_info: &vk::FenceGetFdInfoKHR) -> VkResult<i32> {
+    pub unsafe fn get_fence_fd(&self, get_info: &vk::FenceGetFdInfoKHR<'_>) -> VkResult<i32> {
         let mut fd = -1;
         (self.fp.get_fence_fd_khr)(self.handle, get_info, &mut fd).result_with_success(fd)
     }

--- a/ash/src/extensions/khr/external_fence_win32.rs
+++ b/ash/src/extensions/khr/external_fence_win32.rs
@@ -25,7 +25,7 @@ impl ExternalFenceWin32 {
     #[inline]
     pub unsafe fn import_fence_win32_handle(
         &self,
-        import_info: &vk::ImportFenceWin32HandleInfoKHR,
+        import_info: &vk::ImportFenceWin32HandleInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.import_fence_win32_handle_khr)(self.handle, import_info).result()
     }
@@ -34,7 +34,7 @@ impl ExternalFenceWin32 {
     #[inline]
     pub unsafe fn get_fence_win32_handle(
         &self,
-        get_info: &vk::FenceGetWin32HandleInfoKHR,
+        get_info: &vk::FenceGetWin32HandleInfoKHR<'_>,
     ) -> VkResult<vk::HANDLE> {
         let mut handle = MaybeUninit::uninit();
         (self.fp.get_fence_win32_handle_khr)(self.handle, get_info, handle.as_mut_ptr())

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -22,7 +22,7 @@ impl ExternalMemoryFd {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryFdKHR.html>
     #[inline]
-    pub unsafe fn get_memory_fd(&self, get_fd_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
+    pub unsafe fn get_memory_fd(&self, get_fd_info: &vk::MemoryGetFdInfoKHR<'_>) -> VkResult<i32> {
         let mut fd = -1;
         (self.fp.get_memory_fd_khr)(self.handle, get_fd_info, &mut fd).result_with_success(fd)
     }
@@ -33,7 +33,7 @@ impl ExternalMemoryFd {
         &self,
         handle_type: vk::ExternalMemoryHandleTypeFlags,
         fd: i32,
-        memory_fd_properties: &mut vk::MemoryFdPropertiesKHR,
+        memory_fd_properties: &mut vk::MemoryFdPropertiesKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.get_memory_fd_properties_khr)(self.handle, handle_type, fd, memory_fd_properties)
             .result()

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -25,7 +25,7 @@ impl ExternalMemoryWin32 {
     #[inline]
     pub unsafe fn get_memory_win32_handle(
         &self,
-        create_info: &vk::MemoryGetWin32HandleInfoKHR,
+        create_info: &vk::MemoryGetWin32HandleInfoKHR<'_>,
     ) -> VkResult<vk::HANDLE> {
         let mut handle = MaybeUninit::uninit();
         (self.fp.get_memory_win32_handle_khr)(self.handle, create_info, handle.as_mut_ptr())
@@ -38,7 +38,7 @@ impl ExternalMemoryWin32 {
         &self,
         handle_type: vk::ExternalMemoryHandleTypeFlags,
         handle: vk::HANDLE,
-        memory_win32_handle_properties: &mut vk::MemoryWin32HandlePropertiesKHR,
+        memory_win32_handle_properties: &mut vk::MemoryWin32HandlePropertiesKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.get_memory_win32_handle_properties_khr)(
             self.handle,

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -23,14 +23,17 @@ impl ExternalSemaphoreFd {
     #[inline]
     pub unsafe fn import_semaphore_fd(
         &self,
-        import_info: &vk::ImportSemaphoreFdInfoKHR,
+        import_info: &vk::ImportSemaphoreFdInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.import_semaphore_fd_khr)(self.handle, import_info).result()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetSemaphoreFdKHR.html>
     #[inline]
-    pub unsafe fn get_semaphore_fd(&self, get_info: &vk::SemaphoreGetFdInfoKHR) -> VkResult<i32> {
+    pub unsafe fn get_semaphore_fd(
+        &self,
+        get_info: &vk::SemaphoreGetFdInfoKHR<'_>,
+    ) -> VkResult<i32> {
         let mut fd = -1;
         (self.fp.get_semaphore_fd_khr)(self.handle, get_info, &mut fd).result_with_success(fd)
     }

--- a/ash/src/extensions/khr/external_semaphore_win32.rs
+++ b/ash/src/extensions/khr/external_semaphore_win32.rs
@@ -25,7 +25,7 @@ impl ExternalSemaphoreWin32 {
     #[inline]
     pub unsafe fn import_semaphore_win32_handle(
         &self,
-        import_info: &vk::ImportSemaphoreWin32HandleInfoKHR,
+        import_info: &vk::ImportSemaphoreWin32HandleInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.import_semaphore_win32_handle_khr)(self.handle, import_info).result()
     }
@@ -34,7 +34,7 @@ impl ExternalSemaphoreWin32 {
     #[inline]
     pub unsafe fn get_semaphore_win32_handle(
         &self,
-        get_info: &vk::SemaphoreGetWin32HandleInfoKHR,
+        get_info: &vk::SemaphoreGetWin32HandleInfoKHR<'_>,
     ) -> VkResult<vk::HANDLE> {
         let mut handle = MaybeUninit::uninit();
         (self.fp.get_semaphore_win32_handle_khr)(self.handle, get_info, handle.as_mut_ptr())

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -23,8 +23,8 @@ impl GetMemoryRequirements2 {
     #[inline]
     pub unsafe fn get_buffer_memory_requirements2(
         &self,
-        info: &vk::BufferMemoryRequirementsInfo2KHR,
-        memory_requirements: &mut vk::MemoryRequirements2KHR,
+        info: &vk::BufferMemoryRequirementsInfo2KHR<'_>,
+        memory_requirements: &mut vk::MemoryRequirements2KHR<'_>,
     ) {
         (self.fp.get_buffer_memory_requirements2_khr)(self.handle, info, memory_requirements);
     }
@@ -33,8 +33,8 @@ impl GetMemoryRequirements2 {
     #[inline]
     pub unsafe fn get_image_memory_requirements2(
         &self,
-        info: &vk::ImageMemoryRequirementsInfo2KHR,
-        memory_requirements: &mut vk::MemoryRequirements2KHR,
+        info: &vk::ImageMemoryRequirementsInfo2KHR<'_>,
+        memory_requirements: &mut vk::MemoryRequirements2KHR<'_>,
     ) {
         (self.fp.get_image_memory_requirements2_khr)(self.handle, info, memory_requirements);
     }
@@ -43,7 +43,7 @@ impl GetMemoryRequirements2 {
     #[inline]
     pub unsafe fn get_image_sparse_memory_requirements2_len(
         &self,
-        info: &vk::ImageSparseMemoryRequirementsInfo2KHR,
+        info: &vk::ImageSparseMemoryRequirementsInfo2KHR<'_>,
     ) -> usize {
         let mut count = 0;
         (self.fp.get_image_sparse_memory_requirements2_khr)(
@@ -62,8 +62,8 @@ impl GetMemoryRequirements2 {
     #[inline]
     pub unsafe fn get_image_sparse_memory_requirements2(
         &self,
-        info: &vk::ImageSparseMemoryRequirementsInfo2KHR,
-        out: &mut [vk::SparseImageMemoryRequirements2KHR],
+        info: &vk::ImageSparseMemoryRequirementsInfo2KHR<'_>,
+        out: &mut [vk::SparseImageMemoryRequirements2KHR<'_>],
     ) {
         let mut count = out.len() as u32;
         (self.fp.get_image_sparse_memory_requirements2_khr)(

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -23,7 +23,7 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_features2(
         &self,
         physical_device: vk::PhysicalDevice,
-        features: &mut vk::PhysicalDeviceFeatures2KHR,
+        features: &mut vk::PhysicalDeviceFeatures2KHR<'_>,
     ) {
         (self.fp.get_physical_device_features2_khr)(physical_device, features);
     }
@@ -34,7 +34,7 @@ impl GetPhysicalDeviceProperties2 {
         &self,
         physical_device: vk::PhysicalDevice,
         format: vk::Format,
-        format_properties: &mut vk::FormatProperties2KHR,
+        format_properties: &mut vk::FormatProperties2KHR<'_>,
     ) {
         (self.fp.get_physical_device_format_properties2_khr)(
             physical_device,
@@ -48,8 +48,8 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_image_format_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        image_format_info: &vk::PhysicalDeviceImageFormatInfo2KHR,
-        image_format_properties: &mut vk::ImageFormatProperties2KHR,
+        image_format_info: &vk::PhysicalDeviceImageFormatInfo2KHR<'_>,
+        image_format_properties: &mut vk::ImageFormatProperties2KHR<'_>,
     ) -> VkResult<()> {
         (self.fp.get_physical_device_image_format_properties2_khr)(
             physical_device,
@@ -64,7 +64,7 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_memory_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        memory_properties: &mut vk::PhysicalDeviceMemoryProperties2KHR,
+        memory_properties: &mut vk::PhysicalDeviceMemoryProperties2KHR<'_>,
     ) {
         (self.fp.get_physical_device_memory_properties2_khr)(physical_device, memory_properties);
     }
@@ -74,7 +74,7 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        properties: &mut vk::PhysicalDeviceProperties2KHR,
+        properties: &mut vk::PhysicalDeviceProperties2KHR<'_>,
     ) {
         (self.fp.get_physical_device_properties2_khr)(physical_device, properties);
     }
@@ -102,7 +102,7 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_queue_family_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        out: &mut [vk::QueueFamilyProperties2KHR],
+        out: &mut [vk::QueueFamilyProperties2KHR<'_>],
     ) {
         let mut count = out.len() as u32;
         (self.fp.get_physical_device_queue_family_properties2_khr)(
@@ -118,7 +118,7 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_sparse_image_format_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
-        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR,
+        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR<'_>,
     ) -> usize {
         let mut count = 0;
         (self
@@ -140,8 +140,8 @@ impl GetPhysicalDeviceProperties2 {
     pub unsafe fn get_physical_device_sparse_image_format_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR,
-        out: &mut [vk::SparseImageFormatProperties2KHR],
+        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR<'_>,
+        out: &mut [vk::SparseImageFormatProperties2KHR<'_>],
     ) {
         let mut count = out.len() as u32;
         (self

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -23,8 +23,8 @@ impl GetSurfaceCapabilities2 {
     pub unsafe fn get_physical_device_surface_capabilities2(
         &self,
         physical_device: vk::PhysicalDevice,
-        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
-        surface_capabilities: &mut vk::SurfaceCapabilities2KHR,
+        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
+        surface_capabilities: &mut vk::SurfaceCapabilities2KHR<'_>,
     ) -> VkResult<()> {
         (self.fp.get_physical_device_surface_capabilities2_khr)(
             physical_device,
@@ -39,7 +39,7 @@ impl GetSurfaceCapabilities2 {
     pub unsafe fn get_physical_device_surface_formats2_len(
         &self,
         physical_device: vk::PhysicalDevice,
-        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
+        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
     ) -> VkResult<usize> {
         let mut count = 0;
         let err_code = (self.fp.get_physical_device_surface_formats2_khr)(
@@ -59,8 +59,8 @@ impl GetSurfaceCapabilities2 {
     pub unsafe fn get_physical_device_surface_formats2(
         &self,
         physical_device: vk::PhysicalDevice,
-        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
-        out: &mut [vk::SurfaceFormat2KHR],
+        surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR<'_>,
+        out: &mut [vk::SurfaceFormat2KHR<'_>],
     ) -> VkResult<()> {
         let mut count = out.len() as u32;
         let err_code = (self.fp.get_physical_device_surface_formats2_khr)(

--- a/ash/src/extensions/khr/maintenance3.rs
+++ b/ash/src/extensions/khr/maintenance3.rs
@@ -23,8 +23,8 @@ impl Maintenance3 {
     #[inline]
     pub unsafe fn get_descriptor_set_layout_support(
         &self,
-        create_info: &vk::DescriptorSetLayoutCreateInfo,
-        out: &mut vk::DescriptorSetLayoutSupportKHR,
+        create_info: &vk::DescriptorSetLayoutCreateInfo<'_>,
+        out: &mut vk::DescriptorSetLayoutSupportKHR<'_>,
     ) {
         (self.fp.get_descriptor_set_layout_support_khr)(self.handle, create_info, out);
     }

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -23,8 +23,8 @@ impl Maintenance4 {
     #[inline]
     pub unsafe fn get_device_buffer_memory_requirements(
         &self,
-        memory_requirements: &vk::DeviceBufferMemoryRequirementsKHR,
-        out: &mut vk::MemoryRequirements2,
+        memory_requirements: &vk::DeviceBufferMemoryRequirementsKHR<'_>,
+        out: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.fp.get_device_buffer_memory_requirements_khr)(self.handle, memory_requirements, out)
     }
@@ -33,8 +33,8 @@ impl Maintenance4 {
     #[inline]
     pub unsafe fn get_device_image_memory_requirements(
         &self,
-        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR,
-        out: &mut vk::MemoryRequirements2,
+        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR<'_>,
+        out: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.fp.get_device_image_memory_requirements_khr)(self.handle, memory_requirements, out)
     }
@@ -43,7 +43,7 @@ impl Maintenance4 {
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements_len(
         &self,
-        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR,
+        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR<'_>,
     ) -> usize {
         let mut count = 0;
         (self.fp.get_device_image_sparse_memory_requirements_khr)(
@@ -62,8 +62,8 @@ impl Maintenance4 {
     #[inline]
     pub unsafe fn get_device_image_sparse_memory_requirements(
         &self,
-        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR,
-        out: &mut [vk::SparseImageMemoryRequirements2],
+        memory_requirements: &vk::DeviceImageMemoryRequirementsKHR<'_>,
+        out: &mut [vk::SparseImageMemoryRequirements2<'_>],
     ) {
         let mut count = out.len() as u32;
         (self.fp.get_device_image_sparse_memory_requirements_khr)(

--- a/ash/src/extensions/khr/maintenance5.rs
+++ b/ash/src/extensions/khr/maintenance5.rs
@@ -38,7 +38,7 @@ impl Maintenance5 {
     #[inline]
     pub unsafe fn get_rendering_area_granularity(
         &self,
-        rendering_area_info: &vk::RenderingAreaInfoKHR,
+        rendering_area_info: &vk::RenderingAreaInfoKHR<'_>,
     ) -> vk::Extent2D {
         let mut granularity = mem::zeroed();
         (self.fp.get_rendering_area_granularity_khr)(
@@ -53,8 +53,8 @@ impl Maintenance5 {
     #[inline]
     pub unsafe fn get_device_image_subresource_layout(
         &self,
-        info: &vk::DeviceImageSubresourceInfoKHR,
-        layout: &mut vk::SubresourceLayout2KHR,
+        info: &vk::DeviceImageSubresourceInfoKHR<'_>,
+        layout: &mut vk::SubresourceLayout2KHR<'_>,
     ) {
         (self.fp.get_device_image_subresource_layout_khr)(self.handle, info, layout)
     }
@@ -73,8 +73,8 @@ impl Maintenance5 {
     pub unsafe fn get_image_subresource_layout2(
         &self,
         image: vk::Image,
-        subresource: &vk::ImageSubresource2KHR,
-        layout: &mut vk::SubresourceLayout2KHR,
+        subresource: &vk::ImageSubresource2KHR<'_>,
+        layout: &mut vk::SubresourceLayout2KHR<'_>,
     ) {
         (self.fp.get_image_subresource_layout2_khr)(self.handle, image, subresource, layout)
     }

--- a/ash/src/extensions/khr/performance_query.rs
+++ b/ash/src/extensions/khr/performance_query.rs
@@ -50,8 +50,8 @@ impl PerformanceQuery {
         &self,
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
-        out_counters: &mut [vk::PerformanceCounterKHR],
-        out_counter_descriptions: &mut [vk::PerformanceCounterDescriptionKHR],
+        out_counters: &mut [vk::PerformanceCounterKHR<'_>],
+        out_counter_descriptions: &mut [vk::PerformanceCounterDescriptionKHR<'_>],
     ) -> VkResult<()> {
         assert_eq!(out_counters.len(), out_counter_descriptions.len());
         let mut count = out_counters.len() as u32;
@@ -75,7 +75,7 @@ impl PerformanceQuery {
     pub unsafe fn get_physical_device_queue_family_performance_query_passes(
         &self,
         physical_device: vk::PhysicalDevice,
-        performance_query_create_info: &vk::QueryPoolPerformanceCreateInfoKHR,
+        performance_query_create_info: &vk::QueryPoolPerformanceCreateInfoKHR<'_>,
     ) -> u32 {
         let mut num_passes = 0;
         (self
@@ -93,7 +93,7 @@ impl PerformanceQuery {
     pub unsafe fn acquire_profiling_lock(
         &self,
         device: vk::Device,
-        info: &vk::AcquireProfilingLockInfoKHR,
+        info: &vk::AcquireProfilingLockInfoKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.acquire_profiling_lock_khr)(device, info).result()
     }

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -24,7 +24,7 @@ impl PipelineExecutableProperties {
     pub unsafe fn get_pipeline_executable_internal_representations(
         &self,
         executable_info: &vk::PipelineExecutableInfoKHR<'_>,
-    ) -> VkResult<Vec<vk::PipelineExecutableInternalRepresentationKHR>> {
+    ) -> VkResult<Vec<vk::PipelineExecutableInternalRepresentationKHR<'_>>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_pipeline_executable_internal_representations_khr)(
                 self.handle,
@@ -40,7 +40,7 @@ impl PipelineExecutableProperties {
     pub unsafe fn get_pipeline_executable_properties(
         &self,
         pipeline_info: &vk::PipelineInfoKHR<'_>,
-    ) -> VkResult<Vec<vk::PipelineExecutablePropertiesKHR>> {
+    ) -> VkResult<Vec<vk::PipelineExecutablePropertiesKHR<'_>>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_pipeline_executable_properties_khr)(
                 self.handle,
@@ -56,7 +56,7 @@ impl PipelineExecutableProperties {
     pub unsafe fn get_pipeline_executable_statistics(
         &self,
         executable_info: &vk::PipelineExecutableInfoKHR<'_>,
-    ) -> VkResult<Vec<vk::PipelineExecutableStatisticKHR>> {
+    ) -> VkResult<Vec<vk::PipelineExecutableStatisticKHR<'_>>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_pipeline_executable_statistics_khr)(
                 self.handle,

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -23,7 +23,7 @@ impl PipelineExecutableProperties {
     #[inline]
     pub unsafe fn get_pipeline_executable_internal_representations(
         &self,
-        executable_info: &vk::PipelineExecutableInfoKHR,
+        executable_info: &vk::PipelineExecutableInfoKHR<'_>,
     ) -> VkResult<Vec<vk::PipelineExecutableInternalRepresentationKHR>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_pipeline_executable_internal_representations_khr)(
@@ -39,7 +39,7 @@ impl PipelineExecutableProperties {
     #[inline]
     pub unsafe fn get_pipeline_executable_properties(
         &self,
-        pipeline_info: &vk::PipelineInfoKHR,
+        pipeline_info: &vk::PipelineInfoKHR<'_>,
     ) -> VkResult<Vec<vk::PipelineExecutablePropertiesKHR>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_pipeline_executable_properties_khr)(
@@ -55,7 +55,7 @@ impl PipelineExecutableProperties {
     #[inline]
     pub unsafe fn get_pipeline_executable_statistics(
         &self,
-        executable_info: &vk::PipelineExecutableInfoKHR,
+        executable_info: &vk::PipelineExecutableInfoKHR<'_>,
     ) -> VkResult<Vec<vk::PipelineExecutableStatisticKHR>> {
         read_into_defaulted_vector(|count, data| {
             (self.fp.get_pipeline_executable_statistics_khr)(

--- a/ash/src/extensions/khr/push_descriptor.rs
+++ b/ash/src/extensions/khr/push_descriptor.rs
@@ -25,7 +25,7 @@ impl PushDescriptor {
         pipeline_bind_point: vk::PipelineBindPoint,
         layout: vk::PipelineLayout,
         set: u32,
-        descriptor_writes: &[vk::WriteDescriptorSet],
+        descriptor_writes: &[vk::WriteDescriptorSet<'_>],
     ) {
         (self.fp.cmd_push_descriptor_set_khr)(
             command_buffer,

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -25,10 +25,10 @@ impl RayTracingPipeline {
     pub unsafe fn cmd_trace_rays(
         &self,
         command_buffer: vk::CommandBuffer,
-        raygen_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
-        miss_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
-        hit_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
-        callable_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
+        raygen_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
+        miss_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
+        hit_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
+        callable_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
         width: u32,
         height: u32,
         depth: u32,
@@ -51,8 +51,8 @@ impl RayTracingPipeline {
         &self,
         deferred_operation: vk::DeferredOperationKHR,
         pipeline_cache: vk::PipelineCache,
-        create_info: &[vk::RayTracingPipelineCreateInfoKHR],
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &[vk::RayTracingPipelineCreateInfoKHR<'_>],
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
         (self.fp.create_ray_tracing_pipelines_khr)(
@@ -122,10 +122,10 @@ impl RayTracingPipeline {
     pub unsafe fn cmd_trace_rays_indirect(
         &self,
         command_buffer: vk::CommandBuffer,
-        raygen_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
-        miss_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
-        hit_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
-        callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
+        raygen_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
+        miss_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
+        hit_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
+        callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
         indirect_device_address: vk::DeviceAddress,
     ) {
         (self.fp.cmd_trace_rays_indirect_khr)(

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -25,10 +25,10 @@ impl RayTracingPipeline {
     pub unsafe fn cmd_trace_rays(
         &self,
         command_buffer: vk::CommandBuffer,
-        raygen_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
-        miss_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
-        hit_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
-        callable_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR<'_>,
+        raygen_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
+        miss_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
+        hit_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
+        callable_shader_binding_tables: &vk::StridedDeviceAddressRegionKHR,
         width: u32,
         height: u32,
         depth: u32,
@@ -122,10 +122,10 @@ impl RayTracingPipeline {
     pub unsafe fn cmd_trace_rays_indirect(
         &self,
         command_buffer: vk::CommandBuffer,
-        raygen_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
-        miss_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
-        hit_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
-        callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR<'_>],
+        raygen_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
+        miss_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
+        hit_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
+        callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
         indirect_device_address: vk::DeviceAddress,
     ) {
         (self.fp.cmd_trace_rays_indirect_khr)(

--- a/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
+++ b/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
@@ -25,8 +25,8 @@ impl SamplerYcbcrConversion {
     #[inline]
     pub unsafe fn create_sampler_ycbcr_conversion(
         &self,
-        create_info: &vk::SamplerYcbcrConversionCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::SamplerYcbcrConversionCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
         let mut ycbcr_conversion = mem::zeroed();
         (self.fp.create_sampler_ycbcr_conversion_khr)(
@@ -43,7 +43,7 @@ impl SamplerYcbcrConversion {
     pub unsafe fn destroy_sampler_ycbcr_conversion(
         &self,
         ycbcr_conversion: vk::SamplerYcbcrConversion,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_sampler_ycbcr_conversion_khr)(
             self.handle,

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -88,7 +88,7 @@ impl Surface {
     pub unsafe fn destroy_surface(
         &self,
         surface: vk::SurfaceKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_surface_khr)(self.handle, surface, allocation_callbacks.as_raw_ptr());
     }

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -26,8 +26,8 @@ impl Swapchain {
     #[inline]
     pub unsafe fn create_swapchain(
         &self,
-        create_info: &vk::SwapchainCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::SwapchainCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SwapchainKHR> {
         let mut swapchain = mem::zeroed();
         (self.fp.create_swapchain_khr)(
@@ -44,7 +44,7 @@ impl Swapchain {
     pub unsafe fn destroy_swapchain(
         &self,
         swapchain: vk::SwapchainKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_swapchain_khr)(self.handle, swapchain, allocation_callbacks.as_raw_ptr());
     }
@@ -94,7 +94,7 @@ impl Swapchain {
     pub unsafe fn queue_present(
         &self,
         queue: vk::Queue,
-        present_info: &vk::PresentInfoKHR,
+        present_info: &vk::PresentInfoKHR<'_>,
     ) -> VkResult<bool> {
         let err_code = (self.fp.queue_present_khr)(queue, present_info);
         match err_code {
@@ -116,7 +116,7 @@ impl Swapchain {
     #[inline]
     pub unsafe fn get_device_group_present_capabilities(
         &self,
-        device_group_present_capabilities: &mut vk::DeviceGroupPresentCapabilitiesKHR,
+        device_group_present_capabilities: &mut vk::DeviceGroupPresentCapabilitiesKHR<'_>,
     ) -> VkResult<()> {
         (self.fp.get_device_group_present_capabilities_khr)(
             self.handle,
@@ -183,7 +183,7 @@ impl Swapchain {
     #[inline]
     pub unsafe fn acquire_next_image2(
         &self,
-        acquire_info: &vk::AcquireNextImageInfoKHR,
+        acquire_info: &vk::AcquireNextImageInfoKHR<'_>,
     ) -> VkResult<(u32, bool)> {
         let mut index = 0;
         let err_code = (self.fp.acquire_next_image2_khr)(self.handle, acquire_info, &mut index);

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -54,7 +54,7 @@ impl Synchronization2 {
     pub unsafe fn cmd_wait_events2(
         &self,
         command_buffer: vk::CommandBuffer,
-        events: &[vk::Event<'_>],
+        events: &[vk::Event],
         dependency_infos: &[vk::DependencyInfoKHR<'_>],
     ) {
         assert_eq!(events.len(), dependency_infos.len());

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -22,7 +22,7 @@ impl Synchronization2 {
     pub unsafe fn cmd_pipeline_barrier2(
         &self,
         command_buffer: vk::CommandBuffer,
-        dependency_info: &vk::DependencyInfoKHR,
+        dependency_info: &vk::DependencyInfoKHR<'_>,
     ) {
         (self.fp.cmd_pipeline_barrier2_khr)(command_buffer, dependency_info)
     }
@@ -44,7 +44,7 @@ impl Synchronization2 {
         &self,
         command_buffer: vk::CommandBuffer,
         event: vk::Event,
-        dependency_info: &vk::DependencyInfoKHR,
+        dependency_info: &vk::DependencyInfoKHR<'_>,
     ) {
         (self.fp.cmd_set_event2_khr)(command_buffer, event, dependency_info)
     }
@@ -54,8 +54,8 @@ impl Synchronization2 {
     pub unsafe fn cmd_wait_events2(
         &self,
         command_buffer: vk::CommandBuffer,
-        events: &[vk::Event],
-        dependency_infos: &[vk::DependencyInfoKHR],
+        events: &[vk::Event<'_>],
+        dependency_infos: &[vk::DependencyInfoKHR<'_>],
     ) {
         assert_eq!(events.len(), dependency_infos.len());
         (self.fp.cmd_wait_events2_khr)(
@@ -83,7 +83,7 @@ impl Synchronization2 {
     pub unsafe fn queue_submit2(
         &self,
         queue: vk::Queue,
-        submits: &[vk::SubmitInfo2KHR],
+        submits: &[vk::SubmitInfo2KHR<'_>],
         fence: vk::Fence,
     ) -> VkResult<()> {
         (self.fp.queue_submit2_khr)(queue, submits.len() as u32, submits.as_ptr(), fence).result()

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -31,7 +31,7 @@ impl TimelineSemaphore {
     #[inline]
     pub unsafe fn wait_semaphores(
         &self,
-        wait_info: &vk::SemaphoreWaitInfo,
+        wait_info: &vk::SemaphoreWaitInfo<'_>,
         timeout: u64,
     ) -> VkResult<()> {
         (self.fp.wait_semaphores_khr)(self.handle, wait_info, timeout).result()
@@ -39,7 +39,10 @@ impl TimelineSemaphore {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSignalSemaphore.html>
     #[inline]
-    pub unsafe fn signal_semaphore(&self, signal_info: &vk::SemaphoreSignalInfo) -> VkResult<()> {
+    pub unsafe fn signal_semaphore(
+        &self,
+        signal_info: &vk::SemaphoreSignalInfo<'_>,
+    ) -> VkResult<()> {
         (self.fp.signal_semaphore_khr)(self.handle, signal_info).result()
     }
 

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -24,8 +24,8 @@ impl WaylandSurface {
     #[inline]
     pub unsafe fn create_wayland_surface(
         &self,
-        create_info: &vk::WaylandSurfaceCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::WaylandSurfaceCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_wayland_surface_khr)(
@@ -43,7 +43,7 @@ impl WaylandSurface {
         &self,
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
-        wl_display: &mut vk::wl_display,
+        wl_display: &mut vk::wl_display<'_>,
     ) -> bool {
         let b = (self.fp.get_physical_device_wayland_presentation_support_khr)(
             physical_device,

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -43,7 +43,7 @@ impl WaylandSurface {
         &self,
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
-        wl_display: &mut vk::wl_display<'_>,
+        wl_display: &mut vk::wl_display,
     ) -> bool {
         let b = (self.fp.get_physical_device_wayland_presentation_support_khr)(
             physical_device,

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -24,8 +24,8 @@ impl Win32Surface {
     #[inline]
     pub unsafe fn create_win32_surface(
         &self,
-        create_info: &vk::Win32SurfaceCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::Win32SurfaceCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_win32_surface_khr)(

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -43,7 +43,7 @@ impl XcbSurface {
         &self,
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
-        connection: &mut vk::xcb_connection_t<'_>,
+        connection: &mut vk::xcb_connection_t,
         visual_id: vk::xcb_visualid_t,
     ) -> bool {
         let b = (self.fp.get_physical_device_xcb_presentation_support_khr)(

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -24,8 +24,8 @@ impl XcbSurface {
     #[inline]
     pub unsafe fn create_xcb_surface(
         &self,
-        create_info: &vk::XcbSurfaceCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::XcbSurfaceCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_xcb_surface_khr)(
@@ -43,7 +43,7 @@ impl XcbSurface {
         &self,
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
-        connection: &mut vk::xcb_connection_t,
+        connection: &mut vk::xcb_connection_t<'_>,
         visual_id: vk::xcb_visualid_t,
     ) -> bool {
         let b = (self.fp.get_physical_device_xcb_presentation_support_khr)(

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -24,8 +24,8 @@ impl XlibSurface {
     #[inline]
     pub unsafe fn create_xlib_surface(
         &self,
-        create_info: &vk::XlibSurfaceCreateInfoKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::XlibSurfaceCreateInfoKHR<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_xlib_surface_khr)(

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -24,8 +24,8 @@ impl IOSSurface {
     #[inline]
     pub unsafe fn create_ios_surface(
         &self,
-        create_info: &vk::IOSSurfaceCreateInfoMVK,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::IOSSurfaceCreateInfoMVK<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_ios_surface_mvk)(

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -24,8 +24,8 @@ impl MacOSSurface {
     #[inline]
     pub unsafe fn create_mac_os_surface(
         &self,
-        create_info: &vk::MacOSSurfaceCreateInfoMVK,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::MacOSSurfaceCreateInfoMVK<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_mac_os_surface_mvk)(

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -24,8 +24,8 @@ impl ViSurface {
     #[inline]
     pub unsafe fn create_vi_surface(
         &self,
-        create_info: &vk::ViSurfaceCreateInfoNN,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::ViSurfaceCreateInfoNN<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
         (self.fp.create_vi_surface_nn)(

--- a/ash/src/extensions/nv/coverage_reduction_mode.rs
+++ b/ash/src/extensions/nv/coverage_reduction_mode.rs
@@ -43,7 +43,7 @@ impl CoverageReductionMode {
     pub unsafe fn get_physical_device_supported_framebuffer_mixed_samples_combinations(
         &self,
         physical_device: vk::PhysicalDevice,
-        out: &mut [vk::FramebufferMixedSamplesCombinationNV],
+        out: &mut [vk::FramebufferMixedSamplesCombinationNV<'_>],
     ) -> VkResult<()> {
         let mut count = out.len() as u32;
         (self

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -44,7 +44,7 @@ impl DeviceDiagnosticCheckpoints {
     pub unsafe fn get_queue_checkpoint_data(
         &self,
         queue: vk::Queue,
-        out: &mut [vk::CheckpointDataNV],
+        out: &mut [vk::CheckpointDataNV<'_>],
     ) {
         let mut count = out.len() as u32;
         (self.fp.get_queue_checkpoint_data_nv)(queue, &mut count, out.as_mut_ptr());

--- a/ash/src/extensions/nv/device_generated_commands_compute.rs
+++ b/ash/src/extensions/nv/device_generated_commands_compute.rs
@@ -23,8 +23,8 @@ impl DeviceGeneratedCommandsCompute {
     #[inline]
     pub unsafe fn get_pipeline_indirect_memory_requirements(
         &self,
-        create_info: &vk::ComputePipelineCreateInfo,
-        memory_requirements: &mut vk::MemoryRequirements2,
+        create_info: &vk::ComputePipelineCreateInfo<'_>,
+        memory_requirements: &mut vk::MemoryRequirements2<'_>,
     ) {
         (self.fp.get_pipeline_indirect_memory_requirements_nv)(
             self.handle,
@@ -52,7 +52,7 @@ impl DeviceGeneratedCommandsCompute {
     #[inline]
     pub unsafe fn get_pipeline_indirect_device_address(
         &self,
-        info: &vk::PipelineIndirectDeviceAddressInfoNV,
+        info: &vk::PipelineIndirectDeviceAddressInfoNV<'_>,
     ) -> vk::DeviceAddress {
         (self.fp.get_pipeline_indirect_device_address_nv)(self.handle, info)
     }

--- a/ash/src/extensions/nv/memory_decompression.rs
+++ b/ash/src/extensions/nv/memory_decompression.rs
@@ -20,7 +20,7 @@ impl MemoryDecompression {
     pub unsafe fn cmd_decompress_memory(
         &self,
         command_buffer: vk::CommandBuffer,
-        decompress_memory_regions: &[vk::DecompressMemoryRegionNV],
+        decompress_memory_regions: &[vk::DecompressMemoryRegionNV<'_>],
     ) {
         (self.fp.cmd_decompress_memory_nv)(
             command_buffer,

--- a/ash/src/extensions/nv/memory_decompression.rs
+++ b/ash/src/extensions/nv/memory_decompression.rs
@@ -20,7 +20,7 @@ impl MemoryDecompression {
     pub unsafe fn cmd_decompress_memory(
         &self,
         command_buffer: vk::CommandBuffer,
-        decompress_memory_regions: &[vk::DecompressMemoryRegionNV<'_>],
+        decompress_memory_regions: &[vk::DecompressMemoryRegionNV],
     ) {
         (self.fp.cmd_decompress_memory_nv)(
             command_buffer,

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -220,7 +220,7 @@ impl RayTracing {
     pub unsafe fn cmd_write_acceleration_structures_properties(
         &self,
         command_buffer: vk::CommandBuffer,
-        structures: &[vk::AccelerationStructureNV<'_>],
+        structures: &[vk::AccelerationStructureNV],
         query_type: vk::QueryType,
         query_pool: vk::QueryPool,
         first_query: u32,

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -56,7 +56,7 @@ impl RayTracing {
     pub unsafe fn get_acceleration_structure_memory_requirements(
         &self,
         info: &vk::AccelerationStructureMemoryRequirementsInfoNV<'_>,
-    ) -> vk::MemoryRequirements2KHR {
+    ) -> vk::MemoryRequirements2KHR<'_> {
         let mut requirements = Default::default();
         (self.fp.get_acceleration_structure_memory_requirements_nv)(
             self.handle,

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -24,8 +24,8 @@ impl RayTracing {
     #[inline]
     pub unsafe fn create_acceleration_structure(
         &self,
-        create_info: &vk::AccelerationStructureCreateInfoNV,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::AccelerationStructureCreateInfoNV<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<vk::AccelerationStructureNV> {
         let mut accel_struct = mem::zeroed();
         (self.fp.create_acceleration_structure_nv)(
@@ -42,7 +42,7 @@ impl RayTracing {
     pub unsafe fn destroy_acceleration_structure(
         &self,
         accel_struct: vk::AccelerationStructureNV,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) {
         (self.fp.destroy_acceleration_structure_nv)(
             self.handle,
@@ -55,7 +55,7 @@ impl RayTracing {
     #[inline]
     pub unsafe fn get_acceleration_structure_memory_requirements(
         &self,
-        info: &vk::AccelerationStructureMemoryRequirementsInfoNV,
+        info: &vk::AccelerationStructureMemoryRequirementsInfoNV<'_>,
     ) -> vk::MemoryRequirements2KHR {
         let mut requirements = Default::default();
         (self.fp.get_acceleration_structure_memory_requirements_nv)(
@@ -70,7 +70,7 @@ impl RayTracing {
     #[inline]
     pub unsafe fn bind_acceleration_structure_memory(
         &self,
-        bind_info: &[vk::BindAccelerationStructureMemoryInfoNV],
+        bind_info: &[vk::BindAccelerationStructureMemoryInfoNV<'_>],
     ) -> VkResult<()> {
         (self.fp.bind_acceleration_structure_memory_nv)(
             self.handle,
@@ -85,7 +85,7 @@ impl RayTracing {
     pub unsafe fn cmd_build_acceleration_structure(
         &self,
         command_buffer: vk::CommandBuffer,
-        info: &vk::AccelerationStructureInfoNV,
+        info: &vk::AccelerationStructureInfoNV<'_>,
         instance_data: vk::Buffer,
         instance_offset: vk::DeviceSize,
         update: bool,
@@ -163,8 +163,8 @@ impl RayTracing {
     pub unsafe fn create_ray_tracing_pipelines(
         &self,
         pipeline_cache: vk::PipelineCache,
-        create_info: &[vk::RayTracingPipelineCreateInfoNV],
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &[vk::RayTracingPipelineCreateInfoNV<'_>],
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
         (self.fp.create_ray_tracing_pipelines_nv)(
@@ -220,7 +220,7 @@ impl RayTracing {
     pub unsafe fn cmd_write_acceleration_structures_properties(
         &self,
         command_buffer: vk::CommandBuffer,
-        structures: &[vk::AccelerationStructureNV],
+        structures: &[vk::AccelerationStructureNV<'_>],
         query_type: vk::QueryType,
         query_pool: vk::QueryPool,
         first_query: u32,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -84,7 +84,7 @@ impl Instance {
     pub unsafe fn get_physical_device_tool_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-        out: &mut [vk::PhysicalDeviceToolProperties],
+        out: &mut [vk::PhysicalDeviceToolProperties<'_>],
     ) -> VkResult<()> {
         let mut count = out.len() as u32;
         (self.instance_fn_1_3.get_physical_device_tool_properties)(
@@ -124,7 +124,7 @@ impl Instance {
     #[inline]
     pub unsafe fn enumerate_physical_device_groups(
         &self,
-        out: &mut [vk::PhysicalDeviceGroupProperties],
+        out: &mut [vk::PhysicalDeviceGroupProperties<'_>],
     ) -> VkResult<()> {
         let mut count = out.len() as u32;
         (self.instance_fn_1_1.enumerate_physical_device_groups)(
@@ -142,7 +142,7 @@ impl Instance {
     pub unsafe fn get_physical_device_features2(
         &self,
         physical_device: vk::PhysicalDevice,
-        features: &mut vk::PhysicalDeviceFeatures2,
+        features: &mut vk::PhysicalDeviceFeatures2<'_>,
     ) {
         (self.instance_fn_1_1.get_physical_device_features2)(physical_device, features);
     }
@@ -152,7 +152,7 @@ impl Instance {
     pub unsafe fn get_physical_device_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        prop: &mut vk::PhysicalDeviceProperties2,
+        prop: &mut vk::PhysicalDeviceProperties2<'_>,
     ) {
         (self.instance_fn_1_1.get_physical_device_properties2)(physical_device, prop);
     }
@@ -163,7 +163,7 @@ impl Instance {
         &self,
         physical_device: vk::PhysicalDevice,
         format: vk::Format,
-        out: &mut vk::FormatProperties2,
+        out: &mut vk::FormatProperties2<'_>,
     ) {
         (self.instance_fn_1_1.get_physical_device_format_properties2)(physical_device, format, out);
     }
@@ -173,8 +173,8 @@ impl Instance {
     pub unsafe fn get_physical_device_image_format_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        format_info: &vk::PhysicalDeviceImageFormatInfo2,
-        image_format_prop: &mut vk::ImageFormatProperties2,
+        format_info: &vk::PhysicalDeviceImageFormatInfo2<'_>,
+        image_format_prop: &mut vk::ImageFormatProperties2<'_>,
     ) -> VkResult<()> {
         (self
             .instance_fn_1_1
@@ -211,7 +211,7 @@ impl Instance {
     pub unsafe fn get_physical_device_queue_family_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        out: &mut [vk::QueueFamilyProperties2],
+        out: &mut [vk::QueueFamilyProperties2<'_>],
     ) {
         let mut count = out.len() as u32;
         (self
@@ -229,7 +229,7 @@ impl Instance {
     pub unsafe fn get_physical_device_memory_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        out: &mut vk::PhysicalDeviceMemoryProperties2,
+        out: &mut vk::PhysicalDeviceMemoryProperties2<'_>,
     ) {
         (self.instance_fn_1_1.get_physical_device_memory_properties2)(physical_device, out);
     }
@@ -239,7 +239,7 @@ impl Instance {
     pub unsafe fn get_physical_device_sparse_image_format_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
-        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2,
+        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2<'_>,
     ) -> usize {
         let mut format_count = 0;
         (self
@@ -261,8 +261,8 @@ impl Instance {
     pub unsafe fn get_physical_device_sparse_image_format_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2,
-        out: &mut [vk::SparseImageFormatProperties2],
+        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2<'_>,
+        out: &mut [vk::SparseImageFormatProperties2<'_>],
     ) {
         let mut count = out.len() as u32;
         (self
@@ -281,8 +281,8 @@ impl Instance {
     pub unsafe fn get_physical_device_external_buffer_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-        external_buffer_info: &vk::PhysicalDeviceExternalBufferInfo,
-        out: &mut vk::ExternalBufferProperties,
+        external_buffer_info: &vk::PhysicalDeviceExternalBufferInfo<'_>,
+        out: &mut vk::ExternalBufferProperties<'_>,
     ) {
         (self
             .instance_fn_1_1
@@ -298,8 +298,8 @@ impl Instance {
     pub unsafe fn get_physical_device_external_fence_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-        external_fence_info: &vk::PhysicalDeviceExternalFenceInfo,
-        out: &mut vk::ExternalFenceProperties,
+        external_fence_info: &vk::PhysicalDeviceExternalFenceInfo<'_>,
+        out: &mut vk::ExternalFenceProperties<'_>,
     ) {
         (self
             .instance_fn_1_1
@@ -315,8 +315,8 @@ impl Instance {
     pub unsafe fn get_physical_device_external_semaphore_properties(
         &self,
         physical_device: vk::PhysicalDevice,
-        external_semaphore_info: &vk::PhysicalDeviceExternalSemaphoreInfo,
-        out: &mut vk::ExternalSemaphoreProperties,
+        external_semaphore_info: &vk::PhysicalDeviceExternalSemaphoreInfo<'_>,
+        out: &mut vk::ExternalSemaphoreProperties<'_>,
     ) {
         (self
             .instance_fn_1_1
@@ -353,8 +353,8 @@ impl Instance {
     pub unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,
-        create_info: &vk::DeviceCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+        create_info: &vk::DeviceCreateInfo<'_>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Device> {
         let mut device = mem::zeroed();
         (self.instance_fn_1_0.create_device)(
@@ -379,7 +379,10 @@ impl Instance {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyInstance.html>
     #[inline]
-    pub unsafe fn destroy_instance(&self, allocation_callbacks: Option<&vk::AllocationCallbacks>) {
+    pub unsafe fn destroy_instance(
+        &self,
+        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+    ) {
         (self.instance_fn_1_0.destroy_instance)(self.handle(), allocation_callbacks.as_raw_ptr());
     }
 

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -1,5 +1,11 @@
-#![deny(clippy::use_self)]
-#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(
+    clippy::use_self,
+    deprecated_in_future,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
 #![allow(
     clippy::too_many_arguments,
     clippy::missing_safety_doc,
@@ -187,7 +193,7 @@ mod tests {
         let mut device_create_info = vk::DeviceCreateInfo::default()
             .push_next(&mut corner)
             .push_next(&mut variable_pointers);
-        let chain2: Vec<*mut vk::BaseOutStructure> = unsafe {
+        let chain2: Vec<*mut vk::BaseOutStructure<'_>> = unsafe {
             vk::ptr_chain_iter(&mut device_create_info)
                 .skip(1)
                 .collect()

--- a/ash/src/prelude.rs
+++ b/ash/src/prelude.rs
@@ -93,7 +93,7 @@ where
 
 #[cfg(feature = "debug")]
 pub(crate) fn debug_flags<Value: Into<u64> + Copy>(
-    f: &mut fmt::Formatter,
+    f: &mut fmt::Formatter<'_>,
     known: &[(Value, &'static str)],
     value: Value,
 ) -> fmt::Result {

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -21,7 +21,7 @@ pub struct Align<T> {
 }
 
 #[derive(Debug)]
-pub struct AlignIter<'a, T: 'a> {
+pub struct AlignIter<'a, T> {
     align: &'a mut Align<T>,
     current: vk::DeviceSize,
 }
@@ -59,7 +59,7 @@ impl<T> Align<T> {
         }
     }
 
-    pub fn iter_mut(&mut self) -> AlignIter<T> {
+    pub fn iter_mut(&mut self) -> AlignIter<'_, T> {
         AlignIter {
             current: 0,
             align: self,
@@ -113,7 +113,7 @@ pub fn read_spv<R: io::Read + io::Seek>(x: &mut R) -> io::Result<Vec<u32>> {
             "input length not divisible by 4",
         ));
     }
-    if size > usize::max_value() as u64 {
+    if size > usize::MAX as u64 {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "input too long"));
     }
     let words = (size / 4) as usize;

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -33,8 +33,10 @@ mod platform_types;
 pub use platform_types::*;
 /// Iterates through the pointer chain. Includes the item that is passed into the function.
 /// Stops at the last [`BaseOutStructure`] that has a null [`BaseOutStructure::p_next`] field.
-pub(crate) unsafe fn ptr_chain_iter<T>(ptr: &mut T) -> impl Iterator<Item = *mut BaseOutStructure> {
-    let ptr = <*mut T>::cast::<BaseOutStructure>(ptr);
+pub(crate) unsafe fn ptr_chain_iter<T>(
+    ptr: &mut T,
+) -> impl Iterator<Item = *mut BaseOutStructure<'_>> {
+    let ptr = <*mut T>::cast::<BaseOutStructure<'_>>(ptr);
     (0..).scan(ptr, |p_ptr, _| {
         if p_ptr.is_null() {
             return None;

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -4,7 +4,7 @@ use crate::vk::definitions::*;
 use crate::vk::enums::*;
 use std::fmt;
 impl fmt::Debug for AccelerationStructureBuildTypeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::HOST => Some("HOST"),
             Self::DEVICE => Some("DEVICE"),
@@ -19,7 +19,7 @@ impl fmt::Debug for AccelerationStructureBuildTypeKHR {
     }
 }
 impl fmt::Debug for AccelerationStructureCompatibilityKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::COMPATIBLE => Some("COMPATIBLE"),
             Self::INCOMPATIBLE => Some("INCOMPATIBLE"),
@@ -33,7 +33,7 @@ impl fmt::Debug for AccelerationStructureCompatibilityKHR {
     }
 }
 impl fmt::Debug for AccelerationStructureCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 AccelerationStructureCreateFlagsKHR::DEVICE_ADDRESS_CAPTURE_REPLAY.0,
@@ -52,7 +52,7 @@ impl fmt::Debug for AccelerationStructureCreateFlagsKHR {
     }
 }
 impl fmt::Debug for AccelerationStructureMemoryRequirementsTypeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OBJECT => Some("OBJECT"),
             Self::BUILD_SCRATCH => Some("BUILD_SCRATCH"),
@@ -67,19 +67,19 @@ impl fmt::Debug for AccelerationStructureMemoryRequirementsTypeNV {
     }
 }
 impl fmt::Debug for AccelerationStructureMotionInfoFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for AccelerationStructureMotionInstanceFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for AccelerationStructureMotionInstanceTypeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::STATIC => Some("STATIC"),
             Self::MATRIX_MOTION => Some("MATRIX_MOTION"),
@@ -94,7 +94,7 @@ impl fmt::Debug for AccelerationStructureMotionInstanceTypeNV {
     }
 }
 impl fmt::Debug for AccelerationStructureTypeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TOP_LEVEL => Some("TOP_LEVEL"),
             Self::BOTTOM_LEVEL => Some("BOTTOM_LEVEL"),
@@ -109,7 +109,7 @@ impl fmt::Debug for AccelerationStructureTypeKHR {
     }
 }
 impl fmt::Debug for AccessFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 AccessFlags::INDIRECT_COMMAND_READ.0,
@@ -199,7 +199,7 @@ impl fmt::Debug for AccessFlags {
     }
 }
 impl fmt::Debug for AccessFlags2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[
             (AccessFlags2::NONE.0, "NONE"),
             (
@@ -327,25 +327,25 @@ impl fmt::Debug for AccessFlags2 {
     }
 }
 impl fmt::Debug for AcquireProfilingLockFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for AndroidSurfaceCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for AttachmentDescriptionFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(AttachmentDescriptionFlags::MAY_ALIAS.0, "MAY_ALIAS")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for AttachmentLoadOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::LOAD => Some("LOAD"),
             Self::CLEAR => Some("CLEAR"),
@@ -361,7 +361,7 @@ impl fmt::Debug for AttachmentLoadOp {
     }
 }
 impl fmt::Debug for AttachmentStoreOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::STORE => Some("STORE"),
             Self::DONT_CARE => Some("DONT_CARE"),
@@ -376,7 +376,7 @@ impl fmt::Debug for AttachmentStoreOp {
     }
 }
 impl fmt::Debug for BlendFactor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ZERO => Some("ZERO"),
             Self::ONE => Some("ONE"),
@@ -407,7 +407,7 @@ impl fmt::Debug for BlendFactor {
     }
 }
 impl fmt::Debug for BlendOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ADD => Some("ADD"),
             Self::SUBTRACT => Some("SUBTRACT"),
@@ -470,7 +470,7 @@ impl fmt::Debug for BlendOp {
     }
 }
 impl fmt::Debug for BlendOverlapEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNCORRELATED => Some("UNCORRELATED"),
             Self::DISJOINT => Some("DISJOINT"),
@@ -485,7 +485,7 @@ impl fmt::Debug for BlendOverlapEXT {
     }
 }
 impl fmt::Debug for BlockMatchWindowCompareModeQCOM {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::MIN => Some("MIN"),
             Self::MAX => Some("MAX"),
@@ -499,7 +499,7 @@ impl fmt::Debug for BlockMatchWindowCompareModeQCOM {
     }
 }
 impl fmt::Debug for BorderColor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FLOAT_TRANSPARENT_BLACK => Some("FLOAT_TRANSPARENT_BLACK"),
             Self::INT_TRANSPARENT_BLACK => Some("INT_TRANSPARENT_BLACK"),
@@ -519,7 +519,7 @@ impl fmt::Debug for BorderColor {
     }
 }
 impl fmt::Debug for BufferCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (BufferCreateFlags::SPARSE_BINDING.0, "SPARSE_BINDING"),
             (BufferCreateFlags::SPARSE_RESIDENCY.0, "SPARSE_RESIDENCY"),
@@ -538,7 +538,7 @@ impl fmt::Debug for BufferCreateFlags {
     }
 }
 impl fmt::Debug for BufferUsageFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (BufferUsageFlags::TRANSFER_SRC.0, "TRANSFER_SRC"),
             (BufferUsageFlags::TRANSFER_DST.0, "TRANSFER_DST"),
@@ -628,7 +628,7 @@ impl fmt::Debug for BufferUsageFlags {
     }
 }
 impl fmt::Debug for BufferUsageFlags2KHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[
             (BufferUsageFlags2KHR::TRANSFER_SRC.0, "TRANSFER_SRC"),
             (BufferUsageFlags2KHR::TRANSFER_DST.0, "TRANSFER_DST"),
@@ -706,13 +706,13 @@ impl fmt::Debug for BufferUsageFlags2KHR {
     }
 }
 impl fmt::Debug for BufferViewCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for BuildAccelerationStructureFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 BuildAccelerationStructureFlagsKHR::ALLOW_UPDATE.0,
@@ -760,7 +760,7 @@ impl fmt::Debug for BuildAccelerationStructureFlagsKHR {
     }
 }
 impl fmt::Debug for BuildAccelerationStructureModeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::BUILD => Some("BUILD"),
             Self::UPDATE => Some("UPDATE"),
@@ -774,7 +774,7 @@ impl fmt::Debug for BuildAccelerationStructureModeKHR {
     }
 }
 impl fmt::Debug for BuildMicromapFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 BuildMicromapFlagsEXT::PREFER_FAST_TRACE.0,
@@ -793,7 +793,7 @@ impl fmt::Debug for BuildMicromapFlagsEXT {
     }
 }
 impl fmt::Debug for BuildMicromapModeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::BUILD => Some("BUILD"),
             _ => None,
@@ -806,7 +806,7 @@ impl fmt::Debug for BuildMicromapModeEXT {
     }
 }
 impl fmt::Debug for ChromaLocation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::COSITED_EVEN => Some("COSITED_EVEN"),
             Self::MIDPOINT => Some("MIDPOINT"),
@@ -820,7 +820,7 @@ impl fmt::Debug for ChromaLocation {
     }
 }
 impl fmt::Debug for CoarseSampleOrderTypeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEFAULT => Some("DEFAULT"),
             Self::CUSTOM => Some("CUSTOM"),
@@ -836,7 +836,7 @@ impl fmt::Debug for CoarseSampleOrderTypeNV {
     }
 }
 impl fmt::Debug for ColorComponentFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ColorComponentFlags::R.0, "R"),
             (ColorComponentFlags::G.0, "G"),
@@ -847,7 +847,7 @@ impl fmt::Debug for ColorComponentFlags {
     }
 }
 impl fmt::Debug for ColorSpaceKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::SRGB_NONLINEAR => Some("SRGB_NONLINEAR"),
             Self::DISPLAY_P3_NONLINEAR_EXT => Some("DISPLAY_P3_NONLINEAR_EXT"),
@@ -875,7 +875,7 @@ impl fmt::Debug for ColorSpaceKHR {
     }
 }
 impl fmt::Debug for CommandBufferLevel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::PRIMARY => Some("PRIMARY"),
             Self::SECONDARY => Some("SECONDARY"),
@@ -889,7 +889,7 @@ impl fmt::Debug for CommandBufferLevel {
     }
 }
 impl fmt::Debug for CommandBufferResetFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             CommandBufferResetFlags::RELEASE_RESOURCES.0,
             "RELEASE_RESOURCES",
@@ -898,7 +898,7 @@ impl fmt::Debug for CommandBufferResetFlags {
     }
 }
 impl fmt::Debug for CommandBufferUsageFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 CommandBufferUsageFlags::ONE_TIME_SUBMIT.0,
@@ -917,7 +917,7 @@ impl fmt::Debug for CommandBufferUsageFlags {
     }
 }
 impl fmt::Debug for CommandPoolCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (CommandPoolCreateFlags::TRANSIENT.0, "TRANSIENT"),
             (
@@ -930,7 +930,7 @@ impl fmt::Debug for CommandPoolCreateFlags {
     }
 }
 impl fmt::Debug for CommandPoolResetFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             CommandPoolResetFlags::RELEASE_RESOURCES.0,
             "RELEASE_RESOURCES",
@@ -939,13 +939,13 @@ impl fmt::Debug for CommandPoolResetFlags {
     }
 }
 impl fmt::Debug for CommandPoolTrimFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for CompareOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NEVER => Some("NEVER"),
             Self::LESS => Some("LESS"),
@@ -965,7 +965,7 @@ impl fmt::Debug for CompareOp {
     }
 }
 impl fmt::Debug for ComponentSwizzle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::IDENTITY => Some("IDENTITY"),
             Self::ZERO => Some("ZERO"),
@@ -984,7 +984,7 @@ impl fmt::Debug for ComponentSwizzle {
     }
 }
 impl fmt::Debug for ComponentTypeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FLOAT16 => Some("FLOAT16"),
             Self::FLOAT32 => Some("FLOAT32"),
@@ -1007,7 +1007,7 @@ impl fmt::Debug for ComponentTypeKHR {
     }
 }
 impl fmt::Debug for CompositeAlphaFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (CompositeAlphaFlagsKHR::OPAQUE.0, "OPAQUE"),
             (CompositeAlphaFlagsKHR::PRE_MULTIPLIED.0, "PRE_MULTIPLIED"),
@@ -1018,13 +1018,13 @@ impl fmt::Debug for CompositeAlphaFlagsKHR {
     }
 }
 impl fmt::Debug for ConditionalRenderingFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(ConditionalRenderingFlagsEXT::INVERTED.0, "INVERTED")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ConservativeRasterizationModeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DISABLED => Some("DISABLED"),
             Self::OVERESTIMATE => Some("OVERESTIMATE"),
@@ -1039,7 +1039,7 @@ impl fmt::Debug for ConservativeRasterizationModeEXT {
     }
 }
 impl fmt::Debug for CopyAccelerationStructureModeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::CLONE => Some("CLONE"),
             Self::COMPACT => Some("COMPACT"),
@@ -1055,7 +1055,7 @@ impl fmt::Debug for CopyAccelerationStructureModeKHR {
     }
 }
 impl fmt::Debug for CopyMicromapModeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::CLONE => Some("CLONE"),
             Self::SERIALIZE => Some("SERIALIZE"),
@@ -1071,7 +1071,7 @@ impl fmt::Debug for CopyMicromapModeEXT {
     }
 }
 impl fmt::Debug for CoverageModulationModeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NONE => Some("NONE"),
             Self::RGB => Some("RGB"),
@@ -1087,7 +1087,7 @@ impl fmt::Debug for CoverageModulationModeNV {
     }
 }
 impl fmt::Debug for CoverageReductionModeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::MERGE => Some("MERGE"),
             Self::TRUNCATE => Some("TRUNCATE"),
@@ -1101,7 +1101,7 @@ impl fmt::Debug for CoverageReductionModeNV {
     }
 }
 impl fmt::Debug for CubicFilterWeightsQCOM {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::CATMULL_ROM => Some("CATMULL_ROM"),
             Self::ZERO_TANGENT_CARDINAL => Some("ZERO_TANGENT_CARDINAL"),
@@ -1117,7 +1117,7 @@ impl fmt::Debug for CubicFilterWeightsQCOM {
     }
 }
 impl fmt::Debug for CullModeFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (CullModeFlags::NONE.0, "NONE"),
             (CullModeFlags::FRONT.0, "FRONT"),
@@ -1128,7 +1128,7 @@ impl fmt::Debug for CullModeFlags {
     }
 }
 impl fmt::Debug for DebugReportFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (DebugReportFlagsEXT::INFORMATION.0, "INFORMATION"),
             (DebugReportFlagsEXT::WARNING.0, "WARNING"),
@@ -1143,7 +1143,7 @@ impl fmt::Debug for DebugReportFlagsEXT {
     }
 }
 impl fmt::Debug for DebugReportObjectTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNKNOWN => Some("UNKNOWN"),
             Self::INSTANCE => Some("INSTANCE"),
@@ -1196,7 +1196,7 @@ impl fmt::Debug for DebugReportObjectTypeEXT {
     }
 }
 impl fmt::Debug for DebugUtilsMessageSeverityFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (DebugUtilsMessageSeverityFlagsEXT::VERBOSE.0, "VERBOSE"),
             (DebugUtilsMessageSeverityFlagsEXT::INFO.0, "INFO"),
@@ -1207,7 +1207,7 @@ impl fmt::Debug for DebugUtilsMessageSeverityFlagsEXT {
     }
 }
 impl fmt::Debug for DebugUtilsMessageTypeFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (DebugUtilsMessageTypeFlagsEXT::GENERAL.0, "GENERAL"),
             (DebugUtilsMessageTypeFlagsEXT::VALIDATION.0, "VALIDATION"),
@@ -1221,19 +1221,19 @@ impl fmt::Debug for DebugUtilsMessageTypeFlagsEXT {
     }
 }
 impl fmt::Debug for DebugUtilsMessengerCallbackDataFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DebugUtilsMessengerCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DependencyFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (DependencyFlags::BY_REGION.0, "BY_REGION"),
             (DependencyFlags::FEEDBACK_LOOP_EXT.0, "FEEDBACK_LOOP_EXT"),
@@ -1244,7 +1244,7 @@ impl fmt::Debug for DependencyFlags {
     }
 }
 impl fmt::Debug for DepthBiasRepresentationEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::LEAST_REPRESENTABLE_VALUE_FORMAT => Some("LEAST_REPRESENTABLE_VALUE_FORMAT"),
             Self::LEAST_REPRESENTABLE_VALUE_FORCE_UNORM => {
@@ -1261,7 +1261,7 @@ impl fmt::Debug for DepthBiasRepresentationEXT {
     }
 }
 impl fmt::Debug for DescriptorBindingFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 DescriptorBindingFlags::UPDATE_AFTER_BIND.0,
@@ -1281,7 +1281,7 @@ impl fmt::Debug for DescriptorBindingFlags {
     }
 }
 impl fmt::Debug for DescriptorPoolCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET.0,
@@ -1305,13 +1305,13 @@ impl fmt::Debug for DescriptorPoolCreateFlags {
     }
 }
 impl fmt::Debug for DescriptorPoolResetFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DescriptorSetLayoutCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR_KHR.0,
@@ -1342,7 +1342,7 @@ impl fmt::Debug for DescriptorSetLayoutCreateFlags {
     }
 }
 impl fmt::Debug for DescriptorType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::SAMPLER => Some("SAMPLER"),
             Self::COMBINED_IMAGE_SAMPLER => Some("COMBINED_IMAGE_SAMPLER"),
@@ -1371,13 +1371,13 @@ impl fmt::Debug for DescriptorType {
     }
 }
 impl fmt::Debug for DescriptorUpdateTemplateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DescriptorUpdateTemplateType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DESCRIPTOR_SET => Some("DESCRIPTOR_SET"),
             Self::PUSH_DESCRIPTORS_KHR => Some("PUSH_DESCRIPTORS_KHR"),
@@ -1391,7 +1391,7 @@ impl fmt::Debug for DescriptorUpdateTemplateType {
     }
 }
 impl fmt::Debug for DeviceAddressBindingFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             DeviceAddressBindingFlagsEXT::INTERNAL_OBJECT.0,
             "INTERNAL_OBJECT",
@@ -1400,7 +1400,7 @@ impl fmt::Debug for DeviceAddressBindingFlagsEXT {
     }
 }
 impl fmt::Debug for DeviceAddressBindingTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::BIND => Some("BIND"),
             Self::UNBIND => Some("UNBIND"),
@@ -1414,13 +1414,13 @@ impl fmt::Debug for DeviceAddressBindingTypeEXT {
     }
 }
 impl fmt::Debug for DeviceCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DeviceDiagnosticsConfigFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 DeviceDiagnosticsConfigFlagsNV::ENABLE_SHADER_DEBUG_INFO.0,
@@ -1443,7 +1443,7 @@ impl fmt::Debug for DeviceDiagnosticsConfigFlagsNV {
     }
 }
 impl fmt::Debug for DeviceEventTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DISPLAY_HOTPLUG => Some("DISPLAY_HOTPLUG"),
             _ => None,
@@ -1456,7 +1456,7 @@ impl fmt::Debug for DeviceEventTypeEXT {
     }
 }
 impl fmt::Debug for DeviceFaultAddressTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NONE => Some("NONE"),
             Self::READ_INVALID => Some("READ_INVALID"),
@@ -1475,7 +1475,7 @@ impl fmt::Debug for DeviceFaultAddressTypeEXT {
     }
 }
 impl fmt::Debug for DeviceFaultVendorBinaryHeaderVersionEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ONE => Some("ONE"),
             _ => None,
@@ -1488,7 +1488,7 @@ impl fmt::Debug for DeviceFaultVendorBinaryHeaderVersionEXT {
     }
 }
 impl fmt::Debug for DeviceGroupPresentModeFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (DeviceGroupPresentModeFlagsKHR::LOCAL.0, "LOCAL"),
             (DeviceGroupPresentModeFlagsKHR::REMOTE.0, "REMOTE"),
@@ -1502,7 +1502,7 @@ impl fmt::Debug for DeviceGroupPresentModeFlagsKHR {
     }
 }
 impl fmt::Debug for DeviceMemoryReportEventTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ALLOCATE => Some("ALLOCATE"),
             Self::FREE => Some("FREE"),
@@ -1519,25 +1519,25 @@ impl fmt::Debug for DeviceMemoryReportEventTypeEXT {
     }
 }
 impl fmt::Debug for DeviceMemoryReportFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DeviceQueueCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(DeviceQueueCreateFlags::PROTECTED.0, "PROTECTED")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DirectDriverLoadingFlagsLUNARG {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DirectDriverLoadingModeLUNARG {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::EXCLUSIVE => Some("EXCLUSIVE"),
             Self::INCLUSIVE => Some("INCLUSIVE"),
@@ -1551,13 +1551,13 @@ impl fmt::Debug for DirectDriverLoadingModeLUNARG {
     }
 }
 impl fmt::Debug for DirectFBSurfaceCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DiscardRectangleModeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::INCLUSIVE => Some("INCLUSIVE"),
             Self::EXCLUSIVE => Some("EXCLUSIVE"),
@@ -1571,7 +1571,7 @@ impl fmt::Debug for DiscardRectangleModeEXT {
     }
 }
 impl fmt::Debug for DisplacementMicromapFormatNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TYPE_64_TRIANGLES_64_BYTES => Some("TYPE_64_TRIANGLES_64_BYTES"),
             Self::TYPE_256_TRIANGLES_128_BYTES => Some("TYPE_256_TRIANGLES_128_BYTES"),
@@ -1586,7 +1586,7 @@ impl fmt::Debug for DisplacementMicromapFormatNV {
     }
 }
 impl fmt::Debug for DisplayEventTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FIRST_PIXEL_OUT => Some("FIRST_PIXEL_OUT"),
             _ => None,
@@ -1599,13 +1599,13 @@ impl fmt::Debug for DisplayEventTypeEXT {
     }
 }
 impl fmt::Debug for DisplayModeCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DisplayPlaneAlphaFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (DisplayPlaneAlphaFlagsKHR::OPAQUE.0, "OPAQUE"),
             (DisplayPlaneAlphaFlagsKHR::GLOBAL.0, "GLOBAL"),
@@ -1619,7 +1619,7 @@ impl fmt::Debug for DisplayPlaneAlphaFlagsKHR {
     }
 }
 impl fmt::Debug for DisplayPowerStateEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OFF => Some("OFF"),
             Self::SUSPEND => Some("SUSPEND"),
@@ -1634,13 +1634,13 @@ impl fmt::Debug for DisplayPowerStateEXT {
     }
 }
 impl fmt::Debug for DisplaySurfaceCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for DriverId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::AMD_PROPRIETARY => Some("AMD_PROPRIETARY"),
             Self::AMD_OPEN_SOURCE => Some("AMD_OPEN_SOURCE"),
@@ -1678,7 +1678,7 @@ impl fmt::Debug for DriverId {
     }
 }
 impl fmt::Debug for DynamicState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::VIEWPORT => Some("VIEWPORT"),
             Self::SCISSOR => Some("SCISSOR"),
@@ -1774,13 +1774,13 @@ impl fmt::Debug for DynamicState {
     }
 }
 impl fmt::Debug for EventCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(EventCreateFlags::DEVICE_ONLY.0, "DEVICE_ONLY")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ExportMetalObjectTypeFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 ExportMetalObjectTypeFlagsEXT::METAL_DEVICE.0,
@@ -1811,7 +1811,7 @@ impl fmt::Debug for ExportMetalObjectTypeFlagsEXT {
     }
 }
 impl fmt::Debug for ExternalFenceFeatureFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ExternalFenceFeatureFlags::EXPORTABLE.0, "EXPORTABLE"),
             (ExternalFenceFeatureFlags::IMPORTABLE.0, "IMPORTABLE"),
@@ -1820,7 +1820,7 @@ impl fmt::Debug for ExternalFenceFeatureFlags {
     }
 }
 impl fmt::Debug for ExternalFenceHandleTypeFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ExternalFenceHandleTypeFlags::OPAQUE_FD.0, "OPAQUE_FD"),
             (ExternalFenceHandleTypeFlags::OPAQUE_WIN32.0, "OPAQUE_WIN32"),
@@ -1834,7 +1834,7 @@ impl fmt::Debug for ExternalFenceHandleTypeFlags {
     }
 }
 impl fmt::Debug for ExternalMemoryFeatureFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 ExternalMemoryFeatureFlags::DEDICATED_ONLY.0,
@@ -1847,7 +1847,7 @@ impl fmt::Debug for ExternalMemoryFeatureFlags {
     }
 }
 impl fmt::Debug for ExternalMemoryFeatureFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 ExternalMemoryFeatureFlagsNV::DEDICATED_ONLY.0,
@@ -1860,7 +1860,7 @@ impl fmt::Debug for ExternalMemoryFeatureFlagsNV {
     }
 }
 impl fmt::Debug for ExternalMemoryHandleTypeFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ExternalMemoryHandleTypeFlags::OPAQUE_FD.0, "OPAQUE_FD"),
             (
@@ -1914,7 +1914,7 @@ impl fmt::Debug for ExternalMemoryHandleTypeFlags {
     }
 }
 impl fmt::Debug for ExternalMemoryHandleTypeFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 ExternalMemoryHandleTypeFlagsNV::OPAQUE_WIN32.0,
@@ -1937,7 +1937,7 @@ impl fmt::Debug for ExternalMemoryHandleTypeFlagsNV {
     }
 }
 impl fmt::Debug for ExternalSemaphoreFeatureFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ExternalSemaphoreFeatureFlags::EXPORTABLE.0, "EXPORTABLE"),
             (ExternalSemaphoreFeatureFlags::IMPORTABLE.0, "IMPORTABLE"),
@@ -1946,7 +1946,7 @@ impl fmt::Debug for ExternalSemaphoreFeatureFlags {
     }
 }
 impl fmt::Debug for ExternalSemaphoreHandleTypeFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ExternalSemaphoreHandleTypeFlags::OPAQUE_FD.0, "OPAQUE_FD"),
             (
@@ -1971,19 +1971,19 @@ impl fmt::Debug for ExternalSemaphoreHandleTypeFlags {
     }
 }
 impl fmt::Debug for FenceCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(FenceCreateFlags::SIGNALED.0, "SIGNALED")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for FenceImportFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(FenceImportFlags::TEMPORARY.0, "TEMPORARY")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for Filter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NEAREST => Some("NEAREST"),
             Self::LINEAR => Some("LINEAR"),
@@ -1998,7 +1998,7 @@ impl fmt::Debug for Filter {
     }
 }
 impl fmt::Debug for Format {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNDEFINED => Some("UNDEFINED"),
             Self::R4G4_UNORM_PACK8 => Some("R4G4_UNORM_PACK8"),
@@ -2292,19 +2292,19 @@ impl fmt::Debug for Format {
     }
 }
 impl fmt::Debug for FormatFeatureFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN : & [(Flags , & str)] = & [(FormatFeatureFlags :: SAMPLED_IMAGE . 0 , "SAMPLED_IMAGE") , (FormatFeatureFlags :: STORAGE_IMAGE . 0 , "STORAGE_IMAGE") , (FormatFeatureFlags :: STORAGE_IMAGE_ATOMIC . 0 , "STORAGE_IMAGE_ATOMIC") , (FormatFeatureFlags :: UNIFORM_TEXEL_BUFFER . 0 , "UNIFORM_TEXEL_BUFFER") , (FormatFeatureFlags :: STORAGE_TEXEL_BUFFER . 0 , "STORAGE_TEXEL_BUFFER") , (FormatFeatureFlags :: STORAGE_TEXEL_BUFFER_ATOMIC . 0 , "STORAGE_TEXEL_BUFFER_ATOMIC") , (FormatFeatureFlags :: VERTEX_BUFFER . 0 , "VERTEX_BUFFER") , (FormatFeatureFlags :: COLOR_ATTACHMENT . 0 , "COLOR_ATTACHMENT") , (FormatFeatureFlags :: COLOR_ATTACHMENT_BLEND . 0 , "COLOR_ATTACHMENT_BLEND") , (FormatFeatureFlags :: DEPTH_STENCIL_ATTACHMENT . 0 , "DEPTH_STENCIL_ATTACHMENT") , (FormatFeatureFlags :: BLIT_SRC . 0 , "BLIT_SRC") , (FormatFeatureFlags :: BLIT_DST . 0 , "BLIT_DST") , (FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_LINEAR . 0 , "SAMPLED_IMAGE_FILTER_LINEAR") , (FormatFeatureFlags :: VIDEO_DECODE_OUTPUT_KHR . 0 , "VIDEO_DECODE_OUTPUT_KHR") , (FormatFeatureFlags :: VIDEO_DECODE_DPB_KHR . 0 , "VIDEO_DECODE_DPB_KHR") , (FormatFeatureFlags :: ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR . 0 , "ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR") , (FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_CUBIC_EXT . 0 , "SAMPLED_IMAGE_FILTER_CUBIC_EXT") , (FormatFeatureFlags :: FRAGMENT_DENSITY_MAP_EXT . 0 , "FRAGMENT_DENSITY_MAP_EXT") , (FormatFeatureFlags :: FRAGMENT_SHADING_RATE_ATTACHMENT_KHR . 0 , "FRAGMENT_SHADING_RATE_ATTACHMENT_KHR") , (FormatFeatureFlags :: VIDEO_ENCODE_INPUT_KHR . 0 , "VIDEO_ENCODE_INPUT_KHR") , (FormatFeatureFlags :: VIDEO_ENCODE_DPB_KHR . 0 , "VIDEO_ENCODE_DPB_KHR") , (FormatFeatureFlags :: TRANSFER_SRC . 0 , "TRANSFER_SRC") , (FormatFeatureFlags :: TRANSFER_DST . 0 , "TRANSFER_DST") , (FormatFeatureFlags :: MIDPOINT_CHROMA_SAMPLES . 0 , "MIDPOINT_CHROMA_SAMPLES") , (FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER") , (FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER") , (FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT") , (FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE") , (FormatFeatureFlags :: DISJOINT . 0 , "DISJOINT") , (FormatFeatureFlags :: COSITED_CHROMA_SAMPLES . 0 , "COSITED_CHROMA_SAMPLES") , (FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_MINMAX . 0 , "SAMPLED_IMAGE_FILTER_MINMAX")] ;
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for FormatFeatureFlags2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN : & [(Flags64 , & str)] = & [(FormatFeatureFlags2 :: SAMPLED_IMAGE . 0 , "SAMPLED_IMAGE") , (FormatFeatureFlags2 :: STORAGE_IMAGE . 0 , "STORAGE_IMAGE") , (FormatFeatureFlags2 :: STORAGE_IMAGE_ATOMIC . 0 , "STORAGE_IMAGE_ATOMIC") , (FormatFeatureFlags2 :: UNIFORM_TEXEL_BUFFER . 0 , "UNIFORM_TEXEL_BUFFER") , (FormatFeatureFlags2 :: STORAGE_TEXEL_BUFFER . 0 , "STORAGE_TEXEL_BUFFER") , (FormatFeatureFlags2 :: STORAGE_TEXEL_BUFFER_ATOMIC . 0 , "STORAGE_TEXEL_BUFFER_ATOMIC") , (FormatFeatureFlags2 :: VERTEX_BUFFER . 0 , "VERTEX_BUFFER") , (FormatFeatureFlags2 :: COLOR_ATTACHMENT . 0 , "COLOR_ATTACHMENT") , (FormatFeatureFlags2 :: COLOR_ATTACHMENT_BLEND . 0 , "COLOR_ATTACHMENT_BLEND") , (FormatFeatureFlags2 :: DEPTH_STENCIL_ATTACHMENT . 0 , "DEPTH_STENCIL_ATTACHMENT") , (FormatFeatureFlags2 :: BLIT_SRC . 0 , "BLIT_SRC") , (FormatFeatureFlags2 :: BLIT_DST . 0 , "BLIT_DST") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_FILTER_LINEAR . 0 , "SAMPLED_IMAGE_FILTER_LINEAR") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_FILTER_CUBIC . 0 , "SAMPLED_IMAGE_FILTER_CUBIC") , (FormatFeatureFlags2 :: TRANSFER_SRC . 0 , "TRANSFER_SRC") , (FormatFeatureFlags2 :: TRANSFER_DST . 0 , "TRANSFER_DST") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_FILTER_MINMAX . 0 , "SAMPLED_IMAGE_FILTER_MINMAX") , (FormatFeatureFlags2 :: MIDPOINT_CHROMA_SAMPLES . 0 , "MIDPOINT_CHROMA_SAMPLES") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE") , (FormatFeatureFlags2 :: DISJOINT . 0 , "DISJOINT") , (FormatFeatureFlags2 :: COSITED_CHROMA_SAMPLES . 0 , "COSITED_CHROMA_SAMPLES") , (FormatFeatureFlags2 :: STORAGE_READ_WITHOUT_FORMAT . 0 , "STORAGE_READ_WITHOUT_FORMAT") , (FormatFeatureFlags2 :: STORAGE_WRITE_WITHOUT_FORMAT . 0 , "STORAGE_WRITE_WITHOUT_FORMAT") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_DEPTH_COMPARISON . 0 , "SAMPLED_IMAGE_DEPTH_COMPARISON") , (FormatFeatureFlags2 :: VIDEO_DECODE_OUTPUT_KHR . 0 , "VIDEO_DECODE_OUTPUT_KHR") , (FormatFeatureFlags2 :: VIDEO_DECODE_DPB_KHR . 0 , "VIDEO_DECODE_DPB_KHR") , (FormatFeatureFlags2 :: ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR . 0 , "ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR") , (FormatFeatureFlags2 :: FRAGMENT_DENSITY_MAP_EXT . 0 , "FRAGMENT_DENSITY_MAP_EXT") , (FormatFeatureFlags2 :: FRAGMENT_SHADING_RATE_ATTACHMENT_KHR . 0 , "FRAGMENT_SHADING_RATE_ATTACHMENT_KHR") , (FormatFeatureFlags2 :: HOST_IMAGE_TRANSFER_EXT . 0 , "HOST_IMAGE_TRANSFER_EXT") , (FormatFeatureFlags2 :: VIDEO_ENCODE_INPUT_KHR . 0 , "VIDEO_ENCODE_INPUT_KHR") , (FormatFeatureFlags2 :: VIDEO_ENCODE_DPB_KHR . 0 , "VIDEO_ENCODE_DPB_KHR") , (FormatFeatureFlags2 :: LINEAR_COLOR_ATTACHMENT_NV . 0 , "LINEAR_COLOR_ATTACHMENT_NV") , (FormatFeatureFlags2 :: WEIGHT_IMAGE_QCOM . 0 , "WEIGHT_IMAGE_QCOM") , (FormatFeatureFlags2 :: WEIGHT_SAMPLED_IMAGE_QCOM . 0 , "WEIGHT_SAMPLED_IMAGE_QCOM") , (FormatFeatureFlags2 :: BLOCK_MATCHING_QCOM . 0 , "BLOCK_MATCHING_QCOM") , (FormatFeatureFlags2 :: BOX_FILTER_SAMPLED_QCOM . 0 , "BOX_FILTER_SAMPLED_QCOM") , (FormatFeatureFlags2 :: OPTICAL_FLOW_IMAGE_NV . 0 , "OPTICAL_FLOW_IMAGE_NV") , (FormatFeatureFlags2 :: OPTICAL_FLOW_VECTOR_NV . 0 , "OPTICAL_FLOW_VECTOR_NV") , (FormatFeatureFlags2 :: OPTICAL_FLOW_COST_NV . 0 , "OPTICAL_FLOW_COST_NV")] ;
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for FragmentShadingRateCombinerOpKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::KEEP => Some("KEEP"),
             Self::REPLACE => Some("REPLACE"),
@@ -2321,7 +2321,7 @@ impl fmt::Debug for FragmentShadingRateCombinerOpKHR {
     }
 }
 impl fmt::Debug for FragmentShadingRateNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TYPE_1_INVOCATION_PER_PIXEL => Some("TYPE_1_INVOCATION_PER_PIXEL"),
             Self::TYPE_1_INVOCATION_PER_1X2_PIXELS => Some("TYPE_1_INVOCATION_PER_1X2_PIXELS"),
@@ -2345,7 +2345,7 @@ impl fmt::Debug for FragmentShadingRateNV {
     }
 }
 impl fmt::Debug for FragmentShadingRateTypeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FRAGMENT_SIZE => Some("FRAGMENT_SIZE"),
             Self::ENUMS => Some("ENUMS"),
@@ -2359,19 +2359,19 @@ impl fmt::Debug for FragmentShadingRateTypeNV {
     }
 }
 impl fmt::Debug for FrameBoundaryFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(FrameBoundaryFlagsEXT::FRAME_END.0, "FRAME_END")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for FramebufferCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(FramebufferCreateFlags::IMAGELESS.0, "IMAGELESS")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for FrontFace {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::COUNTER_CLOCKWISE => Some("COUNTER_CLOCKWISE"),
             Self::CLOCKWISE => Some("CLOCKWISE"),
@@ -2385,7 +2385,7 @@ impl fmt::Debug for FrontFace {
     }
 }
 impl fmt::Debug for FullScreenExclusiveEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEFAULT => Some("DEFAULT"),
             Self::ALLOWED => Some("ALLOWED"),
@@ -2401,7 +2401,7 @@ impl fmt::Debug for FullScreenExclusiveEXT {
     }
 }
 impl fmt::Debug for GeometryFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (GeometryFlagsKHR::OPAQUE.0, "OPAQUE"),
             (
@@ -2413,7 +2413,7 @@ impl fmt::Debug for GeometryFlagsKHR {
     }
 }
 impl fmt::Debug for GeometryInstanceFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 GeometryInstanceFlagsKHR::TRIANGLE_FACING_CULL_DISABLE.0,
@@ -2441,7 +2441,7 @@ impl fmt::Debug for GeometryInstanceFlagsKHR {
     }
 }
 impl fmt::Debug for GeometryTypeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TRIANGLES => Some("TRIANGLES"),
             Self::AABBS => Some("AABBS"),
@@ -2456,7 +2456,7 @@ impl fmt::Debug for GeometryTypeKHR {
     }
 }
 impl fmt::Debug for GraphicsPipelineLibraryFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 GraphicsPipelineLibraryFlagsEXT::VERTEX_INPUT_INTERFACE.0,
@@ -2479,25 +2479,25 @@ impl fmt::Debug for GraphicsPipelineLibraryFlagsEXT {
     }
 }
 impl fmt::Debug for HeadlessSurfaceCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for HostImageCopyFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(HostImageCopyFlagsEXT::MEMCPY.0, "MEMCPY")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for IOSSurfaceCreateFlagsMVK {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ImageAspectFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ImageAspectFlags::COLOR.0, "COLOR"),
             (ImageAspectFlags::DEPTH.0, "DEPTH"),
@@ -2516,7 +2516,7 @@ impl fmt::Debug for ImageAspectFlags {
     }
 }
 impl fmt::Debug for ImageCompressionFixedRateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ImageCompressionFixedRateFlagsEXT::NONE.0, "NONE"),
             (ImageCompressionFixedRateFlagsEXT::TYPE_1BPC.0, "TYPE_1BPC"),
@@ -2593,7 +2593,7 @@ impl fmt::Debug for ImageCompressionFixedRateFlagsEXT {
     }
 }
 impl fmt::Debug for ImageCompressionFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ImageCompressionFlagsEXT::DEFAULT.0, "DEFAULT"),
             (
@@ -2610,7 +2610,7 @@ impl fmt::Debug for ImageCompressionFlagsEXT {
     }
 }
 impl fmt::Debug for ImageConstraintsInfoFlagsFUCHSIA {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 ImageConstraintsInfoFlagsFUCHSIA::CPU_READ_RARELY.0,
@@ -2637,7 +2637,7 @@ impl fmt::Debug for ImageConstraintsInfoFlagsFUCHSIA {
     }
 }
 impl fmt::Debug for ImageCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ImageCreateFlags::SPARSE_BINDING.0, "SPARSE_BINDING"),
             (ImageCreateFlags::SPARSE_RESIDENCY.0, "SPARSE_RESIDENCY"),
@@ -2687,13 +2687,13 @@ impl fmt::Debug for ImageCreateFlags {
     }
 }
 impl fmt::Debug for ImageFormatConstraintsFlagsFUCHSIA {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ImageLayout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNDEFINED => Some("UNDEFINED"),
             Self::GENERAL => Some("GENERAL"),
@@ -2741,13 +2741,13 @@ impl fmt::Debug for ImageLayout {
     }
 }
 impl fmt::Debug for ImagePipeSurfaceCreateFlagsFUCHSIA {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ImageTiling {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OPTIMAL => Some("OPTIMAL"),
             Self::LINEAR => Some("LINEAR"),
@@ -2762,7 +2762,7 @@ impl fmt::Debug for ImageTiling {
     }
 }
 impl fmt::Debug for ImageType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TYPE_1D => Some("TYPE_1D"),
             Self::TYPE_2D => Some("TYPE_2D"),
@@ -2777,7 +2777,7 @@ impl fmt::Debug for ImageType {
     }
 }
 impl fmt::Debug for ImageUsageFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ImageUsageFlags::TRANSFER_SRC.0, "TRANSFER_SRC"),
             (ImageUsageFlags::TRANSFER_DST.0, "TRANSFER_DST"),
@@ -2844,7 +2844,7 @@ impl fmt::Debug for ImageUsageFlags {
     }
 }
 impl fmt::Debug for ImageViewCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 ImageViewCreateFlags::FRAGMENT_DENSITY_MAP_DYNAMIC_EXT.0,
@@ -2863,7 +2863,7 @@ impl fmt::Debug for ImageViewCreateFlags {
     }
 }
 impl fmt::Debug for ImageViewType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TYPE_1D => Some("TYPE_1D"),
             Self::TYPE_2D => Some("TYPE_2D"),
@@ -2882,7 +2882,7 @@ impl fmt::Debug for ImageViewType {
     }
 }
 impl fmt::Debug for IndexType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UINT16 => Some("UINT16"),
             Self::UINT32 => Some("UINT32"),
@@ -2898,7 +2898,7 @@ impl fmt::Debug for IndexType {
     }
 }
 impl fmt::Debug for IndirectCommandsLayoutUsageFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 IndirectCommandsLayoutUsageFlagsNV::EXPLICIT_PREPROCESS.0,
@@ -2917,7 +2917,7 @@ impl fmt::Debug for IndirectCommandsLayoutUsageFlagsNV {
     }
 }
 impl fmt::Debug for IndirectCommandsTokenTypeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::SHADER_GROUP => Some("SHADER_GROUP"),
             Self::STATE_FLAGS => Some("STATE_FLAGS"),
@@ -2940,14 +2940,14 @@ impl fmt::Debug for IndirectCommandsTokenTypeNV {
     }
 }
 impl fmt::Debug for IndirectStateFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] =
             &[(IndirectStateFlagsNV::FLAG_FRONTFACE.0, "FLAG_FRONTFACE")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for InstanceCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR.0,
             "ENUMERATE_PORTABILITY_KHR",
@@ -2956,7 +2956,7 @@ impl fmt::Debug for InstanceCreateFlags {
     }
 }
 impl fmt::Debug for InternalAllocationType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::EXECUTABLE => Some("EXECUTABLE"),
             _ => None,
@@ -2969,7 +2969,7 @@ impl fmt::Debug for InternalAllocationType {
     }
 }
 impl fmt::Debug for LatencyMarkerNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::SIMULATION_START => Some("SIMULATION_START"),
             Self::SIMULATION_END => Some("SIMULATION_END"),
@@ -2993,7 +2993,7 @@ impl fmt::Debug for LatencyMarkerNV {
     }
 }
 impl fmt::Debug for LayeredDriverUnderlyingApiMSFT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NONE => Some("NONE"),
             Self::D3D12 => Some("D3D12"),
@@ -3007,7 +3007,7 @@ impl fmt::Debug for LayeredDriverUnderlyingApiMSFT {
     }
 }
 impl fmt::Debug for LineRasterizationModeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEFAULT => Some("DEFAULT"),
             Self::RECTANGULAR => Some("RECTANGULAR"),
@@ -3023,7 +3023,7 @@ impl fmt::Debug for LineRasterizationModeEXT {
     }
 }
 impl fmt::Debug for LogicOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::CLEAR => Some("CLEAR"),
             Self::AND => Some("AND"),
@@ -3051,13 +3051,13 @@ impl fmt::Debug for LogicOp {
     }
 }
 impl fmt::Debug for MacOSSurfaceCreateFlagsMVK {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for MemoryAllocateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (MemoryAllocateFlags::DEVICE_MASK.0, "DEVICE_MASK"),
             (MemoryAllocateFlags::DEVICE_ADDRESS.0, "DEVICE_ADDRESS"),
@@ -3070,7 +3070,7 @@ impl fmt::Debug for MemoryAllocateFlags {
     }
 }
 impl fmt::Debug for MemoryDecompressionMethodFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[(
             MemoryDecompressionMethodFlagsNV::GDEFLATE_1_0.0,
             "GDEFLATE_1_0",
@@ -3079,7 +3079,7 @@ impl fmt::Debug for MemoryDecompressionMethodFlagsNV {
     }
 }
 impl fmt::Debug for MemoryHeapFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (MemoryHeapFlags::DEVICE_LOCAL.0, "DEVICE_LOCAL"),
             (MemoryHeapFlags::MULTI_INSTANCE.0, "MULTI_INSTANCE"),
@@ -3088,13 +3088,13 @@ impl fmt::Debug for MemoryHeapFlags {
     }
 }
 impl fmt::Debug for MemoryMapFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for MemoryOverallocationBehaviorAMD {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEFAULT => Some("DEFAULT"),
             Self::ALLOWED => Some("ALLOWED"),
@@ -3109,7 +3109,7 @@ impl fmt::Debug for MemoryOverallocationBehaviorAMD {
     }
 }
 impl fmt::Debug for MemoryPropertyFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (MemoryPropertyFlags::DEVICE_LOCAL.0, "DEVICE_LOCAL"),
             (MemoryPropertyFlags::HOST_VISIBLE.0, "HOST_VISIBLE"),
@@ -3131,19 +3131,19 @@ impl fmt::Debug for MemoryPropertyFlags {
     }
 }
 impl fmt::Debug for MemoryUnmapFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for MetalSurfaceCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for MicromapCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             MicromapCreateFlagsEXT::DEVICE_ADDRESS_CAPTURE_REPLAY.0,
             "DEVICE_ADDRESS_CAPTURE_REPLAY",
@@ -3152,7 +3152,7 @@ impl fmt::Debug for MicromapCreateFlagsEXT {
     }
 }
 impl fmt::Debug for MicromapTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OPACITY_MICROMAP => Some("OPACITY_MICROMAP"),
             Self::DISPLACEMENT_MICROMAP_NV => Some("DISPLACEMENT_MICROMAP_NV"),
@@ -3166,7 +3166,7 @@ impl fmt::Debug for MicromapTypeEXT {
     }
 }
 impl fmt::Debug for OpacityMicromapFormatEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TYPE_2_STATE => Some("TYPE_2_STATE"),
             Self::TYPE_4_STATE => Some("TYPE_4_STATE"),
@@ -3180,7 +3180,7 @@ impl fmt::Debug for OpacityMicromapFormatEXT {
     }
 }
 impl fmt::Debug for OpacityMicromapSpecialIndexEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FULLY_TRANSPARENT => Some("FULLY_TRANSPARENT"),
             Self::FULLY_OPAQUE => Some("FULLY_OPAQUE"),
@@ -3196,7 +3196,7 @@ impl fmt::Debug for OpacityMicromapSpecialIndexEXT {
     }
 }
 impl fmt::Debug for OpticalFlowExecuteFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             OpticalFlowExecuteFlagsNV::DISABLE_TEMPORAL_HINTS.0,
             "DISABLE_TEMPORAL_HINTS",
@@ -3205,7 +3205,7 @@ impl fmt::Debug for OpticalFlowExecuteFlagsNV {
     }
 }
 impl fmt::Debug for OpticalFlowGridSizeFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (OpticalFlowGridSizeFlagsNV::UNKNOWN.0, "UNKNOWN"),
             (OpticalFlowGridSizeFlagsNV::TYPE_1X1.0, "TYPE_1X1"),
@@ -3217,7 +3217,7 @@ impl fmt::Debug for OpticalFlowGridSizeFlagsNV {
     }
 }
 impl fmt::Debug for OpticalFlowPerformanceLevelNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNKNOWN => Some("UNKNOWN"),
             Self::SLOW => Some("SLOW"),
@@ -3233,7 +3233,7 @@ impl fmt::Debug for OpticalFlowPerformanceLevelNV {
     }
 }
 impl fmt::Debug for OpticalFlowSessionBindingPointNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNKNOWN => Some("UNKNOWN"),
             Self::INPUT => Some("INPUT"),
@@ -3254,7 +3254,7 @@ impl fmt::Debug for OpticalFlowSessionBindingPointNV {
     }
 }
 impl fmt::Debug for OpticalFlowSessionCreateFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 OpticalFlowSessionCreateFlagsNV::ENABLE_HINT.0,
@@ -3281,7 +3281,7 @@ impl fmt::Debug for OpticalFlowSessionCreateFlagsNV {
     }
 }
 impl fmt::Debug for OpticalFlowUsageFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (OpticalFlowUsageFlagsNV::UNKNOWN.0, "UNKNOWN"),
             (OpticalFlowUsageFlagsNV::INPUT.0, "INPUT"),
@@ -3294,7 +3294,7 @@ impl fmt::Debug for OpticalFlowUsageFlagsNV {
     }
 }
 impl fmt::Debug for OutOfBandQueueTypeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::RENDER => Some("RENDER"),
             Self::PRESENT => Some("PRESENT"),
@@ -3308,7 +3308,7 @@ impl fmt::Debug for OutOfBandQueueTypeNV {
     }
 }
 impl fmt::Debug for PeerMemoryFeatureFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (PeerMemoryFeatureFlags::COPY_SRC.0, "COPY_SRC"),
             (PeerMemoryFeatureFlags::COPY_DST.0, "COPY_DST"),
@@ -3319,7 +3319,7 @@ impl fmt::Debug for PeerMemoryFeatureFlags {
     }
 }
 impl fmt::Debug for PerformanceConfigurationTypeINTEL {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED => {
                 Some("COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED")
@@ -3334,7 +3334,7 @@ impl fmt::Debug for PerformanceConfigurationTypeINTEL {
     }
 }
 impl fmt::Debug for PerformanceCounterDescriptionFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 PerformanceCounterDescriptionFlagsKHR::PERFORMANCE_IMPACTING.0,
@@ -3349,7 +3349,7 @@ impl fmt::Debug for PerformanceCounterDescriptionFlagsKHR {
     }
 }
 impl fmt::Debug for PerformanceCounterScopeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::COMMAND_BUFFER => Some("COMMAND_BUFFER"),
             Self::RENDER_PASS => Some("RENDER_PASS"),
@@ -3364,7 +3364,7 @@ impl fmt::Debug for PerformanceCounterScopeKHR {
     }
 }
 impl fmt::Debug for PerformanceCounterStorageKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::INT32 => Some("INT32"),
             Self::INT64 => Some("INT64"),
@@ -3382,7 +3382,7 @@ impl fmt::Debug for PerformanceCounterStorageKHR {
     }
 }
 impl fmt::Debug for PerformanceCounterUnitKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::GENERIC => Some("GENERIC"),
             Self::PERCENTAGE => Some("PERCENTAGE"),
@@ -3405,7 +3405,7 @@ impl fmt::Debug for PerformanceCounterUnitKHR {
     }
 }
 impl fmt::Debug for PerformanceOverrideTypeINTEL {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NULL_HARDWARE => Some("NULL_HARDWARE"),
             Self::FLUSH_GPU_CACHES => Some("FLUSH_GPU_CACHES"),
@@ -3419,7 +3419,7 @@ impl fmt::Debug for PerformanceOverrideTypeINTEL {
     }
 }
 impl fmt::Debug for PerformanceParameterTypeINTEL {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::HW_COUNTERS_SUPPORTED => Some("HW_COUNTERS_SUPPORTED"),
             Self::STREAM_MARKER_VALIDS => Some("STREAM_MARKER_VALIDS"),
@@ -3433,7 +3433,7 @@ impl fmt::Debug for PerformanceParameterTypeINTEL {
     }
 }
 impl fmt::Debug for PerformanceValueTypeINTEL {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UINT32 => Some("UINT32"),
             Self::UINT64 => Some("UINT64"),
@@ -3450,7 +3450,7 @@ impl fmt::Debug for PerformanceValueTypeINTEL {
     }
 }
 impl fmt::Debug for PhysicalDeviceSchedulingControlsFlagsARM {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             PhysicalDeviceSchedulingControlsFlagsARM::SHADER_CORE_COUNT.0,
             "SHADER_CORE_COUNT",
@@ -3459,7 +3459,7 @@ impl fmt::Debug for PhysicalDeviceSchedulingControlsFlagsARM {
     }
 }
 impl fmt::Debug for PhysicalDeviceType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OTHER => Some("OTHER"),
             Self::INTEGRATED_GPU => Some("INTEGRATED_GPU"),
@@ -3476,7 +3476,7 @@ impl fmt::Debug for PhysicalDeviceType {
     }
 }
 impl fmt::Debug for PipelineBindPoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::GRAPHICS => Some("GRAPHICS"),
             Self::COMPUTE => Some("COMPUTE"),
@@ -3493,7 +3493,7 @@ impl fmt::Debug for PipelineBindPoint {
     }
 }
 impl fmt::Debug for PipelineCacheCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             PipelineCacheCreateFlags::EXTERNALLY_SYNCHRONIZED.0,
             "EXTERNALLY_SYNCHRONIZED",
@@ -3502,7 +3502,7 @@ impl fmt::Debug for PipelineCacheCreateFlags {
     }
 }
 impl fmt::Debug for PipelineCacheHeaderVersion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ONE => Some("ONE"),
             _ => None,
@@ -3515,7 +3515,7 @@ impl fmt::Debug for PipelineCacheHeaderVersion {
     }
 }
 impl fmt::Debug for PipelineColorBlendStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             PipelineColorBlendStateCreateFlags::RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXT.0,
             "RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXT",
@@ -3524,31 +3524,31 @@ impl fmt::Debug for PipelineColorBlendStateCreateFlags {
     }
 }
 impl fmt::Debug for PipelineCompilerControlFlagsAMD {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineCoverageModulationStateCreateFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineCoverageReductionStateCreateFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineCoverageToColorStateCreateFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 PipelineCreateFlags::DISABLE_OPTIMIZATION.0,
@@ -3667,7 +3667,7 @@ impl fmt::Debug for PipelineCreateFlags {
     }
 }
 impl fmt::Debug for PipelineCreateFlags2KHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[
             (
                 PipelineCreateFlags2KHR::DISABLE_OPTIMIZATION.0,
@@ -3789,7 +3789,7 @@ impl fmt::Debug for PipelineCreateFlags2KHR {
     }
 }
 impl fmt::Debug for PipelineCreationFeedbackFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (PipelineCreationFeedbackFlags::VALID.0, "VALID"),
             (
@@ -3805,25 +3805,25 @@ impl fmt::Debug for PipelineCreationFeedbackFlags {
     }
 }
 impl fmt::Debug for PipelineDepthStencilStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN : & [(Flags , & str)] = & [(PipelineDepthStencilStateCreateFlags :: RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_EXT . 0 , "RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_EXT") , (PipelineDepthStencilStateCreateFlags :: RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_EXT . 0 , "RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_EXT")] ;
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineDiscardRectangleStateCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineDynamicStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineExecutableStatisticFormatKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::BOOL32 => Some("BOOL32"),
             Self::INT64 => Some("INT64"),
@@ -3839,13 +3839,13 @@ impl fmt::Debug for PipelineExecutableStatisticFormatKHR {
     }
 }
 impl fmt::Debug for PipelineInputAssemblyStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineLayoutCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(
             PipelineLayoutCreateFlags::INDEPENDENT_SETS_EXT.0,
             "INDEPENDENT_SETS_EXT",
@@ -3854,37 +3854,37 @@ impl fmt::Debug for PipelineLayoutCreateFlags {
     }
 }
 impl fmt::Debug for PipelineMultisampleStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineRasterizationConservativeStateCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineRasterizationDepthClipStateCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineRasterizationStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineRasterizationStateStreamCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineRobustnessBufferBehaviorEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEVICE_DEFAULT => Some("DEVICE_DEFAULT"),
             Self::DISABLED => Some("DISABLED"),
@@ -3900,7 +3900,7 @@ impl fmt::Debug for PipelineRobustnessBufferBehaviorEXT {
     }
 }
 impl fmt::Debug for PipelineRobustnessImageBehaviorEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEVICE_DEFAULT => Some("DEVICE_DEFAULT"),
             Self::DISABLED => Some("DISABLED"),
@@ -3916,7 +3916,7 @@ impl fmt::Debug for PipelineRobustnessImageBehaviorEXT {
     }
 }
 impl fmt::Debug for PipelineShaderStageCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 PipelineShaderStageCreateFlags::ALLOW_VARYING_SUBGROUP_SIZE.0,
@@ -3931,7 +3931,7 @@ impl fmt::Debug for PipelineShaderStageCreateFlags {
     }
 }
 impl fmt::Debug for PipelineStageFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (PipelineStageFlags::TOP_OF_PIPE.0, "TOP_OF_PIPE"),
             (PipelineStageFlags::DRAW_INDIRECT.0, "DRAW_INDIRECT"),
@@ -4001,7 +4001,7 @@ impl fmt::Debug for PipelineStageFlags {
     }
 }
 impl fmt::Debug for PipelineStageFlags2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[
             (PipelineStageFlags2::NONE.0, "NONE"),
             (PipelineStageFlags2::TOP_OF_PIPE.0, "TOP_OF_PIPE"),
@@ -4107,31 +4107,31 @@ impl fmt::Debug for PipelineStageFlags2 {
     }
 }
 impl fmt::Debug for PipelineTessellationStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineVertexInputStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineViewportStateCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PipelineViewportSwizzleStateCreateFlagsNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for PointClippingBehavior {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ALL_CLIP_PLANES => Some("ALL_CLIP_PLANES"),
             Self::USER_CLIP_PLANES_ONLY => Some("USER_CLIP_PLANES_ONLY"),
@@ -4145,7 +4145,7 @@ impl fmt::Debug for PointClippingBehavior {
     }
 }
 impl fmt::Debug for PolygonMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FILL => Some("FILL"),
             Self::LINE => Some("LINE"),
@@ -4161,7 +4161,7 @@ impl fmt::Debug for PolygonMode {
     }
 }
 impl fmt::Debug for PresentGravityFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (PresentGravityFlagsEXT::MIN.0, "MIN"),
             (PresentGravityFlagsEXT::MAX.0, "MAX"),
@@ -4171,7 +4171,7 @@ impl fmt::Debug for PresentGravityFlagsEXT {
     }
 }
 impl fmt::Debug for PresentModeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::IMMEDIATE => Some("IMMEDIATE"),
             Self::MAILBOX => Some("MAILBOX"),
@@ -4189,7 +4189,7 @@ impl fmt::Debug for PresentModeKHR {
     }
 }
 impl fmt::Debug for PresentScalingFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (PresentScalingFlagsEXT::ONE_TO_ONE.0, "ONE_TO_ONE"),
             (
@@ -4202,7 +4202,7 @@ impl fmt::Debug for PresentScalingFlagsEXT {
     }
 }
 impl fmt::Debug for PrimitiveTopology {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::POINT_LIST => Some("POINT_LIST"),
             Self::LINE_LIST => Some("LINE_LIST"),
@@ -4225,13 +4225,13 @@ impl fmt::Debug for PrimitiveTopology {
     }
 }
 impl fmt::Debug for PrivateDataSlotCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ProvokingVertexModeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::FIRST_VERTEX => Some("FIRST_VERTEX"),
             Self::LAST_VERTEX => Some("LAST_VERTEX"),
@@ -4245,13 +4245,13 @@ impl fmt::Debug for ProvokingVertexModeEXT {
     }
 }
 impl fmt::Debug for QueryControlFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(QueryControlFlags::PRECISE.0, "PRECISE")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for QueryPipelineStatisticFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 QueryPipelineStatisticFlags::INPUT_ASSEMBLY_VERTICES.0,
@@ -4314,13 +4314,13 @@ impl fmt::Debug for QueryPipelineStatisticFlags {
     }
 }
 impl fmt::Debug for QueryPoolCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for QueryPoolSamplingModeINTEL {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::MANUAL => Some("MANUAL"),
             _ => None,
@@ -4333,7 +4333,7 @@ impl fmt::Debug for QueryPoolSamplingModeINTEL {
     }
 }
 impl fmt::Debug for QueryResultFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (QueryResultFlags::TYPE_64.0, "TYPE_64"),
             (QueryResultFlags::WAIT.0, "WAIT"),
@@ -4345,7 +4345,7 @@ impl fmt::Debug for QueryResultFlags {
     }
 }
 impl fmt::Debug for QueryResultStatusKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ERROR => Some("ERROR"),
             Self::NOT_READY => Some("NOT_READY"),
@@ -4361,7 +4361,7 @@ impl fmt::Debug for QueryResultStatusKHR {
     }
 }
 impl fmt::Debug for QueryType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OCCLUSION => Some("OCCLUSION"),
             Self::PIPELINE_STATISTICS => Some("PIPELINE_STATISTICS"),
@@ -4398,7 +4398,7 @@ impl fmt::Debug for QueryType {
     }
 }
 impl fmt::Debug for QueueFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (QueueFlags::GRAPHICS.0, "GRAPHICS"),
             (QueueFlags::COMPUTE.0, "COMPUTE"),
@@ -4413,7 +4413,7 @@ impl fmt::Debug for QueueFlags {
     }
 }
 impl fmt::Debug for QueueGlobalPriorityKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::LOW => Some("LOW"),
             Self::MEDIUM => Some("MEDIUM"),
@@ -4429,7 +4429,7 @@ impl fmt::Debug for QueueGlobalPriorityKHR {
     }
 }
 impl fmt::Debug for RasterizationOrderAMD {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::STRICT => Some("STRICT"),
             Self::RELAXED => Some("RELAXED"),
@@ -4443,7 +4443,7 @@ impl fmt::Debug for RasterizationOrderAMD {
     }
 }
 impl fmt::Debug for RayTracingInvocationReorderModeNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NONE => Some("NONE"),
             Self::REORDER => Some("REORDER"),
@@ -4457,7 +4457,7 @@ impl fmt::Debug for RayTracingInvocationReorderModeNV {
     }
 }
 impl fmt::Debug for RayTracingShaderGroupTypeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::GENERAL => Some("GENERAL"),
             Self::TRIANGLES_HIT_GROUP => Some("TRIANGLES_HIT_GROUP"),
@@ -4472,14 +4472,14 @@ impl fmt::Debug for RayTracingShaderGroupTypeKHR {
     }
 }
 impl fmt::Debug for RenderPassCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] =
             &[(RenderPassCreateFlags::TRANSFORM_QCOM.0, "TRANSFORM_QCOM")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for RenderingFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 RenderingFlags::CONTENTS_SECONDARY_COMMAND_BUFFERS.0,
@@ -4497,7 +4497,7 @@ impl fmt::Debug for RenderingFlags {
     }
 }
 impl fmt::Debug for ResolveModeFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ResolveModeFlags::NONE.0, "NONE"),
             (ResolveModeFlags::SAMPLE_ZERO.0, "SAMPLE_ZERO"),
@@ -4513,7 +4513,7 @@ impl fmt::Debug for ResolveModeFlags {
     }
 }
 impl fmt::Debug for SampleCountFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (SampleCountFlags::TYPE_1.0, "TYPE_1"),
             (SampleCountFlags::TYPE_2.0, "TYPE_2"),
@@ -4527,7 +4527,7 @@ impl fmt::Debug for SampleCountFlags {
     }
 }
 impl fmt::Debug for SamplerAddressMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::REPEAT => Some("REPEAT"),
             Self::MIRRORED_REPEAT => Some("MIRRORED_REPEAT"),
@@ -4544,7 +4544,7 @@ impl fmt::Debug for SamplerAddressMode {
     }
 }
 impl fmt::Debug for SamplerCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (SamplerCreateFlags::SUBSAMPLED_EXT.0, "SUBSAMPLED_EXT"),
             (
@@ -4568,7 +4568,7 @@ impl fmt::Debug for SamplerCreateFlags {
     }
 }
 impl fmt::Debug for SamplerMipmapMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NEAREST => Some("NEAREST"),
             Self::LINEAR => Some("LINEAR"),
@@ -4582,7 +4582,7 @@ impl fmt::Debug for SamplerMipmapMode {
     }
 }
 impl fmt::Debug for SamplerReductionMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::WEIGHTED_AVERAGE => Some("WEIGHTED_AVERAGE"),
             Self::MIN => Some("MIN"),
@@ -4598,7 +4598,7 @@ impl fmt::Debug for SamplerReductionMode {
     }
 }
 impl fmt::Debug for SamplerYcbcrModelConversion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::RGB_IDENTITY => Some("RGB_IDENTITY"),
             Self::YCBCR_IDENTITY => Some("YCBCR_IDENTITY"),
@@ -4615,7 +4615,7 @@ impl fmt::Debug for SamplerYcbcrModelConversion {
     }
 }
 impl fmt::Debug for SamplerYcbcrRange {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ITU_FULL => Some("ITU_FULL"),
             Self::ITU_NARROW => Some("ITU_NARROW"),
@@ -4629,7 +4629,7 @@ impl fmt::Debug for SamplerYcbcrRange {
     }
 }
 impl fmt::Debug for ScopeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEVICE => Some("DEVICE"),
             Self::WORKGROUP => Some("WORKGROUP"),
@@ -4645,25 +4645,25 @@ impl fmt::Debug for ScopeKHR {
     }
 }
 impl fmt::Debug for ScreenSurfaceCreateFlagsQNX {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for SemaphoreCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for SemaphoreImportFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(SemaphoreImportFlags::TEMPORARY.0, "TEMPORARY")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for SemaphoreType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::BINARY => Some("BINARY"),
             Self::TIMELINE => Some("TIMELINE"),
@@ -4677,13 +4677,13 @@ impl fmt::Debug for SemaphoreType {
     }
 }
 impl fmt::Debug for SemaphoreWaitFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(SemaphoreWaitFlags::ANY.0, "ANY")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ShaderCodeTypeEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::BINARY => Some("BINARY"),
             Self::SPIRV => Some("SPIRV"),
@@ -4697,13 +4697,13 @@ impl fmt::Debug for ShaderCodeTypeEXT {
     }
 }
 impl fmt::Debug for ShaderCorePropertiesFlagsAMD {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ShaderCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ShaderCreateFlagsEXT::LINK_STAGE.0, "LINK_STAGE"),
             (
@@ -4729,7 +4729,7 @@ impl fmt::Debug for ShaderCreateFlagsEXT {
     }
 }
 impl fmt::Debug for ShaderFloatControlsIndependence {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::TYPE_32_ONLY => Some("TYPE_32_ONLY"),
             Self::ALL => Some("ALL"),
@@ -4744,7 +4744,7 @@ impl fmt::Debug for ShaderFloatControlsIndependence {
     }
 }
 impl fmt::Debug for ShaderGroupShaderKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::GENERAL => Some("GENERAL"),
             Self::CLOSEST_HIT => Some("CLOSEST_HIT"),
@@ -4760,7 +4760,7 @@ impl fmt::Debug for ShaderGroupShaderKHR {
     }
 }
 impl fmt::Debug for ShaderInfoTypeAMD {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::STATISTICS => Some("STATISTICS"),
             Self::BINARY => Some("BINARY"),
@@ -4775,13 +4775,13 @@ impl fmt::Debug for ShaderInfoTypeAMD {
     }
 }
 impl fmt::Debug for ShaderModuleCreateFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ShaderStageFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ShaderStageFlags::VERTEX.0, "VERTEX"),
             (
@@ -4818,7 +4818,7 @@ impl fmt::Debug for ShaderStageFlags {
     }
 }
 impl fmt::Debug for ShadingRatePaletteEntryNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::NO_INVOCATIONS => Some("NO_INVOCATIONS"),
             Self::TYPE_16_INVOCATIONS_PER_PIXEL => Some("TYPE_16_INVOCATIONS_PER_PIXEL"),
@@ -4842,7 +4842,7 @@ impl fmt::Debug for ShadingRatePaletteEntryNV {
     }
 }
 impl fmt::Debug for SharingMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::EXCLUSIVE => Some("EXCLUSIVE"),
             Self::CONCURRENT => Some("CONCURRENT"),
@@ -4856,7 +4856,7 @@ impl fmt::Debug for SharingMode {
     }
 }
 impl fmt::Debug for SparseImageFormatFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (SparseImageFormatFlags::SINGLE_MIPTAIL.0, "SINGLE_MIPTAIL"),
             (
@@ -4872,13 +4872,13 @@ impl fmt::Debug for SparseImageFormatFlags {
     }
 }
 impl fmt::Debug for SparseMemoryBindFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(SparseMemoryBindFlags::METADATA.0, "METADATA")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for StencilFaceFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (StencilFaceFlags::FRONT.0, "FRONT"),
             (StencilFaceFlags::BACK.0, "BACK"),
@@ -4888,7 +4888,7 @@ impl fmt::Debug for StencilFaceFlags {
     }
 }
 impl fmt::Debug for StencilOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::KEEP => Some("KEEP"),
             Self::ZERO => Some("ZERO"),
@@ -4908,13 +4908,13 @@ impl fmt::Debug for StencilOp {
     }
 }
 impl fmt::Debug for StreamDescriptorSurfaceCreateFlagsGGP {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for StructureType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::APPLICATION_INFO => Some("APPLICATION_INFO"),
             Self::INSTANCE_CREATE_INFO => Some("INSTANCE_CREATE_INFO"),
@@ -6835,7 +6835,7 @@ impl fmt::Debug for StructureType {
     }
 }
 impl fmt::Debug for SubgroupFeatureFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (SubgroupFeatureFlags::BASIC.0, "BASIC"),
             (SubgroupFeatureFlags::VOTE.0, "VOTE"),
@@ -6851,13 +6851,13 @@ impl fmt::Debug for SubgroupFeatureFlags {
     }
 }
 impl fmt::Debug for SubmitFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(SubmitFlags::PROTECTED.0, "PROTECTED")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for SubpassContents {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::INLINE => Some("INLINE"),
             Self::SECONDARY_COMMAND_BUFFERS => Some("SECONDARY_COMMAND_BUFFERS"),
@@ -6874,7 +6874,7 @@ impl fmt::Debug for SubpassContents {
     }
 }
 impl fmt::Debug for SubpassDescriptionFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 SubpassDescriptionFlags::PER_VIEW_ATTRIBUTES_NVX.0,
@@ -6913,7 +6913,7 @@ impl fmt::Debug for SubpassDescriptionFlags {
     }
 }
 impl fmt::Debug for SubpassMergeStatusEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::MERGED => Some("MERGED"),
             Self::DISALLOWED => Some("DISALLOWED"),
@@ -6943,13 +6943,13 @@ impl fmt::Debug for SubpassMergeStatusEXT {
     }
 }
 impl fmt::Debug for SurfaceCounterFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for SurfaceTransformFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (SurfaceTransformFlagsKHR::IDENTITY.0, "IDENTITY"),
             (SurfaceTransformFlagsKHR::ROTATE_90.0, "ROTATE_90"),
@@ -6977,7 +6977,7 @@ impl fmt::Debug for SurfaceTransformFlagsKHR {
     }
 }
 impl fmt::Debug for SwapchainCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 SwapchainCreateFlagsKHR::SPLIT_INSTANCE_BIND_REGIONS.0,
@@ -6994,13 +6994,13 @@ impl fmt::Debug for SwapchainCreateFlagsKHR {
     }
 }
 impl fmt::Debug for SwapchainImageUsageFlagsANDROID {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[(SwapchainImageUsageFlagsANDROID::SHARED.0, "SHARED")];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for SystemAllocationScope {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::COMMAND => Some("COMMAND"),
             Self::OBJECT => Some("OBJECT"),
@@ -7017,7 +7017,7 @@ impl fmt::Debug for SystemAllocationScope {
     }
 }
 impl fmt::Debug for TessellationDomainOrigin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UPPER_LEFT => Some("UPPER_LEFT"),
             Self::LOWER_LEFT => Some("LOWER_LEFT"),
@@ -7031,7 +7031,7 @@ impl fmt::Debug for TessellationDomainOrigin {
     }
 }
 impl fmt::Debug for TimeDomainEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEVICE => Some("DEVICE"),
             Self::CLOCK_MONOTONIC => Some("CLOCK_MONOTONIC"),
@@ -7047,7 +7047,7 @@ impl fmt::Debug for TimeDomainEXT {
     }
 }
 impl fmt::Debug for ToolPurposeFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (ToolPurposeFlags::VALIDATION.0, "VALIDATION"),
             (ToolPurposeFlags::PROFILING.0, "PROFILING"),
@@ -7067,13 +7067,13 @@ impl fmt::Debug for ToolPurposeFlags {
     }
 }
 impl fmt::Debug for ValidationCacheCreateFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ValidationCacheHeaderVersionEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ONE => Some("ONE"),
             _ => None,
@@ -7086,7 +7086,7 @@ impl fmt::Debug for ValidationCacheHeaderVersionEXT {
     }
 }
 impl fmt::Debug for ValidationCheckEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ALL => Some("ALL"),
             Self::SHADERS => Some("SHADERS"),
@@ -7100,7 +7100,7 @@ impl fmt::Debug for ValidationCheckEXT {
     }
 }
 impl fmt::Debug for ValidationFeatureDisableEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::ALL => Some("ALL"),
             Self::SHADERS => Some("SHADERS"),
@@ -7120,7 +7120,7 @@ impl fmt::Debug for ValidationFeatureDisableEXT {
     }
 }
 impl fmt::Debug for ValidationFeatureEnableEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::GPU_ASSISTED => Some("GPU_ASSISTED"),
             Self::GPU_ASSISTED_RESERVE_BINDING_SLOT => Some("GPU_ASSISTED_RESERVE_BINDING_SLOT"),
@@ -7137,7 +7137,7 @@ impl fmt::Debug for ValidationFeatureEnableEXT {
     }
 }
 impl fmt::Debug for VendorId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::VIV => Some("VIV"),
             Self::VSI => Some("VSI"),
@@ -7156,7 +7156,7 @@ impl fmt::Debug for VendorId {
     }
 }
 impl fmt::Debug for VertexInputRate {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::VERTEX => Some("VERTEX"),
             Self::INSTANCE => Some("INSTANCE"),
@@ -7170,19 +7170,19 @@ impl fmt::Debug for VertexInputRate {
     }
 }
 impl fmt::Debug for ViSurfaceCreateFlagsNN {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for VideoBeginCodingFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for VideoCapabilityFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoCapabilityFlagsKHR::PROTECTED_CONTENT.0,
@@ -7197,7 +7197,7 @@ impl fmt::Debug for VideoCapabilityFlagsKHR {
     }
 }
 impl fmt::Debug for VideoChromaSubsamplingFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoChromaSubsamplingFlagsKHR::INVALID.0, "INVALID"),
             (VideoChromaSubsamplingFlagsKHR::MONOCHROME.0, "MONOCHROME"),
@@ -7209,7 +7209,7 @@ impl fmt::Debug for VideoChromaSubsamplingFlagsKHR {
     }
 }
 impl fmt::Debug for VideoCodecOperationFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoCodecOperationFlagsKHR::NONE.0, "NONE"),
             (
@@ -7227,7 +7227,7 @@ impl fmt::Debug for VideoCodecOperationFlagsKHR {
     }
 }
 impl fmt::Debug for VideoCodingControlFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoCodingControlFlagsKHR::RESET.0, "RESET"),
             (
@@ -7243,7 +7243,7 @@ impl fmt::Debug for VideoCodingControlFlagsKHR {
     }
 }
 impl fmt::Debug for VideoComponentBitDepthFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoComponentBitDepthFlagsKHR::INVALID.0, "INVALID"),
             (VideoComponentBitDepthFlagsKHR::TYPE_8.0, "TYPE_8"),
@@ -7254,7 +7254,7 @@ impl fmt::Debug for VideoComponentBitDepthFlagsKHR {
     }
 }
 impl fmt::Debug for VideoDecodeCapabilityFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoDecodeCapabilityFlagsKHR::DPB_AND_OUTPUT_COINCIDE.0,
@@ -7269,13 +7269,13 @@ impl fmt::Debug for VideoDecodeCapabilityFlagsKHR {
     }
 }
 impl fmt::Debug for VideoDecodeFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for VideoDecodeH264PictureLayoutFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoDecodeH264PictureLayoutFlagsKHR::PROGRESSIVE.0,
@@ -7294,7 +7294,7 @@ impl fmt::Debug for VideoDecodeH264PictureLayoutFlagsKHR {
     }
 }
 impl fmt::Debug for VideoDecodeUsageFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoDecodeUsageFlagsKHR::DEFAULT.0, "DEFAULT"),
             (VideoDecodeUsageFlagsKHR::TRANSCODING.0, "TRANSCODING"),
@@ -7305,7 +7305,7 @@ impl fmt::Debug for VideoDecodeUsageFlagsKHR {
     }
 }
 impl fmt::Debug for VideoEncodeCapabilityFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeCapabilityFlagsKHR::PRECEDING_EXTERNALLY_ENCODED_BYTES.0,
@@ -7320,7 +7320,7 @@ impl fmt::Debug for VideoEncodeCapabilityFlagsKHR {
     }
 }
 impl fmt::Debug for VideoEncodeContentFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoEncodeContentFlagsKHR::DEFAULT.0, "DEFAULT"),
             (VideoEncodeContentFlagsKHR::CAMERA.0, "CAMERA"),
@@ -7331,7 +7331,7 @@ impl fmt::Debug for VideoEncodeContentFlagsKHR {
     }
 }
 impl fmt::Debug for VideoEncodeFeedbackFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET.0,
@@ -7350,13 +7350,13 @@ impl fmt::Debug for VideoEncodeFeedbackFlagsKHR {
     }
 }
 impl fmt::Debug for VideoEncodeFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for VideoEncodeH264CapabilityFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH264CapabilityFlagsEXT::HRD_COMPLIANCE.0,
@@ -7399,7 +7399,7 @@ impl fmt::Debug for VideoEncodeH264CapabilityFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH264RateControlFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH264RateControlFlagsEXT::ATTEMPT_HRD_COMPLIANCE.0,
@@ -7426,7 +7426,7 @@ impl fmt::Debug for VideoEncodeH264RateControlFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH264StdFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH264StdFlagsEXT::SEPARATE_COLOR_PLANE_FLAG_SET.0,
@@ -7513,7 +7513,7 @@ impl fmt::Debug for VideoEncodeH264StdFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH265CapabilityFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH265CapabilityFlagsEXT::HRD_COMPLIANCE.0,
@@ -7560,7 +7560,7 @@ impl fmt::Debug for VideoEncodeH265CapabilityFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH265CtbSizeFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoEncodeH265CtbSizeFlagsEXT::TYPE_16.0, "TYPE_16"),
             (VideoEncodeH265CtbSizeFlagsEXT::TYPE_32.0, "TYPE_32"),
@@ -7570,7 +7570,7 @@ impl fmt::Debug for VideoEncodeH265CtbSizeFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH265RateControlFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH265RateControlFlagsEXT::ATTEMPT_HRD_COMPLIANCE.0,
@@ -7597,7 +7597,7 @@ impl fmt::Debug for VideoEncodeH265RateControlFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH265StdFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH265StdFlagsEXT::SEPARATE_COLOR_PLANE_FLAG_SET.0,
@@ -7688,7 +7688,7 @@ impl fmt::Debug for VideoEncodeH265StdFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeH265TransformBlockSizeFlagsEXT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoEncodeH265TransformBlockSizeFlagsEXT::TYPE_4.0,
@@ -7711,13 +7711,13 @@ impl fmt::Debug for VideoEncodeH265TransformBlockSizeFlagsEXT {
     }
 }
 impl fmt::Debug for VideoEncodeRateControlFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for VideoEncodeRateControlModeFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoEncodeRateControlModeFlagsKHR::DEFAULT.0, "DEFAULT"),
             (VideoEncodeRateControlModeFlagsKHR::DISABLED.0, "DISABLED"),
@@ -7728,7 +7728,7 @@ impl fmt::Debug for VideoEncodeRateControlModeFlagsKHR {
     }
 }
 impl fmt::Debug for VideoEncodeTuningModeKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::DEFAULT => Some("DEFAULT"),
             Self::HIGH_QUALITY => Some("HIGH_QUALITY"),
@@ -7745,7 +7745,7 @@ impl fmt::Debug for VideoEncodeTuningModeKHR {
     }
 }
 impl fmt::Debug for VideoEncodeUsageFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoEncodeUsageFlagsKHR::DEFAULT.0, "DEFAULT"),
             (VideoEncodeUsageFlagsKHR::TRANSCODING.0, "TRANSCODING"),
@@ -7757,13 +7757,13 @@ impl fmt::Debug for VideoEncodeUsageFlagsKHR {
     }
 }
 impl fmt::Debug for VideoEndCodingFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for VideoSessionCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
                 VideoSessionCreateFlagsKHR::PROTECTED_CONTENT.0,
@@ -7778,13 +7778,13 @@ impl fmt::Debug for VideoSessionCreateFlagsKHR {
     }
 }
 impl fmt::Debug for VideoSessionParametersCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ViewportCoordinateSwizzleNV {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::POSITIVE_X => Some("POSITIVE_X"),
             Self::NEGATIVE_X => Some("NEGATIVE_X"),
@@ -7804,25 +7804,25 @@ impl fmt::Debug for ViewportCoordinateSwizzleNV {
     }
 }
 impl fmt::Debug for WaylandSurfaceCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for Win32SurfaceCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for XcbSurfaceCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for XlibSurfaceCreateFlagsKHR {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -525,7 +525,7 @@ pub type PFN_vkDebugUtilsMessengerCallbackEXT = Option<
     unsafe extern "system" fn(
         message_severity: DebugUtilsMessageSeverityFlagsEXT,
         message_types: DebugUtilsMessageTypeFlagsEXT,
-        p_callback_data: *const DebugUtilsMessengerCallbackDataEXT,
+        p_callback_data: *const DebugUtilsMessengerCallbackDataEXT<'_>,
         p_user_data: *mut c_void,
     ) -> Bool32,
 >;
@@ -533,7 +533,7 @@ pub type PFN_vkDebugUtilsMessengerCallbackEXT = Option<
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/PFN_vkDeviceMemoryReportCallbackEXT.html>"]
 pub type PFN_vkDeviceMemoryReportCallbackEXT = Option<
     unsafe extern "system" fn(
-        p_callback_data: *const DeviceMemoryReportCallbackDataEXT,
+        p_callback_data: *const DeviceMemoryReportCallbackDataEXT<'_>,
         p_user_data: *mut c_void,
     ),
 >;
@@ -810,7 +810,7 @@ pub struct PhysicalDeviceProperties {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PhysicalDeviceProperties {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PhysicalDeviceProperties")
             .field("api_version", &self.api_version)
             .field("driver_version", &self.driver_version)
@@ -898,7 +898,7 @@ pub struct ExtensionProperties {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for ExtensionProperties {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("ExtensionProperties")
             .field("extension_name", &unsafe {
                 ::std::ffi::CStr::from_ptr(self.extension_name.as_ptr())
@@ -939,7 +939,7 @@ pub struct LayerProperties {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for LayerProperties {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("LayerProperties")
             .field("layer_name", &unsafe {
                 ::std::ffi::CStr::from_ptr(self.layer_name.as_ptr())
@@ -1058,7 +1058,7 @@ pub struct AllocationCallbacks<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AllocationCallbacks<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AllocationCallbacks")
             .field("p_user_data", &self.p_user_data)
             .field(
@@ -1242,7 +1242,10 @@ impl<'a> DeviceCreateInfo<'a> {
         self
     }
     #[inline]
-    pub fn queue_create_infos(mut self, queue_create_infos: &'a [DeviceQueueCreateInfo]) -> Self {
+    pub fn queue_create_infos(
+        mut self,
+        queue_create_infos: &'a [DeviceQueueCreateInfo<'a>],
+    ) -> Self {
         self.queue_create_info_count = queue_create_infos.len() as _;
         self.p_queue_create_infos = queue_create_infos.as_ptr();
         self
@@ -2951,7 +2954,7 @@ impl<'a> BindSparseInfo<'a> {
         self
     }
     #[inline]
-    pub fn buffer_binds(mut self, buffer_binds: &'a [SparseBufferMemoryBindInfo]) -> Self {
+    pub fn buffer_binds(mut self, buffer_binds: &'a [SparseBufferMemoryBindInfo<'a>]) -> Self {
         self.buffer_bind_count = buffer_binds.len() as _;
         self.p_buffer_binds = buffer_binds.as_ptr();
         self
@@ -2959,14 +2962,14 @@ impl<'a> BindSparseInfo<'a> {
     #[inline]
     pub fn image_opaque_binds(
         mut self,
-        image_opaque_binds: &'a [SparseImageOpaqueMemoryBindInfo],
+        image_opaque_binds: &'a [SparseImageOpaqueMemoryBindInfo<'a>],
     ) -> Self {
         self.image_opaque_bind_count = image_opaque_binds.len() as _;
         self.p_image_opaque_binds = image_opaque_binds.as_ptr();
         self
     }
     #[inline]
-    pub fn image_binds(mut self, image_binds: &'a [SparseImageMemoryBindInfo]) -> Self {
+    pub fn image_binds(mut self, image_binds: &'a [SparseImageMemoryBindInfo<'a>]) -> Self {
         self.image_bind_count = image_binds.len() as _;
         self.p_image_binds = image_binds.as_ptr();
         self
@@ -3371,7 +3374,7 @@ impl<'a> DescriptorSetLayoutCreateInfo<'a> {
         self
     }
     #[inline]
-    pub fn bindings(mut self, bindings: &'a [DescriptorSetLayoutBinding]) -> Self {
+    pub fn bindings(mut self, bindings: &'a [DescriptorSetLayoutBinding<'a>]) -> Self {
         self.binding_count = bindings.len() as _;
         self.p_bindings = bindings.as_ptr();
         self
@@ -4738,7 +4741,7 @@ impl<'a> GraphicsPipelineCreateInfo<'a> {
         self
     }
     #[inline]
-    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo<'a>]) -> Self {
         self.stage_count = stages.len() as _;
         self.p_stages = stages.as_ptr();
         self
@@ -5406,7 +5409,7 @@ pub struct RenderPassBeginInfo<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for RenderPassBeginInfo<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("RenderPassBeginInfo")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -5531,7 +5534,7 @@ pub struct ClearAttachment {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for ClearAttachment {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("ClearAttachment")
             .field("aspect_mask", &self.aspect_mask)
             .field("color_attachment", &self.color_attachment)
@@ -5817,7 +5820,7 @@ impl<'a> RenderPassCreateInfo<'a> {
         self
     }
     #[inline]
-    pub fn subpasses(mut self, subpasses: &'a [SubpassDescription]) -> Self {
+    pub fn subpasses(mut self, subpasses: &'a [SubpassDescription<'a>]) -> Self {
         self.subpass_count = subpasses.len() as _;
         self.p_subpasses = subpasses.as_ptr();
         self
@@ -8768,7 +8771,7 @@ pub struct DebugReportCallbackCreateInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DebugReportCallbackCreateInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DebugReportCallbackCreateInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -9803,7 +9806,7 @@ unsafe impl<'a> TaggedStructure for GraphicsShaderGroupCreateInfoNV<'a> {
 }
 impl<'a> GraphicsShaderGroupCreateInfoNV<'a> {
     #[inline]
-    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo<'a>]) -> Self {
         self.stage_count = stages.len() as _;
         self.p_stages = stages.as_ptr();
         self
@@ -9859,7 +9862,7 @@ unsafe impl<'a> TaggedStructure for GraphicsPipelineShaderGroupsCreateInfoNV<'a>
 unsafe impl ExtendsGraphicsPipelineCreateInfo for GraphicsPipelineShaderGroupsCreateInfoNV<'_> {}
 impl<'a> GraphicsPipelineShaderGroupsCreateInfoNV<'a> {
     #[inline]
-    pub fn groups(mut self, groups: &'a [GraphicsShaderGroupCreateInfoNV]) -> Self {
+    pub fn groups(mut self, groups: &'a [GraphicsShaderGroupCreateInfoNV<'a>]) -> Self {
         self.group_count = groups.len() as _;
         self.p_groups = groups.as_ptr();
         self
@@ -10135,7 +10138,7 @@ impl<'a> IndirectCommandsLayoutCreateInfoNV<'a> {
         self
     }
     #[inline]
-    pub fn tokens(mut self, tokens: &'a [IndirectCommandsLayoutTokenNV]) -> Self {
+    pub fn tokens(mut self, tokens: &'a [IndirectCommandsLayoutTokenNV<'a>]) -> Self {
         self.token_count = tokens.len() as _;
         self.p_tokens = tokens.as_ptr();
         self
@@ -10895,7 +10898,7 @@ pub struct PhysicalDeviceDriverProperties<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PhysicalDeviceDriverProperties<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PhysicalDeviceDriverProperties")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -10979,7 +10982,7 @@ unsafe impl<'a> TaggedStructure for PresentRegionsKHR<'a> {
 unsafe impl ExtendsPresentInfoKHR for PresentRegionsKHR<'_> {}
 impl<'a> PresentRegionsKHR<'a> {
     #[inline]
-    pub fn regions(mut self, regions: &'a [PresentRegionKHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [PresentRegionKHR<'a>]) -> Self {
         self.swapchain_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -16504,7 +16507,7 @@ impl<'a> RenderPassSampleLocationsBeginInfoEXT<'a> {
     #[inline]
     pub fn attachment_initial_sample_locations(
         mut self,
-        attachment_initial_sample_locations: &'a [AttachmentSampleLocationsEXT],
+        attachment_initial_sample_locations: &'a [AttachmentSampleLocationsEXT<'a>],
     ) -> Self {
         self.attachment_initial_sample_locations_count =
             attachment_initial_sample_locations.len() as _;
@@ -16514,7 +16517,7 @@ impl<'a> RenderPassSampleLocationsBeginInfoEXT<'a> {
     #[inline]
     pub fn post_subpass_sample_locations(
         mut self,
-        post_subpass_sample_locations: &'a [SubpassSampleLocationsEXT],
+        post_subpass_sample_locations: &'a [SubpassSampleLocationsEXT<'a>],
     ) -> Self {
         self.post_subpass_sample_locations_count = post_subpass_sample_locations.len() as _;
         self.p_post_subpass_sample_locations = post_subpass_sample_locations.as_ptr();
@@ -18403,7 +18406,7 @@ pub struct DebugUtilsMessengerCreateInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DebugUtilsMessengerCreateInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DebugUtilsMessengerCreateInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -18532,19 +18535,19 @@ impl<'a> DebugUtilsMessengerCallbackDataEXT<'a> {
         self
     }
     #[inline]
-    pub fn queue_labels(mut self, queue_labels: &'a [DebugUtilsLabelEXT]) -> Self {
+    pub fn queue_labels(mut self, queue_labels: &'a [DebugUtilsLabelEXT<'a>]) -> Self {
         self.queue_label_count = queue_labels.len() as _;
         self.p_queue_labels = queue_labels.as_ptr();
         self
     }
     #[inline]
-    pub fn cmd_buf_labels(mut self, cmd_buf_labels: &'a [DebugUtilsLabelEXT]) -> Self {
+    pub fn cmd_buf_labels(mut self, cmd_buf_labels: &'a [DebugUtilsLabelEXT<'a>]) -> Self {
         self.cmd_buf_label_count = cmd_buf_labels.len() as _;
         self.p_cmd_buf_labels = cmd_buf_labels.as_ptr();
         self
     }
     #[inline]
-    pub fn objects(mut self, objects: &'a [DebugUtilsObjectNameInfoEXT]) -> Self {
+    pub fn objects(mut self, objects: &'a [DebugUtilsObjectNameInfoEXT<'a>]) -> Self {
         self.object_count = objects.len() as _;
         self.p_objects = objects.as_ptr();
         self
@@ -18614,7 +18617,7 @@ pub struct DeviceDeviceMemoryReportCreateInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DeviceDeviceMemoryReportCreateInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DeviceDeviceMemoryReportCreateInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -20057,19 +20060,22 @@ impl<'a> SubpassDescription2<'a> {
         self
     }
     #[inline]
-    pub fn input_attachments(mut self, input_attachments: &'a [AttachmentReference2]) -> Self {
+    pub fn input_attachments(mut self, input_attachments: &'a [AttachmentReference2<'a>]) -> Self {
         self.input_attachment_count = input_attachments.len() as _;
         self.p_input_attachments = input_attachments.as_ptr();
         self
     }
     #[inline]
-    pub fn color_attachments(mut self, color_attachments: &'a [AttachmentReference2]) -> Self {
+    pub fn color_attachments(mut self, color_attachments: &'a [AttachmentReference2<'a>]) -> Self {
         self.color_attachment_count = color_attachments.len() as _;
         self.p_color_attachments = color_attachments.as_ptr();
         self
     }
     #[inline]
-    pub fn resolve_attachments(mut self, resolve_attachments: &'a [AttachmentReference2]) -> Self {
+    pub fn resolve_attachments(
+        mut self,
+        resolve_attachments: &'a [AttachmentReference2<'a>],
+    ) -> Self {
         self.color_attachment_count = resolve_attachments.len() as _;
         self.p_resolve_attachments = resolve_attachments.as_ptr();
         self
@@ -20246,19 +20252,19 @@ impl<'a> RenderPassCreateInfo2<'a> {
         self
     }
     #[inline]
-    pub fn attachments(mut self, attachments: &'a [AttachmentDescription2]) -> Self {
+    pub fn attachments(mut self, attachments: &'a [AttachmentDescription2<'a>]) -> Self {
         self.attachment_count = attachments.len() as _;
         self.p_attachments = attachments.as_ptr();
         self
     }
     #[inline]
-    pub fn subpasses(mut self, subpasses: &'a [SubpassDescription2]) -> Self {
+    pub fn subpasses(mut self, subpasses: &'a [SubpassDescription2<'a>]) -> Self {
         self.subpass_count = subpasses.len() as _;
         self.p_subpasses = subpasses.as_ptr();
         self
     }
     #[inline]
-    pub fn dependencies(mut self, dependencies: &'a [SubpassDependency2]) -> Self {
+    pub fn dependencies(mut self, dependencies: &'a [SubpassDependency2<'a>]) -> Self {
         self.dependency_count = dependencies.len() as _;
         self.p_dependencies = dependencies.as_ptr();
         self
@@ -22546,7 +22552,7 @@ impl<'a> PipelineViewportShadingRateImageStateCreateInfoNV<'a> {
     #[inline]
     pub fn shading_rate_palettes(
         mut self,
-        shading_rate_palettes: &'a [ShadingRatePaletteNV],
+        shading_rate_palettes: &'a [ShadingRatePaletteNV<'a>],
     ) -> Self {
         self.viewport_count = shading_rate_palettes.len() as _;
         self.p_shading_rate_palettes = shading_rate_palettes.as_ptr();
@@ -22787,7 +22793,7 @@ impl<'a> PipelineViewportCoarseSampleOrderStateCreateInfoNV<'a> {
     #[inline]
     pub fn custom_sample_orders(
         mut self,
-        custom_sample_orders: &'a [CoarseSampleOrderCustomNV],
+        custom_sample_orders: &'a [CoarseSampleOrderCustomNV<'a>],
     ) -> Self {
         self.custom_sample_order_count = custom_sample_orders.len() as _;
         self.p_custom_sample_orders = custom_sample_orders.as_ptr();
@@ -23495,13 +23501,13 @@ impl<'a> RayTracingPipelineCreateInfoNV<'a> {
         self
     }
     #[inline]
-    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo<'a>]) -> Self {
         self.stage_count = stages.len() as _;
         self.p_stages = stages.as_ptr();
         self
     }
     #[inline]
-    pub fn groups(mut self, groups: &'a [RayTracingShaderGroupCreateInfoNV]) -> Self {
+    pub fn groups(mut self, groups: &'a [RayTracingShaderGroupCreateInfoNV<'a>]) -> Self {
         self.group_count = groups.len() as _;
         self.p_groups = groups.as_ptr();
         self
@@ -23595,13 +23601,13 @@ impl<'a> RayTracingPipelineCreateInfoKHR<'a> {
         self
     }
     #[inline]
-    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo<'a>]) -> Self {
         self.stage_count = stages.len() as _;
         self.p_stages = stages.as_ptr();
         self
     }
     #[inline]
-    pub fn groups(mut self, groups: &'a [RayTracingShaderGroupCreateInfoKHR]) -> Self {
+    pub fn groups(mut self, groups: &'a [RayTracingShaderGroupCreateInfoKHR<'a>]) -> Self {
         self.group_count = groups.len() as _;
         self.p_groups = groups.as_ptr();
         self
@@ -23930,7 +23936,7 @@ impl<'a> AccelerationStructureInfoNV<'a> {
         self
     }
     #[inline]
-    pub fn geometries(mut self, geometries: &'a [GeometryNV]) -> Self {
+    pub fn geometries(mut self, geometries: &'a [GeometryNV<'a>]) -> Self {
         self.geometry_count = geometries.len() as _;
         self.p_geometries = geometries.as_ptr();
         self
@@ -26170,7 +26176,7 @@ impl<'a> FramebufferAttachmentsCreateInfo<'a> {
     #[inline]
     pub fn attachment_image_infos(
         mut self,
-        attachment_image_infos: &'a [FramebufferAttachmentImageInfo],
+        attachment_image_infos: &'a [FramebufferAttachmentImageInfo<'a>],
     ) -> Self {
         self.attachment_image_info_count = attachment_image_infos.len() as _;
         self.p_attachment_image_infos = attachment_image_infos.as_ptr();
@@ -27048,7 +27054,7 @@ pub struct PerformanceCounterDescriptionKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PerformanceCounterDescriptionKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PerformanceCounterDescriptionKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -27462,7 +27468,7 @@ pub struct PerformanceValueINTEL {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PerformanceValueINTEL {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PerformanceValueINTEL")
             .field("ty", &self.ty)
             .field("data", &"union")
@@ -28135,7 +28141,7 @@ pub struct PipelineExecutablePropertiesKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PipelineExecutablePropertiesKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PipelineExecutablePropertiesKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -28256,7 +28262,7 @@ pub struct PipelineExecutableStatisticKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PipelineExecutableStatisticKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PipelineExecutableStatisticKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -28325,7 +28331,7 @@ pub struct PipelineExecutableInternalRepresentationKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PipelineExecutableInternalRepresentationKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PipelineExecutableInternalRepresentationKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -29832,7 +29838,7 @@ pub struct PhysicalDeviceVulkan12Properties<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PhysicalDeviceVulkan12Properties<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PhysicalDeviceVulkan12Properties")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31189,7 +31195,7 @@ pub struct PhysicalDeviceToolProperties<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for PhysicalDeviceToolProperties<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PhysicalDeviceToolProperties")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31266,7 +31272,7 @@ pub struct SamplerCustomBorderColorCreateInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for SamplerCustomBorderColorCreateInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("SamplerCustomBorderColorCreateInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31524,7 +31530,7 @@ pub struct AccelerationStructureGeometryTrianglesDataKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureGeometryTrianglesDataKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureGeometryTrianglesDataKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31626,7 +31632,7 @@ pub struct AccelerationStructureGeometryAabbsDataKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureGeometryAabbsDataKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureGeometryAabbsDataKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31675,7 +31681,7 @@ pub struct AccelerationStructureGeometryInstancesDataKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureGeometryInstancesDataKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureGeometryInstancesDataKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31739,7 +31745,7 @@ pub struct AccelerationStructureGeometryKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureGeometryKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureGeometryKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31801,7 +31807,7 @@ pub struct AccelerationStructureBuildGeometryInfoKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureBuildGeometryInfoKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureBuildGeometryInfoKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -31879,7 +31885,7 @@ impl<'a> AccelerationStructureBuildGeometryInfoKHR<'a> {
         self
     }
     #[inline]
-    pub fn geometries(mut self, geometries: &'a [AccelerationStructureGeometryKHR]) -> Self {
+    pub fn geometries(mut self, geometries: &'a [AccelerationStructureGeometryKHR<'a>]) -> Self {
         self.geometry_count = geometries.len() as _;
         self.p_geometries = geometries.as_ptr();
         self
@@ -31887,7 +31893,7 @@ impl<'a> AccelerationStructureBuildGeometryInfoKHR<'a> {
     #[inline]
     pub fn geometries_ptrs(
         mut self,
-        geometries_ptrs: &'a [&'a AccelerationStructureGeometryKHR],
+        geometries_ptrs: &'a [&'a AccelerationStructureGeometryKHR<'a>],
     ) -> Self {
         self.geometry_count = geometries_ptrs.len() as _;
         self.pp_geometries = geometries_ptrs.as_ptr().cast();
@@ -32205,7 +32211,7 @@ pub struct CopyAccelerationStructureToMemoryInfoKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for CopyAccelerationStructureToMemoryInfoKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("CopyAccelerationStructureToMemoryInfoKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -32262,7 +32268,7 @@ pub struct CopyMemoryToAccelerationStructureInfoKHR<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for CopyMemoryToAccelerationStructureInfoKHR<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("CopyMemoryToAccelerationStructureInfoKHR")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -34074,7 +34080,7 @@ impl<'a> CopyBufferInfo2<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [BufferCopy2]) -> Self {
+    pub fn regions(mut self, regions: &'a [BufferCopy2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -34136,7 +34142,7 @@ impl<'a> CopyImageInfo2<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [ImageCopy2]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageCopy2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -34201,7 +34207,7 @@ impl<'a> BlitImageInfo2<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [ImageBlit2]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageBlit2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -34275,7 +34281,7 @@ impl<'a> CopyBufferToImageInfo2<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [BufferImageCopy2]) -> Self {
+    pub fn regions(mut self, regions: &'a [BufferImageCopy2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -34330,7 +34336,7 @@ impl<'a> CopyImageToBufferInfo2<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [BufferImageCopy2]) -> Self {
+    pub fn regions(mut self, regions: &'a [BufferImageCopy2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -34392,7 +34398,7 @@ impl<'a> ResolveImageInfo2<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [ImageResolve2]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageResolve2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -35265,7 +35271,7 @@ impl<'a> MutableDescriptorTypeCreateInfoEXT<'a> {
     #[inline]
     pub fn mutable_descriptor_type_lists(
         mut self,
-        mutable_descriptor_type_lists: &'a [MutableDescriptorTypeListEXT],
+        mutable_descriptor_type_lists: &'a [MutableDescriptorTypeListEXT<'a>],
     ) -> Self {
         self.mutable_descriptor_type_list_count = mutable_descriptor_type_lists.len() as _;
         self.p_mutable_descriptor_type_lists = mutable_descriptor_type_lists.as_ptr();
@@ -35893,7 +35899,7 @@ impl<'a> DependencyInfo<'a> {
         self
     }
     #[inline]
-    pub fn memory_barriers(mut self, memory_barriers: &'a [MemoryBarrier2]) -> Self {
+    pub fn memory_barriers(mut self, memory_barriers: &'a [MemoryBarrier2<'a>]) -> Self {
         self.memory_barrier_count = memory_barriers.len() as _;
         self.p_memory_barriers = memory_barriers.as_ptr();
         self
@@ -35901,7 +35907,7 @@ impl<'a> DependencyInfo<'a> {
     #[inline]
     pub fn buffer_memory_barriers(
         mut self,
-        buffer_memory_barriers: &'a [BufferMemoryBarrier2],
+        buffer_memory_barriers: &'a [BufferMemoryBarrier2<'a>],
     ) -> Self {
         self.buffer_memory_barrier_count = buffer_memory_barriers.len() as _;
         self.p_buffer_memory_barriers = buffer_memory_barriers.as_ptr();
@@ -35910,7 +35916,7 @@ impl<'a> DependencyInfo<'a> {
     #[inline]
     pub fn image_memory_barriers(
         mut self,
-        image_memory_barriers: &'a [ImageMemoryBarrier2],
+        image_memory_barriers: &'a [ImageMemoryBarrier2<'a>],
     ) -> Self {
         self.image_memory_barrier_count = image_memory_barriers.len() as _;
         self.p_image_memory_barriers = image_memory_barriers.as_ptr();
@@ -36051,7 +36057,10 @@ impl<'a> SubmitInfo2<'a> {
         self
     }
     #[inline]
-    pub fn wait_semaphore_infos(mut self, wait_semaphore_infos: &'a [SemaphoreSubmitInfo]) -> Self {
+    pub fn wait_semaphore_infos(
+        mut self,
+        wait_semaphore_infos: &'a [SemaphoreSubmitInfo<'a>],
+    ) -> Self {
         self.wait_semaphore_info_count = wait_semaphore_infos.len() as _;
         self.p_wait_semaphore_infos = wait_semaphore_infos.as_ptr();
         self
@@ -36059,7 +36068,7 @@ impl<'a> SubmitInfo2<'a> {
     #[inline]
     pub fn command_buffer_infos(
         mut self,
-        command_buffer_infos: &'a [CommandBufferSubmitInfo],
+        command_buffer_infos: &'a [CommandBufferSubmitInfo<'a>],
     ) -> Self {
         self.command_buffer_info_count = command_buffer_infos.len() as _;
         self.p_command_buffer_infos = command_buffer_infos.as_ptr();
@@ -36068,7 +36077,7 @@ impl<'a> SubmitInfo2<'a> {
     #[inline]
     pub fn signal_semaphore_infos(
         mut self,
-        signal_semaphore_infos: &'a [SemaphoreSubmitInfo],
+        signal_semaphore_infos: &'a [SemaphoreSubmitInfo<'a>],
     ) -> Self {
         self.signal_semaphore_info_count = signal_semaphore_infos.len() as _;
         self.p_signal_semaphore_infos = signal_semaphore_infos.as_ptr();
@@ -36476,7 +36485,7 @@ impl<'a> CopyMemoryToImageInfoEXT<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [MemoryToImageCopyEXT]) -> Self {
+    pub fn regions(mut self, regions: &'a [MemoryToImageCopyEXT<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -36531,7 +36540,7 @@ impl<'a> CopyImageToMemoryInfoEXT<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [ImageToMemoryCopyEXT]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageToMemoryCopyEXT<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -36600,7 +36609,7 @@ impl<'a> CopyImageToImageInfoEXT<'a> {
         self
     }
     #[inline]
-    pub fn regions(mut self, regions: &'a [ImageCopy2]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageCopy2<'a>]) -> Self {
         self.region_count = regions.len() as _;
         self.p_regions = regions.as_ptr();
         self
@@ -37080,7 +37089,7 @@ unsafe impl ExtendsImageCreateInfo for VideoProfileListInfoKHR<'_> {}
 unsafe impl ExtendsBufferCreateInfo for VideoProfileListInfoKHR<'_> {}
 impl<'a> VideoProfileListInfoKHR<'a> {
     #[inline]
-    pub fn profiles(mut self, profiles: &'a [VideoProfileInfoKHR]) -> Self {
+    pub fn profiles(mut self, profiles: &'a [VideoProfileInfoKHR<'a>]) -> Self {
         self.profile_count = profiles.len() as _;
         self.p_profiles = profiles.as_ptr();
         self
@@ -37723,7 +37732,7 @@ impl<'a> VideoDecodeInfoKHR<'a> {
         self
     }
     #[inline]
-    pub fn reference_slots(mut self, reference_slots: &'a [VideoReferenceSlotInfoKHR]) -> Self {
+    pub fn reference_slots(mut self, reference_slots: &'a [VideoReferenceSlotInfoKHR<'a>]) -> Self {
         self.reference_slot_count = reference_slots.len() as _;
         self.p_reference_slots = reference_slots.as_ptr();
         self
@@ -38635,7 +38644,7 @@ impl<'a> VideoBeginCodingInfoKHR<'a> {
         self
     }
     #[inline]
-    pub fn reference_slots(mut self, reference_slots: &'a [VideoReferenceSlotInfoKHR]) -> Self {
+    pub fn reference_slots(mut self, reference_slots: &'a [VideoReferenceSlotInfoKHR<'a>]) -> Self {
         self.reference_slot_count = reference_slots.len() as _;
         self.p_reference_slots = reference_slots.as_ptr();
         self
@@ -38858,7 +38867,7 @@ impl<'a> VideoEncodeInfoKHR<'a> {
         self
     }
     #[inline]
-    pub fn reference_slots(mut self, reference_slots: &'a [VideoReferenceSlotInfoKHR]) -> Self {
+    pub fn reference_slots(mut self, reference_slots: &'a [VideoReferenceSlotInfoKHR<'a>]) -> Self {
         self.reference_slot_count = reference_slots.len() as _;
         self.p_reference_slots = reference_slots.as_ptr();
         self
@@ -39107,7 +39116,7 @@ impl<'a> VideoEncodeRateControlInfoKHR<'a> {
         self
     }
     #[inline]
-    pub fn layers(mut self, layers: &'a [VideoEncodeRateControlLayerInfoKHR]) -> Self {
+    pub fn layers(mut self, layers: &'a [VideoEncodeRateControlLayerInfoKHR<'a>]) -> Self {
         self.layer_count = layers.len() as _;
         self.p_layers = layers.as_ptr();
         self
@@ -39822,7 +39831,7 @@ impl<'a> VideoEncodeH264PictureInfoEXT<'a> {
     #[inline]
     pub fn nalu_slice_entries(
         mut self,
-        nalu_slice_entries: &'a [VideoEncodeH264NaluSliceInfoEXT],
+        nalu_slice_entries: &'a [VideoEncodeH264NaluSliceInfoEXT<'a>],
     ) -> Self {
         self.nalu_slice_entry_count = nalu_slice_entries.len() as _;
         self.p_nalu_slice_entries = nalu_slice_entries.as_ptr();
@@ -40707,7 +40716,7 @@ impl<'a> VideoEncodeH265PictureInfoEXT<'a> {
     #[inline]
     pub fn nalu_slice_segment_entries(
         mut self,
-        nalu_slice_segment_entries: &'a [VideoEncodeH265NaluSliceSegmentInfoEXT],
+        nalu_slice_segment_entries: &'a [VideoEncodeH265NaluSliceSegmentInfoEXT<'a>],
     ) -> Self {
         self.nalu_slice_segment_entry_count = nalu_slice_segment_entries.len() as _;
         self.p_nalu_slice_segment_entries = nalu_slice_segment_entries.as_ptr();
@@ -42101,7 +42110,7 @@ pub struct DescriptorGetInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DescriptorGetInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DescriptorGetInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -42913,7 +42922,7 @@ pub struct AccelerationStructureGeometryMotionTrianglesDataNV<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureGeometryMotionTrianglesDataNV<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureGeometryMotionTrianglesDataNV")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -43138,7 +43147,7 @@ pub struct AccelerationStructureMotionInstanceNV {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureMotionInstanceNV {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureMotionInstanceNV")
             .field("ty", &self.ty)
             .field("flags", &self.flags)
@@ -43604,7 +43613,7 @@ impl<'a> ImageFormatConstraintsInfoFUCHSIA<'a> {
         self
     }
     #[inline]
-    pub fn color_spaces(mut self, color_spaces: &'a [SysmemColorSpaceFUCHSIA]) -> Self {
+    pub fn color_spaces(mut self, color_spaces: &'a [SysmemColorSpaceFUCHSIA<'a>]) -> Self {
         self.color_space_count = color_spaces.len() as _;
         self.p_color_spaces = color_spaces.as_ptr();
         self
@@ -43644,7 +43653,7 @@ impl<'a> ImageConstraintsInfoFUCHSIA<'a> {
     #[inline]
     pub fn format_constraints(
         mut self,
-        format_constraints: &'a [ImageFormatConstraintsInfoFUCHSIA],
+        format_constraints: &'a [ImageFormatConstraintsInfoFUCHSIA<'a>],
     ) -> Self {
         self.format_constraints_count = format_constraints.len() as _;
         self.p_format_constraints = format_constraints.as_ptr();
@@ -44262,7 +44271,10 @@ impl<'a> RenderingInfo<'a> {
         self
     }
     #[inline]
-    pub fn color_attachments(mut self, color_attachments: &'a [RenderingAttachmentInfo]) -> Self {
+    pub fn color_attachments(
+        mut self,
+        color_attachments: &'a [RenderingAttachmentInfo<'a>],
+    ) -> Self {
         self.color_attachment_count = color_attachments.len() as _;
         self.p_color_attachments = color_attachments.as_ptr();
         self
@@ -44313,7 +44325,7 @@ pub struct RenderingAttachmentInfo<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for RenderingAttachmentInfo<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("RenderingAttachmentInfo")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -45665,7 +45677,7 @@ pub struct RenderPassSubpassFeedbackInfoEXT {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for RenderPassSubpassFeedbackInfoEXT {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("RenderPassSubpassFeedbackInfoEXT")
             .field("subpass_merge_status", &self.subpass_merge_status)
             .field("description", &unsafe {
@@ -45793,7 +45805,7 @@ pub struct MicromapBuildInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for MicromapBuildInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("MicromapBuildInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -46044,7 +46056,7 @@ pub struct CopyMicromapToMemoryInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for CopyMicromapToMemoryInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("CopyMicromapToMemoryInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -46100,7 +46112,7 @@ pub struct CopyMemoryToMicromapInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for CopyMemoryToMicromapInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("CopyMemoryToMicromapInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -46352,7 +46364,7 @@ pub struct AccelerationStructureTrianglesOpacityMicromapEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureTrianglesOpacityMicromapEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureTrianglesOpacityMicromapEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -46532,7 +46544,7 @@ pub struct AccelerationStructureTrianglesDisplacementMicromapNV<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AccelerationStructureTrianglesDisplacementMicromapNV")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -48437,7 +48449,7 @@ pub struct DeviceFaultVendorInfoEXT {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DeviceFaultVendorInfoEXT {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DeviceFaultVendorInfoEXT")
             .field("description", &unsafe {
                 ::std::ffi::CStr::from_ptr(self.description.as_ptr())
@@ -48533,7 +48545,7 @@ pub struct DeviceFaultInfoEXT<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DeviceFaultInfoEXT<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DeviceFaultInfoEXT")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -49705,7 +49717,7 @@ pub struct DirectDriverLoadingInfoLUNARG<'a> {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DirectDriverLoadingInfoLUNARG<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DirectDriverLoadingInfoLUNARG")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
@@ -49783,7 +49795,7 @@ impl<'a> DirectDriverLoadingListLUNARG<'a> {
         self
     }
     #[inline]
-    pub fn drivers(mut self, drivers: &'a [DirectDriverLoadingInfoLUNARG]) -> Self {
+    pub fn drivers(mut self, drivers: &'a [DirectDriverLoadingInfoLUNARG<'a>]) -> Self {
         self.driver_count = drivers.len() as _;
         self.p_drivers = drivers.as_ptr();
         self
@@ -51015,7 +51027,7 @@ impl<'a> ExecutionGraphPipelineCreateInfoAMDX<'a> {
         self
     }
     #[inline]
-    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo<'a>]) -> Self {
         self.stage_count = stages.len() as _;
         self.p_stages = stages.as_ptr();
         self
@@ -51140,7 +51152,7 @@ pub struct DispatchGraphInfoAMDX {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DispatchGraphInfoAMDX {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DispatchGraphInfoAMDX")
             .field("node_index", &self.node_index)
             .field("payload_count", &self.payload_count)
@@ -51181,7 +51193,7 @@ pub struct DispatchGraphCountInfoAMDX {
 }
 #[cfg(feature = "debug")]
 impl fmt::Debug for DispatchGraphCountInfoAMDX {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DispatchGraphCountInfoAMDX")
             .field("count", &self.count)
             .field("infos", &"union")

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -989,7 +989,7 @@ impl Result {
 }
 impl ::std::error::Error for Result {}
 impl fmt::Display for Result {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match * self { Self :: SUCCESS => Some ("Command completed successfully") , Self :: NOT_READY => Some ("A fence or query has not yet completed") , Self :: TIMEOUT => Some ("A wait operation has not completed in the specified time") , Self :: EVENT_SET => Some ("An event is signaled") , Self :: EVENT_RESET => Some ("An event is unsignaled") , Self :: INCOMPLETE => Some ("A return array was too small for the result") , Self :: ERROR_OUT_OF_HOST_MEMORY => Some ("A host memory allocation has failed") , Self :: ERROR_OUT_OF_DEVICE_MEMORY => Some ("A device memory allocation has failed") , Self :: ERROR_INITIALIZATION_FAILED => Some ("Initialization of an object has failed") , Self :: ERROR_DEVICE_LOST => Some ("The logical device has been lost. See <https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#devsandqueues-lost-device>") , Self :: ERROR_MEMORY_MAP_FAILED => Some ("Mapping of a memory object has failed") , Self :: ERROR_LAYER_NOT_PRESENT => Some ("Layer specified does not exist") , Self :: ERROR_EXTENSION_NOT_PRESENT => Some ("Extension specified does not exist") , Self :: ERROR_FEATURE_NOT_PRESENT => Some ("Requested feature is not available on this device") , Self :: ERROR_INCOMPATIBLE_DRIVER => Some ("Unable to find a Vulkan driver") , Self :: ERROR_TOO_MANY_OBJECTS => Some ("Too many objects of the type have already been created") , Self :: ERROR_FORMAT_NOT_SUPPORTED => Some ("Requested format is not supported on this device") , Self :: ERROR_FRAGMENTED_POOL => Some ("A requested pool allocation has failed due to fragmentation of the pool's memory") , Self :: ERROR_UNKNOWN => Some ("An unknown error has occurred, due to an implementation or application bug") , _ => None , } ;
         if let Some(x) = name {
             fmt.write_str(x)
@@ -2907,7 +2907,7 @@ impl OutOfBandQueueTypeNV {
     pub const PRESENT: Self = Self(1);
 }
 impl fmt::Debug for ObjectType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::UNKNOWN => Some("UNKNOWN"),
             Self::INSTANCE => Some("INSTANCE"),
@@ -2970,7 +2970,7 @@ impl fmt::Debug for ObjectType {
     }
 }
 impl fmt::Debug for Result {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::SUCCESS => Some("SUCCESS"),
             Self::NOT_READY => Some("NOT_READY"),

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -13,7 +13,7 @@ impl KhrSurfaceFn {
 pub type PFN_vkDestroySurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     surface: SurfaceKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSurfaceSupportKHR = unsafe extern "system" fn(
@@ -63,7 +63,7 @@ impl KhrSurfaceFn {
                 unsafe extern "system" fn destroy_surface_khr(
                     _instance: Instance,
                     _surface: SurfaceKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_surface_khr)))
                 }
@@ -183,15 +183,15 @@ impl KhrSwapchainFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateSwapchainKHR = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const SwapchainCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const SwapchainCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_swapchain: *mut SwapchainKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySwapchainKHR = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSwapchainImagesKHR = unsafe extern "system" fn(
@@ -211,11 +211,11 @@ pub type PFN_vkAcquireNextImageKHR = unsafe extern "system" fn(
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueuePresentKHR =
-    unsafe extern "system" fn(queue: Queue, p_present_info: *const PresentInfoKHR) -> Result;
+    unsafe extern "system" fn(queue: Queue, p_present_info: *const PresentInfoKHR<'_>) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceGroupPresentCapabilitiesKHR = unsafe extern "system" fn(
     device: Device,
-    p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
+    p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceGroupSurfacePresentModesKHR = unsafe extern "system" fn(
@@ -233,7 +233,7 @@ pub type PFN_vkGetPhysicalDevicePresentRectanglesKHR = unsafe extern "system" fn
 #[allow(non_camel_case_types)]
 pub type PFN_vkAcquireNextImage2KHR = unsafe extern "system" fn(
     device: Device,
-    p_acquire_info: *const AcquireNextImageInfoKHR,
+    p_acquire_info: *const AcquireNextImageInfoKHR<'_>,
     p_image_index: *mut u32,
 ) -> Result;
 #[derive(Clone)]
@@ -259,8 +259,8 @@ impl KhrSwapchainFn {
             create_swapchain_khr: unsafe {
                 unsafe extern "system" fn create_swapchain_khr(
                     _device: Device,
-                    _p_create_info: *const SwapchainCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const SwapchainCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_swapchain: *mut SwapchainKHR,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_swapchain_khr)))
@@ -278,7 +278,7 @@ impl KhrSwapchainFn {
                 unsafe extern "system" fn destroy_swapchain_khr(
                     _device: Device,
                     _swapchain: SwapchainKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -341,7 +341,7 @@ impl KhrSwapchainFn {
             queue_present_khr: unsafe {
                 unsafe extern "system" fn queue_present_khr(
                     _queue: Queue,
-                    _p_present_info: *const PresentInfoKHR,
+                    _p_present_info: *const PresentInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_present_khr)))
                 }
@@ -356,7 +356,9 @@ impl KhrSwapchainFn {
             get_device_group_present_capabilities_khr: unsafe {
                 unsafe extern "system" fn get_device_group_present_capabilities_khr(
                     _device: Device,
-                    _p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
+                    _p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR<
+                        '_,
+                    >,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -419,7 +421,7 @@ impl KhrSwapchainFn {
             acquire_next_image2_khr: unsafe {
                 unsafe extern "system" fn acquire_next_image2_khr(
                     _device: Device,
-                    _p_acquire_info: *const AcquireNextImageInfoKHR,
+                    _p_acquire_info: *const AcquireNextImageInfoKHR<'_>,
                     _p_image_index: *mut u32,
                 ) -> Result {
                     panic!(concat!(
@@ -479,7 +481,7 @@ impl KhrDisplayFn {
 pub type PFN_vkGetPhysicalDeviceDisplayPropertiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
-    p_properties: *mut DisplayPropertiesKHR,
+    p_properties: *mut DisplayPropertiesKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR = unsafe extern "system" fn(
@@ -505,8 +507,8 @@ pub type PFN_vkGetDisplayModePropertiesKHR = unsafe extern "system" fn(
 pub type PFN_vkCreateDisplayModeKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     display: DisplayKHR,
-    p_create_info: *const DisplayModeCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DisplayModeCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_mode: *mut DisplayModeKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -519,8 +521,8 @@ pub type PFN_vkGetDisplayPlaneCapabilitiesKHR = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDisplayPlaneSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const DisplaySurfaceCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DisplaySurfaceCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -546,7 +548,7 @@ impl KhrDisplayFn {
                 unsafe extern "system" fn get_physical_device_display_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut DisplayPropertiesKHR,
+                    _p_properties: *mut DisplayPropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -632,8 +634,8 @@ impl KhrDisplayFn {
                 unsafe extern "system" fn create_display_mode_khr(
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
-                    _p_create_info: *const DisplayModeCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DisplayModeCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_mode: *mut DisplayModeKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -675,8 +677,8 @@ impl KhrDisplayFn {
             create_display_plane_surface_khr: unsafe {
                 unsafe extern "system" fn create_display_plane_surface_khr(
                     _instance: Instance,
-                    _p_create_info: *const DisplaySurfaceCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DisplaySurfaceCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -716,8 +718,8 @@ impl KhrDisplaySwapchainFn {
 pub type PFN_vkCreateSharedSwapchainsKHR = unsafe extern "system" fn(
     device: Device,
     swapchain_count: u32,
-    p_create_infos: *const SwapchainCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const SwapchainCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_swapchains: *mut SwapchainKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -736,8 +738,8 @@ impl KhrDisplaySwapchainFn {
                 unsafe extern "system" fn create_shared_swapchains_khr(
                     _device: Device,
                     _swapchain_count: u32,
-                    _p_create_infos: *const SwapchainCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const SwapchainCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_swapchains: *mut SwapchainKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -774,8 +776,8 @@ impl KhrXlibSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateXlibSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const XlibSurfaceCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const XlibSurfaceCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -802,8 +804,8 @@ impl KhrXlibSurfaceFn {
             create_xlib_surface_khr: unsafe {
                 unsafe extern "system" fn create_xlib_surface_khr(
                     _instance: Instance,
-                    _p_create_info: *const XlibSurfaceCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const XlibSurfaceCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -857,8 +859,8 @@ impl KhrXcbSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateXcbSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const XcbSurfaceCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const XcbSurfaceCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -885,8 +887,8 @@ impl KhrXcbSurfaceFn {
             create_xcb_surface_khr: unsafe {
                 unsafe extern "system" fn create_xcb_surface_khr(
                     _instance: Instance,
-                    _p_create_info: *const XcbSurfaceCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const XcbSurfaceCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -940,8 +942,8 @@ impl KhrWaylandSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateWaylandSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const WaylandSurfaceCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const WaylandSurfaceCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -968,8 +970,8 @@ impl KhrWaylandSurfaceFn {
             create_wayland_surface_khr: unsafe {
                 unsafe extern "system" fn create_wayland_surface_khr(
                     _instance: Instance,
-                    _p_create_info: *const WaylandSurfaceCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const WaylandSurfaceCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -1022,8 +1024,8 @@ impl KhrAndroidSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateAndroidSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const AndroidSurfaceCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const AndroidSurfaceCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -1041,8 +1043,8 @@ impl KhrAndroidSurfaceFn {
             create_android_surface_khr: unsafe {
                 unsafe extern "system" fn create_android_surface_khr(
                     _instance: Instance,
-                    _p_create_info: *const AndroidSurfaceCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const AndroidSurfaceCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -1074,8 +1076,8 @@ impl KhrWin32SurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateWin32SurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const Win32SurfaceCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const Win32SurfaceCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -1098,8 +1100,8 @@ impl KhrWin32SurfaceFn {
             create_win32_surface_khr: unsafe {
                 unsafe extern "system" fn create_win32_surface_khr(
                     _instance: Instance,
-                    _p_create_info: *const Win32SurfaceCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const Win32SurfaceCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -1303,15 +1305,15 @@ impl ExtDebugReportFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDebugReportCallbackEXT = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const DebugReportCallbackCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DebugReportCallbackCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_callback: *mut DebugReportCallbackEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDebugReportCallbackEXT = unsafe extern "system" fn(
     instance: Instance,
     callback: DebugReportCallbackEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkDebugReportMessageEXT = unsafe extern "system" fn(
@@ -1341,8 +1343,8 @@ impl ExtDebugReportFn {
             create_debug_report_callback_ext: unsafe {
                 unsafe extern "system" fn create_debug_report_callback_ext(
                     _instance: Instance,
-                    _p_create_info: *const DebugReportCallbackCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DebugReportCallbackCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_callback: *mut DebugReportCallbackEXT,
                 ) -> Result {
                     panic!(concat!(
@@ -1364,7 +1366,7 @@ impl ExtDebugReportFn {
                 unsafe extern "system" fn destroy_debug_report_callback_ext(
                     _instance: Instance,
                     _callback: DebugReportCallbackEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1511,24 +1513,24 @@ impl ExtDebugMarkerFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkDebugMarkerSetObjectTagEXT = unsafe extern "system" fn(
     device: Device,
-    p_tag_info: *const DebugMarkerObjectTagInfoEXT,
+    p_tag_info: *const DebugMarkerObjectTagInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDebugMarkerSetObjectNameEXT = unsafe extern "system" fn(
     device: Device,
-    p_name_info: *const DebugMarkerObjectNameInfoEXT,
+    p_name_info: *const DebugMarkerObjectNameInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDebugMarkerBeginEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_marker_info: *const DebugMarkerMarkerInfoEXT,
+    p_marker_info: *const DebugMarkerMarkerInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDebugMarkerEndEXT = unsafe extern "system" fn(command_buffer: CommandBuffer);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDebugMarkerInsertEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_marker_info: *const DebugMarkerMarkerInfoEXT,
+    p_marker_info: *const DebugMarkerMarkerInfoEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtDebugMarkerFn {
@@ -1549,7 +1551,7 @@ impl ExtDebugMarkerFn {
             debug_marker_set_object_tag_ext: unsafe {
                 unsafe extern "system" fn debug_marker_set_object_tag_ext(
                     _device: Device,
-                    _p_tag_info: *const DebugMarkerObjectTagInfoEXT,
+                    _p_tag_info: *const DebugMarkerObjectTagInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1569,7 +1571,7 @@ impl ExtDebugMarkerFn {
             debug_marker_set_object_name_ext: unsafe {
                 unsafe extern "system" fn debug_marker_set_object_name_ext(
                     _device: Device,
-                    _p_name_info: *const DebugMarkerObjectNameInfoEXT,
+                    _p_name_info: *const DebugMarkerObjectNameInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1589,7 +1591,7 @@ impl ExtDebugMarkerFn {
             cmd_debug_marker_begin_ext: unsafe {
                 unsafe extern "system" fn cmd_debug_marker_begin_ext(
                     _command_buffer: CommandBuffer,
-                    _p_marker_info: *const DebugMarkerMarkerInfoEXT,
+                    _p_marker_info: *const DebugMarkerMarkerInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1624,7 +1626,7 @@ impl ExtDebugMarkerFn {
             cmd_debug_marker_insert_ext: unsafe {
                 unsafe extern "system" fn cmd_debug_marker_insert_ext(
                     _command_buffer: CommandBuffer,
-                    _p_marker_info: *const DebugMarkerMarkerInfoEXT,
+                    _p_marker_info: *const DebugMarkerMarkerInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1657,76 +1659,76 @@ impl KhrVideoQueueFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_video_profile: *const VideoProfileInfoKHR,
-    p_capabilities: *mut VideoCapabilitiesKHR,
+    p_video_profile: *const VideoProfileInfoKHR<'_>,
+    p_capabilities: *mut VideoCapabilitiesKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_video_format_info: *const PhysicalDeviceVideoFormatInfoKHR,
+    p_video_format_info: *const PhysicalDeviceVideoFormatInfoKHR<'_>,
     p_video_format_property_count: *mut u32,
-    p_video_format_properties: *mut VideoFormatPropertiesKHR,
+    p_video_format_properties: *mut VideoFormatPropertiesKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateVideoSessionKHR = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const VideoSessionCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const VideoSessionCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_video_session: *mut VideoSessionKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyVideoSessionKHR = unsafe extern "system" fn(
     device: Device,
     video_session: VideoSessionKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetVideoSessionMemoryRequirementsKHR = unsafe extern "system" fn(
     device: Device,
     video_session: VideoSessionKHR,
     p_memory_requirements_count: *mut u32,
-    p_memory_requirements: *mut VideoSessionMemoryRequirementsKHR,
+    p_memory_requirements: *mut VideoSessionMemoryRequirementsKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkBindVideoSessionMemoryKHR = unsafe extern "system" fn(
     device: Device,
     video_session: VideoSessionKHR,
     bind_session_memory_info_count: u32,
-    p_bind_session_memory_infos: *const BindVideoSessionMemoryInfoKHR,
+    p_bind_session_memory_infos: *const BindVideoSessionMemoryInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateVideoSessionParametersKHR = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const VideoSessionParametersCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const VideoSessionParametersCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_video_session_parameters: *mut VideoSessionParametersKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkUpdateVideoSessionParametersKHR = unsafe extern "system" fn(
     device: Device,
     video_session_parameters: VideoSessionParametersKHR,
-    p_update_info: *const VideoSessionParametersUpdateInfoKHR,
+    p_update_info: *const VideoSessionParametersUpdateInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyVideoSessionParametersKHR = unsafe extern "system" fn(
     device: Device,
     video_session_parameters: VideoSessionParametersKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginVideoCodingKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_begin_info: *const VideoBeginCodingInfoKHR,
+    p_begin_info: *const VideoBeginCodingInfoKHR<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEndVideoCodingKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_end_coding_info: *const VideoEndCodingInfoKHR,
+    p_end_coding_info: *const VideoEndCodingInfoKHR<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdControlVideoCodingKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_coding_control_info: *const VideoCodingControlInfoKHR,
+    p_coding_control_info: *const VideoCodingControlInfoKHR<'_>,
 );
 #[derive(Clone)]
 pub struct KhrVideoQueueFn {
@@ -1755,8 +1757,8 @@ impl KhrVideoQueueFn {
             get_physical_device_video_capabilities_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_video_capabilities_khr(
                     _physical_device: PhysicalDevice,
-                    _p_video_profile: *const VideoProfileInfoKHR,
-                    _p_capabilities: *mut VideoCapabilitiesKHR,
+                    _p_video_profile: *const VideoProfileInfoKHR<'_>,
+                    _p_capabilities: *mut VideoCapabilitiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1776,9 +1778,9 @@ impl KhrVideoQueueFn {
             get_physical_device_video_format_properties_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_video_format_properties_khr(
                     _physical_device: PhysicalDevice,
-                    _p_video_format_info: *const PhysicalDeviceVideoFormatInfoKHR,
+                    _p_video_format_info: *const PhysicalDeviceVideoFormatInfoKHR<'_>,
                     _p_video_format_property_count: *mut u32,
-                    _p_video_format_properties: *mut VideoFormatPropertiesKHR,
+                    _p_video_format_properties: *mut VideoFormatPropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1798,8 +1800,8 @@ impl KhrVideoQueueFn {
             create_video_session_khr: unsafe {
                 unsafe extern "system" fn create_video_session_khr(
                     _device: Device,
-                    _p_create_info: *const VideoSessionCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const VideoSessionCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_video_session: *mut VideoSessionKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -1820,7 +1822,7 @@ impl KhrVideoQueueFn {
                 unsafe extern "system" fn destroy_video_session_khr(
                     _device: Device,
                     _video_session: VideoSessionKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1841,7 +1843,7 @@ impl KhrVideoQueueFn {
                     _device: Device,
                     _video_session: VideoSessionKHR,
                     _p_memory_requirements_count: *mut u32,
-                    _p_memory_requirements: *mut VideoSessionMemoryRequirementsKHR,
+                    _p_memory_requirements: *mut VideoSessionMemoryRequirementsKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1863,7 +1865,7 @@ impl KhrVideoQueueFn {
                     _device: Device,
                     _video_session: VideoSessionKHR,
                     _bind_session_memory_info_count: u32,
-                    _p_bind_session_memory_infos: *const BindVideoSessionMemoryInfoKHR,
+                    _p_bind_session_memory_infos: *const BindVideoSessionMemoryInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1883,8 +1885,8 @@ impl KhrVideoQueueFn {
             create_video_session_parameters_khr: unsafe {
                 unsafe extern "system" fn create_video_session_parameters_khr(
                     _device: Device,
-                    _p_create_info: *const VideoSessionParametersCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const VideoSessionParametersCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_video_session_parameters: *mut VideoSessionParametersKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -1906,7 +1908,7 @@ impl KhrVideoQueueFn {
                 unsafe extern "system" fn update_video_session_parameters_khr(
                     _device: Device,
                     _video_session_parameters: VideoSessionParametersKHR,
-                    _p_update_info: *const VideoSessionParametersUpdateInfoKHR,
+                    _p_update_info: *const VideoSessionParametersUpdateInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1927,7 +1929,7 @@ impl KhrVideoQueueFn {
                 unsafe extern "system" fn destroy_video_session_parameters_khr(
                     _device: Device,
                     _video_session_parameters: VideoSessionParametersKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1947,7 +1949,7 @@ impl KhrVideoQueueFn {
             cmd_begin_video_coding_khr: unsafe {
                 unsafe extern "system" fn cmd_begin_video_coding_khr(
                     _command_buffer: CommandBuffer,
-                    _p_begin_info: *const VideoBeginCodingInfoKHR,
+                    _p_begin_info: *const VideoBeginCodingInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1966,7 +1968,7 @@ impl KhrVideoQueueFn {
             cmd_end_video_coding_khr: unsafe {
                 unsafe extern "system" fn cmd_end_video_coding_khr(
                     _command_buffer: CommandBuffer,
-                    _p_end_coding_info: *const VideoEndCodingInfoKHR,
+                    _p_end_coding_info: *const VideoEndCodingInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1985,7 +1987,7 @@ impl KhrVideoQueueFn {
             cmd_control_video_coding_khr: unsafe {
                 unsafe extern "system" fn cmd_control_video_coding_khr(
                     _command_buffer: CommandBuffer,
-                    _p_coding_control_info: *const VideoCodingControlInfoKHR,
+                    _p_coding_control_info: *const VideoCodingControlInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2057,7 +2059,7 @@ impl KhrVideoDecodeQueueFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDecodeVideoKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_decode_info: *const VideoDecodeInfoKHR,
+    p_decode_info: *const VideoDecodeInfoKHR<'_>,
 );
 #[derive(Clone)]
 pub struct KhrVideoDecodeQueueFn {
@@ -2074,7 +2076,7 @@ impl KhrVideoDecodeQueueFn {
             cmd_decode_video_khr: unsafe {
                 unsafe extern "system" fn cmd_decode_video_khr(
                     _command_buffer: CommandBuffer,
-                    _p_decode_info: *const VideoDecodeInfoKHR,
+                    _p_decode_info: *const VideoDecodeInfoKHR<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_decode_video_khr)))
                 }
@@ -2403,32 +2405,34 @@ impl NvxBinaryImportFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCuModuleNVX = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const CuModuleCreateInfoNVX,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const CuModuleCreateInfoNVX<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_module: *mut CuModuleNVX,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCuFunctionNVX = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const CuFunctionCreateInfoNVX,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const CuFunctionCreateInfoNVX<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_function: *mut CuFunctionNVX,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCuModuleNVX = unsafe extern "system" fn(
     device: Device,
     module: CuModuleNVX,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCuFunctionNVX = unsafe extern "system" fn(
     device: Device,
     function: CuFunctionNVX,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCuLaunchKernelNVX =
-    unsafe extern "system" fn(command_buffer: CommandBuffer, p_launch_info: *const CuLaunchInfoNVX);
+pub type PFN_vkCmdCuLaunchKernelNVX = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_launch_info: *const CuLaunchInfoNVX<'_>,
+);
 #[derive(Clone)]
 pub struct NvxBinaryImportFn {
     pub create_cu_module_nvx: PFN_vkCreateCuModuleNVX,
@@ -2448,8 +2452,8 @@ impl NvxBinaryImportFn {
             create_cu_module_nvx: unsafe {
                 unsafe extern "system" fn create_cu_module_nvx(
                     _device: Device,
-                    _p_create_info: *const CuModuleCreateInfoNVX,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const CuModuleCreateInfoNVX<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_module: *mut CuModuleNVX,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_cu_module_nvx)))
@@ -2466,8 +2470,8 @@ impl NvxBinaryImportFn {
             create_cu_function_nvx: unsafe {
                 unsafe extern "system" fn create_cu_function_nvx(
                     _device: Device,
-                    _p_create_info: *const CuFunctionCreateInfoNVX,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const CuFunctionCreateInfoNVX<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_function: *mut CuFunctionNVX,
                 ) -> Result {
                     panic!(concat!(
@@ -2488,7 +2492,7 @@ impl NvxBinaryImportFn {
                 unsafe extern "system" fn destroy_cu_module_nvx(
                     _device: Device,
                     _module: CuModuleNVX,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2508,7 +2512,7 @@ impl NvxBinaryImportFn {
                 unsafe extern "system" fn destroy_cu_function_nvx(
                     _device: Device,
                     _function: CuFunctionNVX,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2527,7 +2531,7 @@ impl NvxBinaryImportFn {
             cmd_cu_launch_kernel_nvx: unsafe {
                 unsafe extern "system" fn cmd_cu_launch_kernel_nvx(
                     _command_buffer: CommandBuffer,
-                    _p_launch_info: *const CuLaunchInfoNVX,
+                    _p_launch_info: *const CuLaunchInfoNVX<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2569,12 +2573,12 @@ impl NvxImageViewHandleFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageViewHandleNVX =
-    unsafe extern "system" fn(device: Device, p_info: *const ImageViewHandleInfoNVX) -> u32;
+    unsafe extern "system" fn(device: Device, p_info: *const ImageViewHandleInfoNVX<'_>) -> u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageViewAddressNVX = unsafe extern "system" fn(
     device: Device,
     image_view: ImageView,
-    p_properties: *mut ImageViewAddressPropertiesNVX,
+    p_properties: *mut ImageViewAddressPropertiesNVX<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct NvxImageViewHandleFn {
@@ -2592,7 +2596,7 @@ impl NvxImageViewHandleFn {
             get_image_view_handle_nvx: unsafe {
                 unsafe extern "system" fn get_image_view_handle_nvx(
                     _device: Device,
-                    _p_info: *const ImageViewHandleInfoNVX,
+                    _p_info: *const ImageViewHandleInfoNVX<'_>,
                 ) -> u32 {
                     panic!(concat!(
                         "Unable to load ",
@@ -2612,7 +2616,7 @@ impl NvxImageViewHandleFn {
                 unsafe extern "system" fn get_image_view_address_nvx(
                     _device: Device,
                     _image_view: ImageView,
-                    _p_properties: *mut ImageViewAddressPropertiesNVX,
+                    _p_properties: *mut ImageViewAddressPropertiesNVX<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -2894,7 +2898,7 @@ impl KhrDynamicRenderingFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginRendering = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_rendering_info: *const RenderingInfo,
+    p_rendering_info: *const RenderingInfo<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEndRendering = unsafe extern "system" fn(command_buffer: CommandBuffer);
@@ -2914,7 +2918,7 @@ impl KhrDynamicRenderingFn {
             cmd_begin_rendering_khr: unsafe {
                 unsafe extern "system" fn cmd_begin_rendering_khr(
                     _command_buffer: CommandBuffer,
-                    _p_rendering_info: *const RenderingInfo,
+                    _p_rendering_info: *const RenderingInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2992,8 +2996,8 @@ impl GgpStreamDescriptorSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateStreamDescriptorSurfaceGGP = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -3011,8 +3015,8 @@ impl GgpStreamDescriptorSurfaceFn {
             create_stream_descriptor_surface_ggp: unsafe {
                 unsafe extern "system" fn create_stream_descriptor_surface_ggp(
                     _instance: Instance,
-                    _p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -3235,42 +3239,42 @@ impl KhrGetPhysicalDeviceProperties2Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceFeatures2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_features: *mut PhysicalDeviceFeatures2,
+    p_features: *mut PhysicalDeviceFeatures2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_properties: *mut PhysicalDeviceProperties2,
+    p_properties: *mut PhysicalDeviceProperties2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceFormatProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     format: Format,
-    p_format_properties: *mut FormatProperties2,
+    p_format_properties: *mut FormatProperties2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceImageFormatProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
-    p_image_format_properties: *mut ImageFormatProperties2,
+    p_image_format_info: *const PhysicalDeviceImageFormatInfo2<'_>,
+    p_image_format_properties: *mut ImageFormatProperties2<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceQueueFamilyProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_queue_family_property_count: *mut u32,
-    p_queue_family_properties: *mut QueueFamilyProperties2,
+    p_queue_family_properties: *mut QueueFamilyProperties2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceMemoryProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
+    p_memory_properties: *mut PhysicalDeviceMemoryProperties2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
+    p_format_info: *const PhysicalDeviceSparseImageFormatInfo2<'_>,
     p_property_count: *mut u32,
-    p_properties: *mut SparseImageFormatProperties2,
+    p_properties: *mut SparseImageFormatProperties2<'_>,
 );
 #[derive(Clone)]
 pub struct KhrGetPhysicalDeviceProperties2Fn {
@@ -3296,7 +3300,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
             get_physical_device_features2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_features2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_features: *mut PhysicalDeviceFeatures2,
+                    _p_features: *mut PhysicalDeviceFeatures2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3316,7 +3320,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
             get_physical_device_properties2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_properties2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_properties: *mut PhysicalDeviceProperties2,
+                    _p_properties: *mut PhysicalDeviceProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3337,7 +3341,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 unsafe extern "system" fn get_physical_device_format_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _format: Format,
-                    _p_format_properties: *mut FormatProperties2,
+                    _p_format_properties: *mut FormatProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3357,8 +3361,8 @@ impl KhrGetPhysicalDeviceProperties2Fn {
             get_physical_device_image_format_properties2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_image_format_properties2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
-                    _p_image_format_properties: *mut ImageFormatProperties2,
+                    _p_image_format_info: *const PhysicalDeviceImageFormatInfo2<'_>,
+                    _p_image_format_properties: *mut ImageFormatProperties2<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -3379,7 +3383,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 unsafe extern "system" fn get_physical_device_queue_family_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_queue_family_property_count: *mut u32,
-                    _p_queue_family_properties: *mut QueueFamilyProperties2,
+                    _p_queue_family_properties: *mut QueueFamilyProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3399,7 +3403,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
             get_physical_device_memory_properties2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_memory_properties2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
+                    _p_memory_properties: *mut PhysicalDeviceMemoryProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3419,9 +3423,9 @@ impl KhrGetPhysicalDeviceProperties2Fn {
             get_physical_device_sparse_image_format_properties2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_sparse_image_format_properties2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
+                    _p_format_info: *const PhysicalDeviceSparseImageFormatInfo2<'_>,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut SparseImageFormatProperties2,
+                    _p_properties: *mut SparseImageFormatProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3572,7 +3576,9 @@ impl KhrDeviceGroupFn {
             get_device_group_present_capabilities_khr: unsafe {
                 unsafe extern "system" fn get_device_group_present_capabilities_khr(
                     _device: Device,
-                    _p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
+                    _p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR<
+                        '_,
+                    >,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -3635,7 +3641,7 @@ impl KhrDeviceGroupFn {
             acquire_next_image2_khr: unsafe {
                 unsafe extern "system" fn acquire_next_image2_khr(
                     _device: Device,
-                    _p_acquire_info: *const AcquireNextImageInfoKHR,
+                    _p_acquire_info: *const AcquireNextImageInfoKHR<'_>,
                     _p_image_index: *mut u32,
                 ) -> Result {
                     panic!(concat!(
@@ -3711,8 +3717,8 @@ impl NnViSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateViSurfaceNN = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const ViSurfaceCreateInfoNN,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ViSurfaceCreateInfoNN<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -3730,8 +3736,8 @@ impl NnViSurfaceFn {
             create_vi_surface_nn: unsafe {
                 unsafe extern "system" fn create_vi_surface_nn(
                     _instance: Instance,
-                    _p_create_info: *const ViSurfaceCreateInfoNN,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ViSurfaceCreateInfoNN<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_vi_surface_nn)))
@@ -3900,7 +3906,7 @@ impl KhrDeviceGroupCreationFn {
 pub type PFN_vkEnumeratePhysicalDeviceGroups = unsafe extern "system" fn(
     instance: Instance,
     p_physical_device_group_count: *mut u32,
-    p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
+    p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrDeviceGroupCreationFn {
@@ -3918,7 +3924,7 @@ impl KhrDeviceGroupCreationFn {
                 unsafe extern "system" fn enumerate_physical_device_groups_khr(
                     _instance: Instance,
                     _p_physical_device_group_count: *mut u32,
-                    _p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
+                    _p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -3956,8 +3962,8 @@ impl KhrExternalMemoryCapabilitiesFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceExternalBufferProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
-    p_external_buffer_properties: *mut ExternalBufferProperties,
+    p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo<'_>,
+    p_external_buffer_properties: *mut ExternalBufferProperties<'_>,
 );
 #[derive(Clone)]
 pub struct KhrExternalMemoryCapabilitiesFn {
@@ -3975,8 +3981,8 @@ impl KhrExternalMemoryCapabilitiesFn {
             get_physical_device_external_buffer_properties_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_external_buffer_properties_khr(
                     _physical_device: PhysicalDevice,
-                    _p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
-                    _p_external_buffer_properties: *mut ExternalBufferProperties,
+                    _p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo<'_>,
+                    _p_external_buffer_properties: *mut ExternalBufferProperties<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4049,7 +4055,7 @@ impl KhrExternalMemoryWin32Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMemoryWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
-    p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR,
+    p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR<'_>,
     p_handle: *mut HANDLE,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4057,7 +4063,7 @@ pub type PFN_vkGetMemoryWin32HandlePropertiesKHR = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     handle: HANDLE,
-    p_memory_win32_handle_properties: *mut MemoryWin32HandlePropertiesKHR,
+    p_memory_win32_handle_properties: *mut MemoryWin32HandlePropertiesKHR<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrExternalMemoryWin32Fn {
@@ -4075,7 +4081,7 @@ impl KhrExternalMemoryWin32Fn {
             get_memory_win32_handle_khr: unsafe {
                 unsafe extern "system" fn get_memory_win32_handle_khr(
                     _device: Device,
-                    _p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR,
+                    _p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR<'_>,
                     _p_handle: *mut HANDLE,
                 ) -> Result {
                     panic!(concat!(
@@ -4097,7 +4103,7 @@ impl KhrExternalMemoryWin32Fn {
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _handle: HANDLE,
-                    _p_memory_win32_handle_properties: *mut MemoryWin32HandlePropertiesKHR,
+                    _p_memory_win32_handle_properties: *mut MemoryWin32HandlePropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -4132,7 +4138,7 @@ impl KhrExternalMemoryFdFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMemoryFdKHR = unsafe extern "system" fn(
     device: Device,
-    p_get_fd_info: *const MemoryGetFdInfoKHR,
+    p_get_fd_info: *const MemoryGetFdInfoKHR<'_>,
     p_fd: *mut c_int,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4140,7 +4146,7 @@ pub type PFN_vkGetMemoryFdPropertiesKHR = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     fd: c_int,
-    p_memory_fd_properties: *mut MemoryFdPropertiesKHR,
+    p_memory_fd_properties: *mut MemoryFdPropertiesKHR<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrExternalMemoryFdFn {
@@ -4158,7 +4164,7 @@ impl KhrExternalMemoryFdFn {
             get_memory_fd_khr: unsafe {
                 unsafe extern "system" fn get_memory_fd_khr(
                     _device: Device,
-                    _p_get_fd_info: *const MemoryGetFdInfoKHR,
+                    _p_get_fd_info: *const MemoryGetFdInfoKHR<'_>,
                     _p_fd: *mut c_int,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(get_memory_fd_khr)))
@@ -4176,7 +4182,7 @@ impl KhrExternalMemoryFdFn {
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _fd: c_int,
-                    _p_memory_fd_properties: *mut MemoryFdPropertiesKHR,
+                    _p_memory_fd_properties: *mut MemoryFdPropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -4222,8 +4228,8 @@ impl KhrExternalSemaphoreCapabilitiesFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceExternalSemaphoreProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
-    p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
+    p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo<'_>,
+    p_external_semaphore_properties: *mut ExternalSemaphoreProperties<'_>,
 );
 #[derive(Clone)]
 pub struct KhrExternalSemaphoreCapabilitiesFn {
@@ -4241,8 +4247,8 @@ impl KhrExternalSemaphoreCapabilitiesFn {
             get_physical_device_external_semaphore_properties_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_external_semaphore_properties_khr(
                     _physical_device: PhysicalDevice,
-                    _p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
-                    _p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
+                    _p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo<'_>,
+                    _p_external_semaphore_properties: *mut ExternalSemaphoreProperties<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4305,12 +4311,12 @@ impl KhrExternalSemaphoreWin32Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkImportSemaphoreWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
-    p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR,
+    p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSemaphoreWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
-    p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR,
+    p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR<'_>,
     p_handle: *mut HANDLE,
 ) -> Result;
 #[derive(Clone)]
@@ -4329,7 +4335,9 @@ impl KhrExternalSemaphoreWin32Fn {
             import_semaphore_win32_handle_khr: unsafe {
                 unsafe extern "system" fn import_semaphore_win32_handle_khr(
                     _device: Device,
-                    _p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR,
+                    _p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR<
+                        '_,
+                    >,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -4349,7 +4357,7 @@ impl KhrExternalSemaphoreWin32Fn {
             get_semaphore_win32_handle_khr: unsafe {
                 unsafe extern "system" fn get_semaphore_win32_handle_khr(
                     _device: Device,
-                    _p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR,
+                    _p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR<'_>,
                     _p_handle: *mut HANDLE,
                 ) -> Result {
                     panic!(concat!(
@@ -4386,12 +4394,12 @@ impl KhrExternalSemaphoreFdFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkImportSemaphoreFdKHR = unsafe extern "system" fn(
     device: Device,
-    p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR,
+    p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSemaphoreFdKHR = unsafe extern "system" fn(
     device: Device,
-    p_get_fd_info: *const SemaphoreGetFdInfoKHR,
+    p_get_fd_info: *const SemaphoreGetFdInfoKHR<'_>,
     p_fd: *mut c_int,
 ) -> Result;
 #[derive(Clone)]
@@ -4410,7 +4418,7 @@ impl KhrExternalSemaphoreFdFn {
             import_semaphore_fd_khr: unsafe {
                 unsafe extern "system" fn import_semaphore_fd_khr(
                     _device: Device,
-                    _p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR,
+                    _p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -4429,7 +4437,7 @@ impl KhrExternalSemaphoreFdFn {
             get_semaphore_fd_khr: unsafe {
                 unsafe extern "system" fn get_semaphore_fd_khr(
                     _device: Device,
-                    _p_get_fd_info: *const SemaphoreGetFdInfoKHR,
+                    _p_get_fd_info: *const SemaphoreGetFdInfoKHR<'_>,
                     _p_fd: *mut c_int,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(get_semaphore_fd_khr)))
@@ -4463,7 +4471,7 @@ pub type PFN_vkCmdPushDescriptorSetKHR = unsafe extern "system" fn(
     layout: PipelineLayout,
     set: u32,
     descriptor_write_count: u32,
-    p_descriptor_writes: *const WriteDescriptorSet,
+    p_descriptor_writes: *const WriteDescriptorSet<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdPushDescriptorSetWithTemplateKHR = unsafe extern "system" fn(
@@ -4493,7 +4501,7 @@ impl KhrPushDescriptorFn {
                     _layout: PipelineLayout,
                     _set: u32,
                     _descriptor_write_count: u32,
-                    _p_descriptor_writes: *const WriteDescriptorSet,
+                    _p_descriptor_writes: *const WriteDescriptorSet<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4558,7 +4566,7 @@ impl ExtConditionalRenderingFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginConditionalRenderingEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT,
+    p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEndConditionalRenderingEXT =
@@ -4579,7 +4587,7 @@ impl ExtConditionalRenderingFn {
             cmd_begin_conditional_rendering_ext: unsafe {
                 unsafe extern "system" fn cmd_begin_conditional_rendering_ext(
                     _command_buffer: CommandBuffer,
-                    _p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT,
+                    _p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4685,15 +4693,15 @@ impl KhrDescriptorUpdateTemplateFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDescriptorUpdateTemplate = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const DescriptorUpdateTemplateCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DescriptorUpdateTemplateCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_descriptor_update_template: *mut DescriptorUpdateTemplate,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDescriptorUpdateTemplate = unsafe extern "system" fn(
     device: Device,
     descriptor_update_template: DescriptorUpdateTemplate,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkUpdateDescriptorSetWithTemplate = unsafe extern "system" fn(
@@ -4721,8 +4729,8 @@ impl KhrDescriptorUpdateTemplateFn {
             create_descriptor_update_template_khr: unsafe {
                 unsafe extern "system" fn create_descriptor_update_template_khr(
                     _device: Device,
-                    _p_create_info: *const DescriptorUpdateTemplateCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DescriptorUpdateTemplateCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_descriptor_update_template: *mut DescriptorUpdateTemplate,
                 ) -> Result {
                     panic!(concat!(
@@ -4744,7 +4752,7 @@ impl KhrDescriptorUpdateTemplateFn {
                 unsafe extern "system" fn destroy_descriptor_update_template_khr(
                     _device: Device,
                     _descriptor_update_template: DescriptorUpdateTemplate,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5009,7 +5017,7 @@ impl ExtDisplaySurfaceCounterFn {
 pub type PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     surface: SurfaceKHR,
-    p_surface_capabilities: *mut SurfaceCapabilities2EXT,
+    p_surface_capabilities: *mut SurfaceCapabilities2EXT<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtDisplaySurfaceCounterFn {
@@ -5028,7 +5036,7 @@ impl ExtDisplaySurfaceCounterFn {
                 unsafe extern "system" fn get_physical_device_surface_capabilities2_ext(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
-                    _p_surface_capabilities: *mut SurfaceCapabilities2EXT,
+                    _p_surface_capabilities: *mut SurfaceCapabilities2EXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -5061,21 +5069,21 @@ impl ExtDisplayControlFn {
 pub type PFN_vkDisplayPowerControlEXT = unsafe extern "system" fn(
     device: Device,
     display: DisplayKHR,
-    p_display_power_info: *const DisplayPowerInfoEXT,
+    p_display_power_info: *const DisplayPowerInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkRegisterDeviceEventEXT = unsafe extern "system" fn(
     device: Device,
-    p_device_event_info: *const DeviceEventInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_device_event_info: *const DeviceEventInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkRegisterDisplayEventEXT = unsafe extern "system" fn(
     device: Device,
     display: DisplayKHR,
-    p_display_event_info: *const DisplayEventInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_display_event_info: *const DisplayEventInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -5104,7 +5112,7 @@ impl ExtDisplayControlFn {
                 unsafe extern "system" fn display_power_control_ext(
                     _device: Device,
                     _display: DisplayKHR,
-                    _p_display_power_info: *const DisplayPowerInfoEXT,
+                    _p_display_power_info: *const DisplayPowerInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -5123,8 +5131,8 @@ impl ExtDisplayControlFn {
             register_device_event_ext: unsafe {
                 unsafe extern "system" fn register_device_event_ext(
                     _device: Device,
-                    _p_device_event_info: *const DeviceEventInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_device_event_info: *const DeviceEventInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_fence: *mut Fence,
                 ) -> Result {
                     panic!(concat!(
@@ -5145,8 +5153,8 @@ impl ExtDisplayControlFn {
                 unsafe extern "system" fn register_display_event_ext(
                     _device: Device,
                     _display: DisplayKHR,
-                    _p_display_event_info: *const DisplayEventInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_display_event_info: *const DisplayEventInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_fence: *mut Fence,
                 ) -> Result {
                     panic!(concat!(
@@ -5497,7 +5505,7 @@ pub type PFN_vkSetHdrMetadataEXT = unsafe extern "system" fn(
     device: Device,
     swapchain_count: u32,
     p_swapchains: *const SwapchainKHR,
-    p_metadata: *const HdrMetadataEXT,
+    p_metadata: *const HdrMetadataEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtHdrMetadataFn {
@@ -5516,7 +5524,7 @@ impl ExtHdrMetadataFn {
                     _device: Device,
                     _swapchain_count: u32,
                     _p_swapchains: *const SwapchainKHR,
-                    _p_metadata: *const HdrMetadataEXT,
+                    _p_metadata: *const HdrMetadataEXT<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(set_hdr_metadata_ext)))
                 }
@@ -5565,26 +5573,26 @@ impl KhrCreateRenderpass2Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateRenderPass2 = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const RenderPassCreateInfo2,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const RenderPassCreateInfo2<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_render_pass: *mut RenderPass,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginRenderPass2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_render_pass_begin: *const RenderPassBeginInfo,
-    p_subpass_begin_info: *const SubpassBeginInfo,
+    p_render_pass_begin: *const RenderPassBeginInfo<'_>,
+    p_subpass_begin_info: *const SubpassBeginInfo<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdNextSubpass2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_subpass_begin_info: *const SubpassBeginInfo,
-    p_subpass_end_info: *const SubpassEndInfo,
+    p_subpass_begin_info: *const SubpassBeginInfo<'_>,
+    p_subpass_end_info: *const SubpassEndInfo<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEndRenderPass2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_subpass_end_info: *const SubpassEndInfo,
+    p_subpass_end_info: *const SubpassEndInfo<'_>,
 );
 #[derive(Clone)]
 pub struct KhrCreateRenderpass2Fn {
@@ -5604,8 +5612,8 @@ impl KhrCreateRenderpass2Fn {
             create_render_pass2_khr: unsafe {
                 unsafe extern "system" fn create_render_pass2_khr(
                     _device: Device,
-                    _p_create_info: *const RenderPassCreateInfo2,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const RenderPassCreateInfo2<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_render_pass: *mut RenderPass,
                 ) -> Result {
                     panic!(concat!(
@@ -5625,8 +5633,8 @@ impl KhrCreateRenderpass2Fn {
             cmd_begin_render_pass2_khr: unsafe {
                 unsafe extern "system" fn cmd_begin_render_pass2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_render_pass_begin: *const RenderPassBeginInfo,
-                    _p_subpass_begin_info: *const SubpassBeginInfo,
+                    _p_render_pass_begin: *const RenderPassBeginInfo<'_>,
+                    _p_subpass_begin_info: *const SubpassBeginInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5645,8 +5653,8 @@ impl KhrCreateRenderpass2Fn {
             cmd_next_subpass2_khr: unsafe {
                 unsafe extern "system" fn cmd_next_subpass2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_subpass_begin_info: *const SubpassBeginInfo,
-                    _p_subpass_end_info: *const SubpassEndInfo,
+                    _p_subpass_begin_info: *const SubpassBeginInfo<'_>,
+                    _p_subpass_end_info: *const SubpassEndInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5665,7 +5673,7 @@ impl KhrCreateRenderpass2Fn {
             cmd_end_render_pass2_khr: unsafe {
                 unsafe extern "system" fn cmd_end_render_pass2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_subpass_end_info: *const SubpassEndInfo,
+                    _p_subpass_end_info: *const SubpassEndInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5759,8 +5767,8 @@ impl KhrExternalFenceCapabilitiesFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceExternalFenceProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
-    p_external_fence_properties: *mut ExternalFenceProperties,
+    p_external_fence_info: *const PhysicalDeviceExternalFenceInfo<'_>,
+    p_external_fence_properties: *mut ExternalFenceProperties<'_>,
 );
 #[derive(Clone)]
 pub struct KhrExternalFenceCapabilitiesFn {
@@ -5778,8 +5786,8 @@ impl KhrExternalFenceCapabilitiesFn {
             get_physical_device_external_fence_properties_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_external_fence_properties_khr(
                     _physical_device: PhysicalDevice,
-                    _p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
-                    _p_external_fence_properties: *mut ExternalFenceProperties,
+                    _p_external_fence_info: *const PhysicalDeviceExternalFenceInfo<'_>,
+                    _p_external_fence_properties: *mut ExternalFenceProperties<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5841,12 +5849,12 @@ impl KhrExternalFenceWin32Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkImportFenceWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
-    p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR,
+    p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetFenceWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
-    p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR,
+    p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR<'_>,
     p_handle: *mut HANDLE,
 ) -> Result;
 #[derive(Clone)]
@@ -5865,7 +5873,7 @@ impl KhrExternalFenceWin32Fn {
             import_fence_win32_handle_khr: unsafe {
                 unsafe extern "system" fn import_fence_win32_handle_khr(
                     _device: Device,
-                    _p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR,
+                    _p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -5885,7 +5893,7 @@ impl KhrExternalFenceWin32Fn {
             get_fence_win32_handle_khr: unsafe {
                 unsafe extern "system" fn get_fence_win32_handle_khr(
                     _device: Device,
-                    _p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR,
+                    _p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR<'_>,
                     _p_handle: *mut HANDLE,
                 ) -> Result {
                     panic!(concat!(
@@ -5919,12 +5927,12 @@ impl KhrExternalFenceFdFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkImportFenceFdKHR = unsafe extern "system" fn(
     device: Device,
-    p_import_fence_fd_info: *const ImportFenceFdInfoKHR,
+    p_import_fence_fd_info: *const ImportFenceFdInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetFenceFdKHR = unsafe extern "system" fn(
     device: Device,
-    p_get_fd_info: *const FenceGetFdInfoKHR,
+    p_get_fd_info: *const FenceGetFdInfoKHR<'_>,
     p_fd: *mut c_int,
 ) -> Result;
 #[derive(Clone)]
@@ -5943,7 +5951,7 @@ impl KhrExternalFenceFdFn {
             import_fence_fd_khr: unsafe {
                 unsafe extern "system" fn import_fence_fd_khr(
                     _device: Device,
-                    _p_import_fence_fd_info: *const ImportFenceFdInfoKHR,
+                    _p_import_fence_fd_info: *const ImportFenceFdInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(import_fence_fd_khr)))
                 }
@@ -5959,7 +5967,7 @@ impl KhrExternalFenceFdFn {
             get_fence_fd_khr: unsafe {
                 unsafe extern "system" fn get_fence_fd_khr(
                     _device: Device,
-                    _p_get_fd_info: *const FenceGetFdInfoKHR,
+                    _p_get_fd_info: *const FenceGetFdInfoKHR<'_>,
                     _p_fd: *mut c_int,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(get_fence_fd_khr)))
@@ -5991,19 +5999,21 @@ pub type PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         p_counter_count: *mut u32,
-        p_counters: *mut PerformanceCounterKHR,
-        p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
+        p_counters: *mut PerformanceCounterKHR<'_>,
+        p_counter_descriptions: *mut PerformanceCounterDescriptionKHR<'_>,
     ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
     unsafe extern "system" fn(
         physical_device: PhysicalDevice,
-        p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+        p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR<'_>,
         p_num_passes: *mut u32,
     );
 #[allow(non_camel_case_types)]
-pub type PFN_vkAcquireProfilingLockKHR =
-    unsafe extern "system" fn(device: Device, p_info: *const AcquireProfilingLockInfoKHR) -> Result;
+pub type PFN_vkAcquireProfilingLockKHR = unsafe extern "system" fn(
+    device: Device,
+    p_info: *const AcquireProfilingLockInfoKHR<'_>,
+) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkReleaseProfilingLockKHR = unsafe extern "system" fn(device: Device);
 #[derive(Clone)]
@@ -6028,8 +6038,8 @@ impl KhrPerformanceQueryFn {
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _p_counter_count: *mut u32,
-                    _p_counters: *mut PerformanceCounterKHR,
-                    _p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
+                    _p_counters: *mut PerformanceCounterKHR<'_>,
+                    _p_counter_descriptions: *mut PerformanceCounterDescriptionKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6051,7 +6061,7 @@ impl KhrPerformanceQueryFn {
             get_physical_device_queue_family_performance_query_passes_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_queue_family_performance_query_passes_khr(
                     _physical_device: PhysicalDevice,
-                    _p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+                    _p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR<'_>,
                     _p_num_passes: *mut u32,
                 ) {
                     panic!(concat!(
@@ -6072,7 +6082,7 @@ impl KhrPerformanceQueryFn {
             acquire_profiling_lock_khr: unsafe {
                 unsafe extern "system" fn acquire_profiling_lock_khr(
                     _device: Device,
-                    _p_info: *const AcquireProfilingLockInfoKHR,
+                    _p_info: *const AcquireProfilingLockInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6169,15 +6179,15 @@ impl KhrGetSurfaceCapabilities2Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
-    p_surface_capabilities: *mut SurfaceCapabilities2KHR,
+    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
+    p_surface_capabilities: *mut SurfaceCapabilities2KHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSurfaceFormats2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
+    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
     p_surface_format_count: *mut u32,
-    p_surface_formats: *mut SurfaceFormat2KHR,
+    p_surface_formats: *mut SurfaceFormat2KHR<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrGetSurfaceCapabilities2Fn {
@@ -6196,8 +6206,8 @@ impl KhrGetSurfaceCapabilities2Fn {
             get_physical_device_surface_capabilities2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_surface_capabilities2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
-                    _p_surface_capabilities: *mut SurfaceCapabilities2KHR,
+                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
+                    _p_surface_capabilities: *mut SurfaceCapabilities2KHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6217,9 +6227,9 @@ impl KhrGetSurfaceCapabilities2Fn {
             get_physical_device_surface_formats2_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_surface_formats2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
+                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
                     _p_surface_format_count: *mut u32,
-                    _p_surface_formats: *mut SurfaceFormat2KHR,
+                    _p_surface_formats: *mut SurfaceFormat2KHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6269,26 +6279,26 @@ impl KhrGetDisplayProperties2Fn {
 pub type PFN_vkGetPhysicalDeviceDisplayProperties2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
-    p_properties: *mut DisplayProperties2KHR,
+    p_properties: *mut DisplayProperties2KHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
-    p_properties: *mut DisplayPlaneProperties2KHR,
+    p_properties: *mut DisplayPlaneProperties2KHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDisplayModeProperties2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     display: DisplayKHR,
     p_property_count: *mut u32,
-    p_properties: *mut DisplayModeProperties2KHR,
+    p_properties: *mut DisplayModeProperties2KHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDisplayPlaneCapabilities2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_display_plane_info: *const DisplayPlaneInfo2KHR,
-    p_capabilities: *mut DisplayPlaneCapabilities2KHR,
+    p_display_plane_info: *const DisplayPlaneInfo2KHR<'_>,
+    p_capabilities: *mut DisplayPlaneCapabilities2KHR<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrGetDisplayProperties2Fn {
@@ -6310,7 +6320,7 @@ impl KhrGetDisplayProperties2Fn {
                 unsafe extern "system" fn get_physical_device_display_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut DisplayProperties2KHR,
+                    _p_properties: *mut DisplayProperties2KHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6331,7 +6341,7 @@ impl KhrGetDisplayProperties2Fn {
                 unsafe extern "system" fn get_physical_device_display_plane_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut DisplayPlaneProperties2KHR,
+                    _p_properties: *mut DisplayPlaneProperties2KHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6353,7 +6363,7 @@ impl KhrGetDisplayProperties2Fn {
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut DisplayModeProperties2KHR,
+                    _p_properties: *mut DisplayModeProperties2KHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6373,8 +6383,8 @@ impl KhrGetDisplayProperties2Fn {
             get_display_plane_capabilities2_khr: unsafe {
                 unsafe extern "system" fn get_display_plane_capabilities2_khr(
                     _physical_device: PhysicalDevice,
-                    _p_display_plane_info: *const DisplayPlaneInfo2KHR,
-                    _p_capabilities: *mut DisplayPlaneCapabilities2KHR,
+                    _p_display_plane_info: *const DisplayPlaneInfo2KHR<'_>,
+                    _p_capabilities: *mut DisplayPlaneCapabilities2KHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6410,8 +6420,8 @@ impl MvkIosSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateIOSSurfaceMVK = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const IOSSurfaceCreateInfoMVK,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const IOSSurfaceCreateInfoMVK<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -6429,8 +6439,8 @@ impl MvkIosSurfaceFn {
             create_ios_surface_mvk: unsafe {
                 unsafe extern "system" fn create_ios_surface_mvk(
                     _instance: Instance,
-                    _p_create_info: *const IOSSurfaceCreateInfoMVK,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const IOSSurfaceCreateInfoMVK<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -6462,8 +6472,8 @@ impl MvkMacosSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateMacOSSurfaceMVK = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const MacOSSurfaceCreateInfoMVK,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const MacOSSurfaceCreateInfoMVK<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -6481,8 +6491,8 @@ impl MvkMacosSurfaceFn {
             create_mac_os_surface_mvk: unsafe {
                 unsafe extern "system" fn create_mac_os_surface_mvk(
                     _instance: Instance,
-                    _p_create_info: *const MacOSSurfaceCreateInfoMVK,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const MacOSSurfaceCreateInfoMVK<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -6547,52 +6557,52 @@ impl ExtDebugUtilsFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetDebugUtilsObjectNameEXT = unsafe extern "system" fn(
     device: Device,
-    p_name_info: *const DebugUtilsObjectNameInfoEXT,
+    p_name_info: *const DebugUtilsObjectNameInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetDebugUtilsObjectTagEXT = unsafe extern "system" fn(
     device: Device,
-    p_tag_info: *const DebugUtilsObjectTagInfoEXT,
+    p_tag_info: *const DebugUtilsObjectTagInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueBeginDebugUtilsLabelEXT =
-    unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT);
+    unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT<'_>);
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueEndDebugUtilsLabelEXT = unsafe extern "system" fn(queue: Queue);
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueInsertDebugUtilsLabelEXT =
-    unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT);
+    unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT<'_>);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginDebugUtilsLabelEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_label_info: *const DebugUtilsLabelEXT,
+    p_label_info: *const DebugUtilsLabelEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEndDebugUtilsLabelEXT = unsafe extern "system" fn(command_buffer: CommandBuffer);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdInsertDebugUtilsLabelEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_label_info: *const DebugUtilsLabelEXT,
+    p_label_info: *const DebugUtilsLabelEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDebugUtilsMessengerEXT = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const DebugUtilsMessengerCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DebugUtilsMessengerCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_messenger: *mut DebugUtilsMessengerEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDebugUtilsMessengerEXT = unsafe extern "system" fn(
     instance: Instance,
     messenger: DebugUtilsMessengerEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkSubmitDebugUtilsMessageEXT = unsafe extern "system" fn(
     instance: Instance,
     message_severity: DebugUtilsMessageSeverityFlagsEXT,
     message_types: DebugUtilsMessageTypeFlagsEXT,
-    p_callback_data: *const DebugUtilsMessengerCallbackDataEXT,
+    p_callback_data: *const DebugUtilsMessengerCallbackDataEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtDebugUtilsFn {
@@ -6619,7 +6629,7 @@ impl ExtDebugUtilsFn {
             set_debug_utils_object_name_ext: unsafe {
                 unsafe extern "system" fn set_debug_utils_object_name_ext(
                     _device: Device,
-                    _p_name_info: *const DebugUtilsObjectNameInfoEXT,
+                    _p_name_info: *const DebugUtilsObjectNameInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6639,7 +6649,7 @@ impl ExtDebugUtilsFn {
             set_debug_utils_object_tag_ext: unsafe {
                 unsafe extern "system" fn set_debug_utils_object_tag_ext(
                     _device: Device,
-                    _p_tag_info: *const DebugUtilsObjectTagInfoEXT,
+                    _p_tag_info: *const DebugUtilsObjectTagInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6659,7 +6669,7 @@ impl ExtDebugUtilsFn {
             queue_begin_debug_utils_label_ext: unsafe {
                 unsafe extern "system" fn queue_begin_debug_utils_label_ext(
                     _queue: Queue,
-                    _p_label_info: *const DebugUtilsLabelEXT,
+                    _p_label_info: *const DebugUtilsLabelEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -6696,7 +6706,7 @@ impl ExtDebugUtilsFn {
             queue_insert_debug_utils_label_ext: unsafe {
                 unsafe extern "system" fn queue_insert_debug_utils_label_ext(
                     _queue: Queue,
-                    _p_label_info: *const DebugUtilsLabelEXT,
+                    _p_label_info: *const DebugUtilsLabelEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -6716,7 +6726,7 @@ impl ExtDebugUtilsFn {
             cmd_begin_debug_utils_label_ext: unsafe {
                 unsafe extern "system" fn cmd_begin_debug_utils_label_ext(
                     _command_buffer: CommandBuffer,
-                    _p_label_info: *const DebugUtilsLabelEXT,
+                    _p_label_info: *const DebugUtilsLabelEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -6755,7 +6765,7 @@ impl ExtDebugUtilsFn {
             cmd_insert_debug_utils_label_ext: unsafe {
                 unsafe extern "system" fn cmd_insert_debug_utils_label_ext(
                     _command_buffer: CommandBuffer,
-                    _p_label_info: *const DebugUtilsLabelEXT,
+                    _p_label_info: *const DebugUtilsLabelEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -6775,8 +6785,8 @@ impl ExtDebugUtilsFn {
             create_debug_utils_messenger_ext: unsafe {
                 unsafe extern "system" fn create_debug_utils_messenger_ext(
                     _instance: Instance,
-                    _p_create_info: *const DebugUtilsMessengerCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DebugUtilsMessengerCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_messenger: *mut DebugUtilsMessengerEXT,
                 ) -> Result {
                     panic!(concat!(
@@ -6798,7 +6808,7 @@ impl ExtDebugUtilsFn {
                 unsafe extern "system" fn destroy_debug_utils_messenger_ext(
                     _instance: Instance,
                     _messenger: DebugUtilsMessengerEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -6820,7 +6830,7 @@ impl ExtDebugUtilsFn {
                     _instance: Instance,
                     _message_severity: DebugUtilsMessageSeverityFlagsEXT,
                     _message_types: DebugUtilsMessageTypeFlagsEXT,
-                    _p_callback_data: *const DebugUtilsMessengerCallbackDataEXT,
+                    _p_callback_data: *const DebugUtilsMessengerCallbackDataEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -6864,12 +6874,12 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
 pub type PFN_vkGetAndroidHardwareBufferPropertiesANDROID = unsafe extern "system" fn(
     device: Device,
     buffer: *const AHardwareBuffer,
-    p_properties: *mut AndroidHardwareBufferPropertiesANDROID,
+    p_properties: *mut AndroidHardwareBufferPropertiesANDROID<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMemoryAndroidHardwareBufferANDROID = unsafe extern "system" fn(
     device: Device,
-    p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID,
+    p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID<'_>,
     p_buffer: *mut *mut AHardwareBuffer,
 ) -> Result;
 #[derive(Clone)]
@@ -6890,7 +6900,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
                 unsafe extern "system" fn get_android_hardware_buffer_properties_android(
                     _device: Device,
                     _buffer: *const AHardwareBuffer,
-                    _p_properties: *mut AndroidHardwareBufferPropertiesANDROID,
+                    _p_properties: *mut AndroidHardwareBufferPropertiesANDROID<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -6910,7 +6920,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
             get_memory_android_hardware_buffer_android: unsafe {
                 unsafe extern "system" fn get_memory_android_hardware_buffer_android(
                     _device: Device,
-                    _p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID,
+                    _p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID<'_>,
                     _p_buffer: *mut *mut AHardwareBuffer,
                 ) -> Result {
                     panic!(concat!(
@@ -6995,21 +7005,21 @@ pub type PFN_vkCreateExecutionGraphPipelinesAMDX = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
-    p_create_infos: *const ExecutionGraphPipelineCreateInfoAMDX,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const ExecutionGraphPipelineCreateInfoAMDX<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetExecutionGraphPipelineScratchSizeAMDX = unsafe extern "system" fn(
     device: Device,
     execution_graph: Pipeline,
-    p_size_info: *mut ExecutionGraphPipelineScratchSizeAMDX,
+    p_size_info: *mut ExecutionGraphPipelineScratchSizeAMDX<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetExecutionGraphPipelineNodeIndexAMDX = unsafe extern "system" fn(
     device: Device,
     execution_graph: Pipeline,
-    p_node_info: *const PipelineShaderStageNodeCreateInfoAMDX,
+    p_node_info: *const PipelineShaderStageNodeCreateInfoAMDX<'_>,
     p_node_index: *mut u32,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -7057,8 +7067,8 @@ impl AmdxShaderEnqueueFn {
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
-                    _p_create_infos: *const ExecutionGraphPipelineCreateInfoAMDX,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const ExecutionGraphPipelineCreateInfoAMDX<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -7080,7 +7090,7 @@ impl AmdxShaderEnqueueFn {
                 unsafe extern "system" fn get_execution_graph_pipeline_scratch_size_amdx(
                     _device: Device,
                     _execution_graph: Pipeline,
-                    _p_size_info: *mut ExecutionGraphPipelineScratchSizeAMDX,
+                    _p_size_info: *mut ExecutionGraphPipelineScratchSizeAMDX<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -7101,7 +7111,7 @@ impl AmdxShaderEnqueueFn {
                 unsafe extern "system" fn get_execution_graph_pipeline_node_index_amdx(
                     _device: Device,
                     _execution_graph: Pipeline,
-                    _p_node_info: *const PipelineShaderStageNodeCreateInfoAMDX,
+                    _p_node_info: *const PipelineShaderStageNodeCreateInfoAMDX<'_>,
                     _p_node_index: *mut u32,
                 ) -> Result {
                     panic!(concat!(
@@ -7279,13 +7289,13 @@ impl ExtSampleLocationsFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetSampleLocationsEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_sample_locations_info: *const SampleLocationsInfoEXT,
+    p_sample_locations_info: *const SampleLocationsInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     samples: SampleCountFlags,
-    p_multisample_properties: *mut MultisamplePropertiesEXT,
+    p_multisample_properties: *mut MultisamplePropertiesEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtSampleLocationsFn {
@@ -7304,7 +7314,7 @@ impl ExtSampleLocationsFn {
             cmd_set_sample_locations_ext: unsafe {
                 unsafe extern "system" fn cmd_set_sample_locations_ext(
                     _command_buffer: CommandBuffer,
-                    _p_sample_locations_info: *const SampleLocationsInfoEXT,
+                    _p_sample_locations_info: *const SampleLocationsInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7325,7 +7335,7 @@ impl ExtSampleLocationsFn {
                 unsafe extern "system" fn get_physical_device_multisample_properties_ext(
                     _physical_device: PhysicalDevice,
                     _samples: SampleCountFlags,
-                    _p_multisample_properties: *mut MultisamplePropertiesEXT,
+                    _p_multisample_properties: *mut MultisamplePropertiesEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7378,21 +7388,21 @@ impl KhrGetMemoryRequirements2Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageMemoryRequirements2 = unsafe extern "system" fn(
     device: Device,
-    p_info: *const ImageMemoryRequirementsInfo2,
-    p_memory_requirements: *mut MemoryRequirements2,
+    p_info: *const ImageMemoryRequirementsInfo2<'_>,
+    p_memory_requirements: *mut MemoryRequirements2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferMemoryRequirements2 = unsafe extern "system" fn(
     device: Device,
-    p_info: *const BufferMemoryRequirementsInfo2,
-    p_memory_requirements: *mut MemoryRequirements2,
+    p_info: *const BufferMemoryRequirementsInfo2<'_>,
+    p_memory_requirements: *mut MemoryRequirements2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageSparseMemoryRequirements2 = unsafe extern "system" fn(
     device: Device,
-    p_info: *const ImageSparseMemoryRequirementsInfo2,
+    p_info: *const ImageSparseMemoryRequirementsInfo2<'_>,
     p_sparse_memory_requirement_count: *mut u32,
-    p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+    p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2<'_>,
 );
 #[derive(Clone)]
 pub struct KhrGetMemoryRequirements2Fn {
@@ -7411,8 +7421,8 @@ impl KhrGetMemoryRequirements2Fn {
             get_image_memory_requirements2_khr: unsafe {
                 unsafe extern "system" fn get_image_memory_requirements2_khr(
                     _device: Device,
-                    _p_info: *const ImageMemoryRequirementsInfo2,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const ImageMemoryRequirementsInfo2<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7432,8 +7442,8 @@ impl KhrGetMemoryRequirements2Fn {
             get_buffer_memory_requirements2_khr: unsafe {
                 unsafe extern "system" fn get_buffer_memory_requirements2_khr(
                     _device: Device,
-                    _p_info: *const BufferMemoryRequirementsInfo2,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const BufferMemoryRequirementsInfo2<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7453,9 +7463,9 @@ impl KhrGetMemoryRequirements2Fn {
             get_image_sparse_memory_requirements2_khr: unsafe {
                 unsafe extern "system" fn get_image_sparse_memory_requirements2_khr(
                     _device: Device,
-                    _p_info: *const ImageSparseMemoryRequirementsInfo2,
+                    _p_info: *const ImageSparseMemoryRequirementsInfo2<'_>,
                     _p_sparse_memory_requirement_count: *mut u32,
-                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7584,28 +7594,28 @@ impl KhrAccelerationStructureFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const AccelerationStructureCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const AccelerationStructureCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_acceleration_structure: *mut AccelerationStructureKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     acceleration_structure: AccelerationStructureKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBuildAccelerationStructuresKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     info_count: u32,
-    p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
+    p_infos: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
     pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBuildAccelerationStructuresIndirectKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     info_count: u32,
-    p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
+    p_infos: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
     p_indirect_device_addresses: *const DeviceAddress,
     p_indirect_strides: *const u32,
     pp_max_primitive_counts: *const *const u32,
@@ -7615,26 +7625,26 @@ pub type PFN_vkBuildAccelerationStructuresKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     info_count: u32,
-    p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
+    p_infos: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
     pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
-    p_info: *const CopyAccelerationStructureInfoKHR,
+    p_info: *const CopyAccelerationStructureInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyAccelerationStructureToMemoryKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
-    p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
+    p_info: *const CopyAccelerationStructureToMemoryInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyMemoryToAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
-    p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
+    p_info: *const CopyMemoryToAccelerationStructureInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkWriteAccelerationStructuresPropertiesKHR = unsafe extern "system" fn(
@@ -7649,23 +7659,23 @@ pub type PFN_vkWriteAccelerationStructuresPropertiesKHR = unsafe extern "system"
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyAccelerationStructureKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_info: *const CopyAccelerationStructureInfoKHR,
+    p_info: *const CopyAccelerationStructureInfoKHR<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyAccelerationStructureToMemoryKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
+    p_info: *const CopyAccelerationStructureToMemoryInfoKHR<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyMemoryToAccelerationStructureKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
+    p_info: *const CopyMemoryToAccelerationStructureInfoKHR<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetAccelerationStructureDeviceAddressKHR =
     unsafe extern "system" fn(
         device: Device,
-        p_info: *const AccelerationStructureDeviceAddressInfoKHR,
+        p_info: *const AccelerationStructureDeviceAddressInfoKHR<'_>,
     ) -> DeviceAddress;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdWriteAccelerationStructuresPropertiesKHR = unsafe extern "system" fn(
@@ -7679,16 +7689,16 @@ pub type PFN_vkCmdWriteAccelerationStructuresPropertiesKHR = unsafe extern "syst
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceAccelerationStructureCompatibilityKHR = unsafe extern "system" fn(
     device: Device,
-    p_version_info: *const AccelerationStructureVersionInfoKHR,
+    p_version_info: *const AccelerationStructureVersionInfoKHR<'_>,
     p_compatibility: *mut AccelerationStructureCompatibilityKHR,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetAccelerationStructureBuildSizesKHR = unsafe extern "system" fn(
     device: Device,
     build_type: AccelerationStructureBuildTypeKHR,
-    p_build_info: *const AccelerationStructureBuildGeometryInfoKHR,
+    p_build_info: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
     p_max_primitive_counts: *const u32,
-    p_size_info: *mut AccelerationStructureBuildSizesInfoKHR,
+    p_size_info: *mut AccelerationStructureBuildSizesInfoKHR<'_>,
 );
 #[derive(Clone)]
 pub struct KhrAccelerationStructureFn {
@@ -7727,8 +7737,8 @@ impl KhrAccelerationStructureFn {
             create_acceleration_structure_khr: unsafe {
                 unsafe extern "system" fn create_acceleration_structure_khr(
                     _device: Device,
-                    _p_create_info: *const AccelerationStructureCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const AccelerationStructureCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_acceleration_structure: *mut AccelerationStructureKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -7750,7 +7760,7 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn destroy_acceleration_structure_khr(
                     _device: Device,
                     _acceleration_structure: AccelerationStructureKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7771,7 +7781,7 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn cmd_build_acceleration_structures_khr(
                     _command_buffer: CommandBuffer,
                     _info_count: u32,
-                    _p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
+                    _p_infos: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
                     _pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
                 ) {
                     panic!(concat!(
@@ -7793,7 +7803,7 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn cmd_build_acceleration_structures_indirect_khr(
                     _command_buffer: CommandBuffer,
                     _info_count: u32,
-                    _p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
+                    _p_infos: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
                     _p_indirect_device_addresses: *const DeviceAddress,
                     _p_indirect_strides: *const u32,
                     _pp_max_primitive_counts: *const *const u32,
@@ -7818,7 +7828,7 @@ impl KhrAccelerationStructureFn {
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _info_count: u32,
-                    _p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
+                    _p_infos: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
                     _pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -7840,7 +7850,7 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn copy_acceleration_structure_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
-                    _p_info: *const CopyAccelerationStructureInfoKHR,
+                    _p_info: *const CopyAccelerationStructureInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -7861,7 +7871,7 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn copy_acceleration_structure_to_memory_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
-                    _p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
+                    _p_info: *const CopyAccelerationStructureToMemoryInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -7882,7 +7892,7 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn copy_memory_to_acceleration_structure_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
-                    _p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
+                    _p_info: *const CopyMemoryToAccelerationStructureInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -7927,7 +7937,7 @@ impl KhrAccelerationStructureFn {
             cmd_copy_acceleration_structure_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_acceleration_structure_khr(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const CopyAccelerationStructureInfoKHR,
+                    _p_info: *const CopyAccelerationStructureInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7947,7 +7957,7 @@ impl KhrAccelerationStructureFn {
             cmd_copy_acceleration_structure_to_memory_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_acceleration_structure_to_memory_khr(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
+                    _p_info: *const CopyAccelerationStructureToMemoryInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7967,7 +7977,7 @@ impl KhrAccelerationStructureFn {
             cmd_copy_memory_to_acceleration_structure_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_memory_to_acceleration_structure_khr(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
+                    _p_info: *const CopyMemoryToAccelerationStructureInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -7987,7 +7997,7 @@ impl KhrAccelerationStructureFn {
             get_acceleration_structure_device_address_khr: unsafe {
                 unsafe extern "system" fn get_acceleration_structure_device_address_khr(
                     _device: Device,
-                    _p_info: *const AccelerationStructureDeviceAddressInfoKHR,
+                    _p_info: *const AccelerationStructureDeviceAddressInfoKHR<'_>,
                 ) -> DeviceAddress {
                     panic!(concat!(
                         "Unable to load ",
@@ -8031,7 +8041,7 @@ impl KhrAccelerationStructureFn {
             get_device_acceleration_structure_compatibility_khr: unsafe {
                 unsafe extern "system" fn get_device_acceleration_structure_compatibility_khr(
                     _device: Device,
-                    _p_version_info: *const AccelerationStructureVersionInfoKHR,
+                    _p_version_info: *const AccelerationStructureVersionInfoKHR<'_>,
                     _p_compatibility: *mut AccelerationStructureCompatibilityKHR,
                 ) {
                     panic!(concat!(
@@ -8053,9 +8063,9 @@ impl KhrAccelerationStructureFn {
                 unsafe extern "system" fn get_acceleration_structure_build_sizes_khr(
                     _device: Device,
                     _build_type: AccelerationStructureBuildTypeKHR,
-                    _p_build_info: *const AccelerationStructureBuildGeometryInfoKHR,
+                    _p_build_info: *const AccelerationStructureBuildGeometryInfoKHR<'_>,
                     _p_max_primitive_counts: *const u32,
-                    _p_size_info: *mut AccelerationStructureBuildSizesInfoKHR,
+                    _p_size_info: *mut AccelerationStructureBuildSizesInfoKHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -8162,8 +8172,8 @@ pub type PFN_vkCreateRayTracingPipelinesKHR = unsafe extern "system" fn(
     deferred_operation: DeferredOperationKHR,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
-    p_create_infos: *const RayTracingPipelineCreateInfoKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const RayTracingPipelineCreateInfoKHR<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -8250,8 +8260,8 @@ impl KhrRayTracingPipelineFn {
                     _deferred_operation: DeferredOperationKHR,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
-                    _p_create_infos: *const RayTracingPipelineCreateInfoKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const RayTracingPipelineCreateInfoKHR<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -8491,15 +8501,15 @@ impl KhrSamplerYcbcrConversionFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateSamplerYcbcrConversion = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const SamplerYcbcrConversionCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const SamplerYcbcrConversionCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_ycbcr_conversion: *mut SamplerYcbcrConversion,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySamplerYcbcrConversion = unsafe extern "system" fn(
     device: Device,
     ycbcr_conversion: SamplerYcbcrConversion,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[derive(Clone)]
 pub struct KhrSamplerYcbcrConversionFn {
@@ -8517,8 +8527,8 @@ impl KhrSamplerYcbcrConversionFn {
             create_sampler_ycbcr_conversion_khr: unsafe {
                 unsafe extern "system" fn create_sampler_ycbcr_conversion_khr(
                     _device: Device,
-                    _p_create_info: *const SamplerYcbcrConversionCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const SamplerYcbcrConversionCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_ycbcr_conversion: *mut SamplerYcbcrConversion,
                 ) -> Result {
                     panic!(concat!(
@@ -8540,7 +8550,7 @@ impl KhrSamplerYcbcrConversionFn {
                 unsafe extern "system" fn destroy_sampler_ycbcr_conversion_khr(
                     _device: Device,
                     _ycbcr_conversion: SamplerYcbcrConversion,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -8685,13 +8695,13 @@ impl KhrBindMemory2Fn {
 pub type PFN_vkBindBufferMemory2 = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
-    p_bind_infos: *const BindBufferMemoryInfo,
+    p_bind_infos: *const BindBufferMemoryInfo<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkBindImageMemory2 = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
-    p_bind_infos: *const BindImageMemoryInfo,
+    p_bind_infos: *const BindImageMemoryInfo<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrBindMemory2Fn {
@@ -8710,7 +8720,7 @@ impl KhrBindMemory2Fn {
                 unsafe extern "system" fn bind_buffer_memory2_khr(
                     _device: Device,
                     _bind_info_count: u32,
-                    _p_bind_infos: *const BindBufferMemoryInfo,
+                    _p_bind_infos: *const BindBufferMemoryInfo<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -8730,7 +8740,7 @@ impl KhrBindMemory2Fn {
                 unsafe extern "system" fn bind_image_memory2_khr(
                     _device: Device,
                     _bind_info_count: u32,
-                    _p_bind_infos: *const BindImageMemoryInfo,
+                    _p_bind_infos: *const BindImageMemoryInfo<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -8768,7 +8778,7 @@ impl ExtImageDrmFormatModifierFn {
 pub type PFN_vkGetImageDrmFormatModifierPropertiesEXT = unsafe extern "system" fn(
     device: Device,
     image: Image,
-    p_properties: *mut ImageDrmFormatModifierPropertiesEXT,
+    p_properties: *mut ImageDrmFormatModifierPropertiesEXT<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtImageDrmFormatModifierFn {
@@ -8786,7 +8796,7 @@ impl ExtImageDrmFormatModifierFn {
                 unsafe extern "system" fn get_image_drm_format_modifier_properties_ext(
                     _device: Device,
                     _image: Image,
-                    _p_properties: *mut ImageDrmFormatModifierPropertiesEXT,
+                    _p_properties: *mut ImageDrmFormatModifierPropertiesEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -8838,15 +8848,15 @@ impl ExtValidationCacheFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateValidationCacheEXT = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const ValidationCacheCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ValidationCacheCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_validation_cache: *mut ValidationCacheEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyValidationCacheEXT = unsafe extern "system" fn(
     device: Device,
     validation_cache: ValidationCacheEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkMergeValidationCachesEXT = unsafe extern "system" fn(
@@ -8880,8 +8890,8 @@ impl ExtValidationCacheFn {
             create_validation_cache_ext: unsafe {
                 unsafe extern "system" fn create_validation_cache_ext(
                     _device: Device,
-                    _p_create_info: *const ValidationCacheCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ValidationCacheCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_validation_cache: *mut ValidationCacheEXT,
                 ) -> Result {
                     panic!(concat!(
@@ -8903,7 +8913,7 @@ impl ExtValidationCacheFn {
                 unsafe extern "system" fn destroy_validation_cache_ext(
                     _device: Device,
                     _validation_cache: ValidationCacheEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -9051,14 +9061,14 @@ pub type PFN_vkCmdSetViewportShadingRatePaletteNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_viewport: u32,
     viewport_count: u32,
-    p_shading_rate_palettes: *const ShadingRatePaletteNV,
+    p_shading_rate_palettes: *const ShadingRatePaletteNV<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetCoarseSampleOrderNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     sample_order_type: CoarseSampleOrderTypeNV,
     custom_sample_order_count: u32,
-    p_custom_sample_orders: *const CoarseSampleOrderCustomNV,
+    p_custom_sample_orders: *const CoarseSampleOrderCustomNV<'_>,
 );
 #[derive(Clone)]
 pub struct NvShadingRateImageFn {
@@ -9100,7 +9110,7 @@ impl NvShadingRateImageFn {
                     _command_buffer: CommandBuffer,
                     _first_viewport: u32,
                     _viewport_count: u32,
-                    _p_shading_rate_palettes: *const ShadingRatePaletteNV,
+                    _p_shading_rate_palettes: *const ShadingRatePaletteNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -9122,7 +9132,7 @@ impl NvShadingRateImageFn {
                     _command_buffer: CommandBuffer,
                     _sample_order_type: CoarseSampleOrderTypeNV,
                     _custom_sample_order_count: u32,
-                    _p_custom_sample_orders: *const CoarseSampleOrderCustomNV,
+                    _p_custom_sample_orders: *const CoarseSampleOrderCustomNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -9179,32 +9189,32 @@ impl NvRayTracingFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateAccelerationStructureNV = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const AccelerationStructureCreateInfoNV,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const AccelerationStructureCreateInfoNV<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_acceleration_structure: *mut AccelerationStructureNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyAccelerationStructureNV = unsafe extern "system" fn(
     device: Device,
     acceleration_structure: AccelerationStructureNV,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetAccelerationStructureMemoryRequirementsNV = unsafe extern "system" fn(
     device: Device,
-    p_info: *const AccelerationStructureMemoryRequirementsInfoNV,
+    p_info: *const AccelerationStructureMemoryRequirementsInfoNV<'_>,
     p_memory_requirements: *mut MemoryRequirements2KHR,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkBindAccelerationStructureMemoryNV = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
-    p_bind_infos: *const BindAccelerationStructureMemoryInfoNV,
+    p_bind_infos: *const BindAccelerationStructureMemoryInfoNV<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBuildAccelerationStructureNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_info: *const AccelerationStructureInfoNV,
+    p_info: *const AccelerationStructureInfoNV<'_>,
     instance_data: Buffer,
     instance_offset: DeviceSize,
     update: Bool32,
@@ -9243,8 +9253,8 @@ pub type PFN_vkCreateRayTracingPipelinesNV = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
-    p_create_infos: *const RayTracingPipelineCreateInfoNV,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const RayTracingPipelineCreateInfoNV<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -9295,8 +9305,8 @@ impl NvRayTracingFn {
             create_acceleration_structure_nv: unsafe {
                 unsafe extern "system" fn create_acceleration_structure_nv(
                     _device: Device,
-                    _p_create_info: *const AccelerationStructureCreateInfoNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const AccelerationStructureCreateInfoNV<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_acceleration_structure: *mut AccelerationStructureNV,
                 ) -> Result {
                     panic!(concat!(
@@ -9318,7 +9328,7 @@ impl NvRayTracingFn {
                 unsafe extern "system" fn destroy_acceleration_structure_nv(
                     _device: Device,
                     _acceleration_structure: AccelerationStructureNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -9338,7 +9348,7 @@ impl NvRayTracingFn {
             get_acceleration_structure_memory_requirements_nv: unsafe {
                 unsafe extern "system" fn get_acceleration_structure_memory_requirements_nv(
                     _device: Device,
-                    _p_info: *const AccelerationStructureMemoryRequirementsInfoNV,
+                    _p_info: *const AccelerationStructureMemoryRequirementsInfoNV<'_>,
                     _p_memory_requirements: *mut MemoryRequirements2KHR,
                 ) {
                     panic!(concat!(
@@ -9360,7 +9370,7 @@ impl NvRayTracingFn {
                 unsafe extern "system" fn bind_acceleration_structure_memory_nv(
                     _device: Device,
                     _bind_info_count: u32,
-                    _p_bind_infos: *const BindAccelerationStructureMemoryInfoNV,
+                    _p_bind_infos: *const BindAccelerationStructureMemoryInfoNV<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -9380,7 +9390,7 @@ impl NvRayTracingFn {
             cmd_build_acceleration_structure_nv: unsafe {
                 unsafe extern "system" fn cmd_build_acceleration_structure_nv(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const AccelerationStructureInfoNV,
+                    _p_info: *const AccelerationStructureInfoNV<'_>,
                     _instance_data: Buffer,
                     _instance_offset: DeviceSize,
                     _update: Bool32,
@@ -9459,8 +9469,8 @@ impl NvRayTracingFn {
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
-                    _p_create_infos: *const RayTracingPipelineCreateInfoNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const RayTracingPipelineCreateInfoNV<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -9696,8 +9706,8 @@ impl KhrMaintenance3Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDescriptorSetLayoutSupport = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const DescriptorSetLayoutCreateInfo,
-    p_support: *mut DescriptorSetLayoutSupport,
+    p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
+    p_support: *mut DescriptorSetLayoutSupport<'_>,
 );
 #[derive(Clone)]
 pub struct KhrMaintenance3Fn {
@@ -9714,8 +9724,8 @@ impl KhrMaintenance3Fn {
             get_descriptor_set_layout_support_khr: unsafe {
                 unsafe extern "system" fn get_descriptor_set_layout_support_khr(
                     _device: Device,
-                    _p_create_info: *const DescriptorSetLayoutCreateInfo,
-                    _p_support: *mut DescriptorSetLayoutSupport,
+                    _p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
+                    _p_support: *mut DescriptorSetLayoutSupport<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -9896,7 +9906,7 @@ pub type PFN_vkGetMemoryHostPointerPropertiesEXT = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     p_host_pointer: *const c_void,
-    p_memory_host_pointer_properties: *mut MemoryHostPointerPropertiesEXT,
+    p_memory_host_pointer_properties: *mut MemoryHostPointerPropertiesEXT<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtExternalMemoryHostFn {
@@ -9915,7 +9925,7 @@ impl ExtExternalMemoryHostFn {
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _p_host_pointer: *const c_void,
-                    _p_memory_host_pointer_properties: *mut MemoryHostPointerPropertiesEXT,
+                    _p_memory_host_pointer_properties: *mut MemoryHostPointerPropertiesEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -10047,7 +10057,7 @@ pub type PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT = unsafe extern "sys
 pub type PFN_vkGetCalibratedTimestampsEXT = unsafe extern "system" fn(
     device: Device,
     timestamp_count: u32,
-    p_timestamp_infos: *const CalibratedTimestampInfoEXT,
+    p_timestamp_infos: *const CalibratedTimestampInfoEXT<'_>,
     p_timestamps: *mut u64,
     p_max_deviation: *mut u64,
 ) -> Result;
@@ -10090,7 +10100,7 @@ impl ExtCalibratedTimestampsFn {
                 unsafe extern "system" fn get_calibrated_timestamps_ext(
                     _device: Device,
                     _timestamp_count: u32,
-                    _p_timestamp_infos: *const CalibratedTimestampInfoEXT,
+                    _p_timestamp_infos: *const CalibratedTimestampInfoEXT<'_>,
                     _p_timestamps: *mut u64,
                     _p_max_deviation: *mut u64,
                 ) -> Result {
@@ -10572,7 +10582,7 @@ pub type PFN_vkCmdSetCheckpointNV =
 pub type PFN_vkGetQueueCheckpointDataNV = unsafe extern "system" fn(
     queue: Queue,
     p_checkpoint_data_count: *mut u32,
-    p_checkpoint_data: *mut CheckpointDataNV,
+    p_checkpoint_data: *mut CheckpointDataNV<'_>,
 );
 #[derive(Clone)]
 pub struct NvDeviceDiagnosticCheckpointsFn {
@@ -10610,7 +10620,7 @@ impl NvDeviceDiagnosticCheckpointsFn {
                 unsafe extern "system" fn get_queue_checkpoint_data_nv(
                     _queue: Queue,
                     _p_checkpoint_data_count: *mut u32,
-                    _p_checkpoint_data: *mut CheckpointDataNV,
+                    _p_checkpoint_data: *mut CheckpointDataNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -10646,12 +10656,14 @@ pub type PFN_vkGetSemaphoreCounterValue =
 #[allow(non_camel_case_types)]
 pub type PFN_vkWaitSemaphores = unsafe extern "system" fn(
     device: Device,
-    p_wait_info: *const SemaphoreWaitInfo,
+    p_wait_info: *const SemaphoreWaitInfo<'_>,
     timeout: u64,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkSignalSemaphore =
-    unsafe extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result;
+pub type PFN_vkSignalSemaphore = unsafe extern "system" fn(
+    device: Device,
+    p_signal_info: *const SemaphoreSignalInfo<'_>,
+) -> Result;
 #[derive(Clone)]
 pub struct KhrTimelineSemaphoreFn {
     pub get_semaphore_counter_value_khr: PFN_vkGetSemaphoreCounterValue,
@@ -10690,7 +10702,7 @@ impl KhrTimelineSemaphoreFn {
             wait_semaphores_khr: unsafe {
                 unsafe extern "system" fn wait_semaphores_khr(
                     _device: Device,
-                    _p_wait_info: *const SemaphoreWaitInfo,
+                    _p_wait_info: *const SemaphoreWaitInfo<'_>,
                     _timeout: u64,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(wait_semaphores_khr)))
@@ -10707,7 +10719,7 @@ impl KhrTimelineSemaphoreFn {
             signal_semaphore_khr: unsafe {
                 unsafe extern "system" fn signal_semaphore_khr(
                     _device: Device,
-                    _p_signal_info: *const SemaphoreSignalInfo,
+                    _p_signal_info: *const SemaphoreSignalInfo<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(signal_semaphore_khr)))
                 }
@@ -10763,29 +10775,29 @@ impl IntelPerformanceQueryFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkInitializePerformanceApiINTEL = unsafe extern "system" fn(
     device: Device,
-    p_initialize_info: *const InitializePerformanceApiInfoINTEL,
+    p_initialize_info: *const InitializePerformanceApiInfoINTEL<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkUninitializePerformanceApiINTEL = unsafe extern "system" fn(device: Device);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetPerformanceMarkerINTEL = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_marker_info: *const PerformanceMarkerInfoINTEL,
+    p_marker_info: *const PerformanceMarkerInfoINTEL<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetPerformanceStreamMarkerINTEL = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_marker_info: *const PerformanceStreamMarkerInfoINTEL,
+    p_marker_info: *const PerformanceStreamMarkerInfoINTEL<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetPerformanceOverrideINTEL = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_override_info: *const PerformanceOverrideInfoINTEL,
+    p_override_info: *const PerformanceOverrideInfoINTEL<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkAcquirePerformanceConfigurationINTEL = unsafe extern "system" fn(
     device: Device,
-    p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL,
+    p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL<'_>,
     p_configuration: *mut PerformanceConfigurationINTEL,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -10825,7 +10837,7 @@ impl IntelPerformanceQueryFn {
             initialize_performance_api_intel: unsafe {
                 unsafe extern "system" fn initialize_performance_api_intel(
                     _device: Device,
-                    _p_initialize_info: *const InitializePerformanceApiInfoINTEL,
+                    _p_initialize_info: *const InitializePerformanceApiInfoINTEL<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -10862,7 +10874,7 @@ impl IntelPerformanceQueryFn {
             cmd_set_performance_marker_intel: unsafe {
                 unsafe extern "system" fn cmd_set_performance_marker_intel(
                     _command_buffer: CommandBuffer,
-                    _p_marker_info: *const PerformanceMarkerInfoINTEL,
+                    _p_marker_info: *const PerformanceMarkerInfoINTEL<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -10882,7 +10894,7 @@ impl IntelPerformanceQueryFn {
             cmd_set_performance_stream_marker_intel: unsafe {
                 unsafe extern "system" fn cmd_set_performance_stream_marker_intel(
                     _command_buffer: CommandBuffer,
-                    _p_marker_info: *const PerformanceStreamMarkerInfoINTEL,
+                    _p_marker_info: *const PerformanceStreamMarkerInfoINTEL<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -10902,7 +10914,7 @@ impl IntelPerformanceQueryFn {
             cmd_set_performance_override_intel: unsafe {
                 unsafe extern "system" fn cmd_set_performance_override_intel(
                     _command_buffer: CommandBuffer,
-                    _p_override_info: *const PerformanceOverrideInfoINTEL,
+                    _p_override_info: *const PerformanceOverrideInfoINTEL<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -10922,7 +10934,7 @@ impl IntelPerformanceQueryFn {
             acquire_performance_configuration_intel: unsafe {
                 unsafe extern "system" fn acquire_performance_configuration_intel(
                     _device: Device,
-                    _p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL,
+                    _p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL<'_>,
                     _p_configuration: *mut PerformanceConfigurationINTEL,
                 ) -> Result {
                     panic!(concat!(
@@ -11108,8 +11120,8 @@ impl FuchsiaImagepipeSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateImagePipeSurfaceFUCHSIA = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -11127,8 +11139,8 @@ impl FuchsiaImagepipeSurfaceFn {
             create_image_pipe_surface_fuchsia: unsafe {
                 unsafe extern "system" fn create_image_pipe_surface_fuchsia(
                     _instance: Instance,
-                    _p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -11174,8 +11186,8 @@ impl ExtMetalSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateMetalSurfaceEXT = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const MetalSurfaceCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const MetalSurfaceCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -11193,8 +11205,8 @@ impl ExtMetalSurfaceFn {
             create_metal_surface_ext: unsafe {
                 unsafe extern "system" fn create_metal_surface_ext(
                     _instance: Instance,
-                    _p_create_info: *const MetalSurfaceCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const MetalSurfaceCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -11328,7 +11340,7 @@ impl KhrFragmentShadingRateFn {
 pub type PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_fragment_shading_rate_count: *mut u32,
-    p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR,
+    p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetFragmentShadingRateKHR = unsafe extern "system" fn(
@@ -11354,7 +11366,7 @@ impl KhrFragmentShadingRateFn {
                 unsafe extern "system" fn get_physical_device_fragment_shading_rates_khr(
                     _physical_device: PhysicalDevice,
                     _p_fragment_shading_rate_count: *mut u32,
-                    _p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR,
+                    _p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -11565,7 +11577,7 @@ impl ExtBufferDeviceAddressFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferDeviceAddress = unsafe extern "system" fn(
     device: Device,
-    p_info: *const BufferDeviceAddressInfo,
+    p_info: *const BufferDeviceAddressInfo<'_>,
 ) -> DeviceAddress;
 #[derive(Clone)]
 pub struct ExtBufferDeviceAddressFn {
@@ -11582,7 +11594,7 @@ impl ExtBufferDeviceAddressFn {
             get_buffer_device_address_ext: unsafe {
                 unsafe extern "system" fn get_buffer_device_address_ext(
                     _device: Device,
-                    _p_info: *const BufferDeviceAddressInfo,
+                    _p_info: *const BufferDeviceAddressInfo<'_>,
                 ) -> DeviceAddress {
                     panic!(concat!(
                         "Unable to load ",
@@ -11631,7 +11643,7 @@ impl ExtToolingInfoFn {
 pub type PFN_vkGetPhysicalDeviceToolProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_tool_count: *mut u32,
-    p_tool_properties: *mut PhysicalDeviceToolProperties,
+    p_tool_properties: *mut PhysicalDeviceToolProperties<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtToolingInfoFn {
@@ -11649,7 +11661,7 @@ impl ExtToolingInfoFn {
                 unsafe extern "system" fn get_physical_device_tool_properties_ext(
                     _physical_device: PhysicalDevice,
                     _p_tool_count: *mut u32,
-                    _p_tool_properties: *mut PhysicalDeviceToolProperties,
+                    _p_tool_properties: *mut PhysicalDeviceToolProperties<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -11759,7 +11771,7 @@ impl NvCooperativeMatrixFn {
 pub type PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
-    p_properties: *mut CooperativeMatrixPropertiesNV,
+    p_properties: *mut CooperativeMatrixPropertiesNV<'_>,
 )
     -> Result;
 #[derive(Clone)]
@@ -11779,7 +11791,7 @@ impl NvCooperativeMatrixFn {
                 unsafe extern "system" fn get_physical_device_cooperative_matrix_properties_nv(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut CooperativeMatrixPropertiesNV,
+                    _p_properties: *mut CooperativeMatrixPropertiesNV<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -11837,7 +11849,7 @@ pub type PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV =
     unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_combination_count: *mut u32,
-        p_combinations: *mut FramebufferMixedSamplesCombinationNV,
+        p_combinations: *mut FramebufferMixedSamplesCombinationNV<'_>,
     ) -> Result;
 #[derive(Clone)]
 pub struct NvCoverageReductionModeFn {
@@ -11856,7 +11868,7 @@ impl NvCoverageReductionModeFn {
                 unsafe extern "system" fn get_physical_device_supported_framebuffer_mixed_samples_combinations_nv(
                     _physical_device: PhysicalDevice,
                     _p_combination_count: *mut u32,
-                    _p_combinations: *mut FramebufferMixedSamplesCombinationNV,
+                    _p_combinations: *mut FramebufferMixedSamplesCombinationNV<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -11943,7 +11955,7 @@ impl ExtFullScreenExclusiveFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
+    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
     p_present_mode_count: *mut u32,
     p_present_modes: *mut PresentModeKHR,
 ) -> Result;
@@ -11956,7 +11968,7 @@ pub type PFN_vkReleaseFullScreenExclusiveModeEXT =
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceGroupSurfacePresentModes2EXT = unsafe extern "system" fn(
     device: Device,
-    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
+    p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
     p_modes: *mut DeviceGroupPresentModeFlagsKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -11978,7 +11990,7 @@ impl ExtFullScreenExclusiveFn {
             get_physical_device_surface_present_modes2_ext: unsafe {
                 unsafe extern "system" fn get_physical_device_surface_present_modes2_ext(
                     _physical_device: PhysicalDevice,
-                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
+                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
                     _p_present_mode_count: *mut u32,
                     _p_present_modes: *mut PresentModeKHR,
                 ) -> Result {
@@ -12040,7 +12052,7 @@ impl ExtFullScreenExclusiveFn {
             get_device_group_surface_present_modes2_ext: unsafe {
                 unsafe extern "system" fn get_device_group_surface_present_modes2_ext(
                     _device: Device,
-                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
+                    _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR<'_>,
                     _p_modes: *mut DeviceGroupPresentModeFlagsKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -12079,8 +12091,8 @@ impl ExtHeadlessSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateHeadlessSurfaceEXT = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const HeadlessSurfaceCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const HeadlessSurfaceCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[derive(Clone)]
@@ -12098,8 +12110,8 @@ impl ExtHeadlessSurfaceFn {
             create_headless_surface_ext: unsafe {
                 unsafe extern "system" fn create_headless_surface_ext(
                     _instance: Instance,
-                    _p_create_info: *const HeadlessSurfaceCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const HeadlessSurfaceCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -12132,11 +12144,11 @@ impl KhrBufferDeviceAddressFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferOpaqueCaptureAddress =
-    unsafe extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64;
+    unsafe extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo<'_>) -> u64;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceMemoryOpaqueCaptureAddress = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
+    p_info: *const DeviceMemoryOpaqueCaptureAddressInfo<'_>,
 ) -> u64;
 #[derive(Clone)]
 pub struct KhrBufferDeviceAddressFn {
@@ -12155,7 +12167,7 @@ impl KhrBufferDeviceAddressFn {
             get_buffer_device_address_khr: unsafe {
                 unsafe extern "system" fn get_buffer_device_address_khr(
                     _device: Device,
-                    _p_info: *const BufferDeviceAddressInfo,
+                    _p_info: *const BufferDeviceAddressInfo<'_>,
                 ) -> DeviceAddress {
                     panic!(concat!(
                         "Unable to load ",
@@ -12175,7 +12187,7 @@ impl KhrBufferDeviceAddressFn {
             get_buffer_opaque_capture_address_khr: unsafe {
                 unsafe extern "system" fn get_buffer_opaque_capture_address_khr(
                     _device: Device,
-                    _p_info: *const BufferDeviceAddressInfo,
+                    _p_info: *const BufferDeviceAddressInfo<'_>,
                 ) -> u64 {
                     panic!(concat!(
                         "Unable to load ",
@@ -12195,7 +12207,7 @@ impl KhrBufferDeviceAddressFn {
             get_device_memory_opaque_capture_address_khr: unsafe {
                 unsafe extern "system" fn get_device_memory_opaque_capture_address_khr(
                     _device: Device,
-                    _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
+                    _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo<'_>,
                 ) -> u64 {
                     panic!(concat!(
                         "Unable to load ",
@@ -12740,14 +12752,14 @@ impl KhrDeferredHostOperationsFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDeferredOperationKHR = unsafe extern "system" fn(
     device: Device,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_deferred_operation: *mut DeferredOperationKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDeferredOperationKHR = unsafe extern "system" fn(
     device: Device,
     operation: DeferredOperationKHR,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeferredOperationMaxConcurrencyKHR =
@@ -12777,7 +12789,7 @@ impl KhrDeferredHostOperationsFn {
             create_deferred_operation_khr: unsafe {
                 unsafe extern "system" fn create_deferred_operation_khr(
                     _device: Device,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_deferred_operation: *mut DeferredOperationKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -12799,7 +12811,7 @@ impl KhrDeferredHostOperationsFn {
                 unsafe extern "system" fn destroy_deferred_operation_khr(
                     _device: Device,
                     _operation: DeferredOperationKHR,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -12899,24 +12911,24 @@ impl KhrPipelineExecutablePropertiesFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineExecutablePropertiesKHR = unsafe extern "system" fn(
     device: Device,
-    p_pipeline_info: *const PipelineInfoKHR,
+    p_pipeline_info: *const PipelineInfoKHR<'_>,
     p_executable_count: *mut u32,
-    p_properties: *mut PipelineExecutablePropertiesKHR,
+    p_properties: *mut PipelineExecutablePropertiesKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineExecutableStatisticsKHR = unsafe extern "system" fn(
     device: Device,
-    p_executable_info: *const PipelineExecutableInfoKHR,
+    p_executable_info: *const PipelineExecutableInfoKHR<'_>,
     p_statistic_count: *mut u32,
-    p_statistics: *mut PipelineExecutableStatisticKHR,
+    p_statistics: *mut PipelineExecutableStatisticKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineExecutableInternalRepresentationsKHR =
     unsafe extern "system" fn(
         device: Device,
-        p_executable_info: *const PipelineExecutableInfoKHR,
+        p_executable_info: *const PipelineExecutableInfoKHR<'_>,
         p_internal_representation_count: *mut u32,
-        p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+        p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR<'_>,
     ) -> Result;
 #[derive(Clone)]
 pub struct KhrPipelineExecutablePropertiesFn {
@@ -12936,9 +12948,9 @@ impl KhrPipelineExecutablePropertiesFn {
             get_pipeline_executable_properties_khr: unsafe {
                 unsafe extern "system" fn get_pipeline_executable_properties_khr(
                     _device: Device,
-                    _p_pipeline_info: *const PipelineInfoKHR,
+                    _p_pipeline_info: *const PipelineInfoKHR<'_>,
                     _p_executable_count: *mut u32,
-                    _p_properties: *mut PipelineExecutablePropertiesKHR,
+                    _p_properties: *mut PipelineExecutablePropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -12958,9 +12970,9 @@ impl KhrPipelineExecutablePropertiesFn {
             get_pipeline_executable_statistics_khr: unsafe {
                 unsafe extern "system" fn get_pipeline_executable_statistics_khr(
                     _device: Device,
-                    _p_executable_info: *const PipelineExecutableInfoKHR,
+                    _p_executable_info: *const PipelineExecutableInfoKHR<'_>,
                     _p_statistic_count: *mut u32,
-                    _p_statistics: *mut PipelineExecutableStatisticKHR,
+                    _p_statistics: *mut PipelineExecutableStatisticKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -12980,9 +12992,11 @@ impl KhrPipelineExecutablePropertiesFn {
             get_pipeline_executable_internal_representations_khr: unsafe {
                 unsafe extern "system" fn get_pipeline_executable_internal_representations_khr(
                     _device: Device,
-                    _p_executable_info: *const PipelineExecutableInfoKHR,
+                    _p_executable_info: *const PipelineExecutableInfoKHR<'_>,
                     _p_internal_representation_count: *mut u32,
-                    _p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+                    _p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR<
+                        '_,
+                    >,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -13025,30 +13039,30 @@ impl ExtHostImageCopyFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyMemoryToImageEXT = unsafe extern "system" fn(
     device: Device,
-    p_copy_memory_to_image_info: *const CopyMemoryToImageInfoEXT,
+    p_copy_memory_to_image_info: *const CopyMemoryToImageInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyImageToMemoryEXT = unsafe extern "system" fn(
     device: Device,
-    p_copy_image_to_memory_info: *const CopyImageToMemoryInfoEXT,
+    p_copy_image_to_memory_info: *const CopyImageToMemoryInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyImageToImageEXT = unsafe extern "system" fn(
     device: Device,
-    p_copy_image_to_image_info: *const CopyImageToImageInfoEXT,
+    p_copy_image_to_image_info: *const CopyImageToImageInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkTransitionImageLayoutEXT = unsafe extern "system" fn(
     device: Device,
     transition_count: u32,
-    p_transitions: *const HostImageLayoutTransitionInfoEXT,
+    p_transitions: *const HostImageLayoutTransitionInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageSubresourceLayout2KHR = unsafe extern "system" fn(
     device: Device,
     image: Image,
-    p_subresource: *const ImageSubresource2KHR,
-    p_layout: *mut SubresourceLayout2KHR,
+    p_subresource: *const ImageSubresource2KHR<'_>,
+    p_layout: *mut SubresourceLayout2KHR<'_>,
 );
 #[derive(Clone)]
 pub struct ExtHostImageCopyFn {
@@ -13069,7 +13083,7 @@ impl ExtHostImageCopyFn {
             copy_memory_to_image_ext: unsafe {
                 unsafe extern "system" fn copy_memory_to_image_ext(
                     _device: Device,
-                    _p_copy_memory_to_image_info: *const CopyMemoryToImageInfoEXT,
+                    _p_copy_memory_to_image_info: *const CopyMemoryToImageInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -13088,7 +13102,7 @@ impl ExtHostImageCopyFn {
             copy_image_to_memory_ext: unsafe {
                 unsafe extern "system" fn copy_image_to_memory_ext(
                     _device: Device,
-                    _p_copy_image_to_memory_info: *const CopyImageToMemoryInfoEXT,
+                    _p_copy_image_to_memory_info: *const CopyImageToMemoryInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -13107,7 +13121,7 @@ impl ExtHostImageCopyFn {
             copy_image_to_image_ext: unsafe {
                 unsafe extern "system" fn copy_image_to_image_ext(
                     _device: Device,
-                    _p_copy_image_to_image_info: *const CopyImageToImageInfoEXT,
+                    _p_copy_image_to_image_info: *const CopyImageToImageInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -13127,7 +13141,7 @@ impl ExtHostImageCopyFn {
                 unsafe extern "system" fn transition_image_layout_ext(
                     _device: Device,
                     _transition_count: u32,
-                    _p_transitions: *const HostImageLayoutTransitionInfoEXT,
+                    _p_transitions: *const HostImageLayoutTransitionInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -13148,8 +13162,8 @@ impl ExtHostImageCopyFn {
                 unsafe extern "system" fn get_image_subresource_layout2_ext(
                     _device: Device,
                     _image: Image,
-                    _p_subresource: *const ImageSubresource2KHR,
-                    _p_layout: *mut SubresourceLayout2KHR,
+                    _p_subresource: *const ImageSubresource2KHR<'_>,
+                    _p_layout: *mut SubresourceLayout2KHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -13201,13 +13215,13 @@ impl KhrMapMemory2Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkMapMemory2KHR = unsafe extern "system" fn(
     device: Device,
-    p_memory_map_info: *const MemoryMapInfoKHR,
+    p_memory_map_info: *const MemoryMapInfoKHR<'_>,
     pp_data: *mut *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkUnmapMemory2KHR = unsafe extern "system" fn(
     device: Device,
-    p_memory_unmap_info: *const MemoryUnmapInfoKHR,
+    p_memory_unmap_info: *const MemoryUnmapInfoKHR<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct KhrMapMemory2Fn {
@@ -13225,7 +13239,7 @@ impl KhrMapMemory2Fn {
             map_memory2_khr: unsafe {
                 unsafe extern "system" fn map_memory2_khr(
                     _device: Device,
-                    _p_memory_map_info: *const MemoryMapInfoKHR,
+                    _p_memory_map_info: *const MemoryMapInfoKHR<'_>,
                     _pp_data: *mut *mut c_void,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(map_memory2_khr)))
@@ -13241,7 +13255,7 @@ impl KhrMapMemory2Fn {
             unmap_memory2_khr: unsafe {
                 unsafe extern "system" fn unmap_memory2_khr(
                     _device: Device,
-                    _p_memory_unmap_info: *const MemoryUnmapInfoKHR,
+                    _p_memory_unmap_info: *const MemoryUnmapInfoKHR<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(unmap_memory2_khr)))
                 }
@@ -13296,7 +13310,7 @@ impl ExtSwapchainMaintenance1Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkReleaseSwapchainImagesEXT = unsafe extern "system" fn(
     device: Device,
-    p_release_info: *const ReleaseSwapchainImagesInfoEXT,
+    p_release_info: *const ReleaseSwapchainImagesInfoEXT<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtSwapchainMaintenance1Fn {
@@ -13313,7 +13327,7 @@ impl ExtSwapchainMaintenance1Fn {
             release_swapchain_images_ext: unsafe {
                 unsafe extern "system" fn release_swapchain_images_ext(
                     _device: Device,
-                    _p_release_info: *const ReleaseSwapchainImagesInfoEXT,
+                    _p_release_info: *const ReleaseSwapchainImagesInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -13370,19 +13384,19 @@ impl NvDeviceGeneratedCommandsFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetGeneratedCommandsMemoryRequirementsNV = unsafe extern "system" fn(
     device: Device,
-    p_info: *const GeneratedCommandsMemoryRequirementsInfoNV,
-    p_memory_requirements: *mut MemoryRequirements2,
+    p_info: *const GeneratedCommandsMemoryRequirementsInfoNV<'_>,
+    p_memory_requirements: *mut MemoryRequirements2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdPreprocessGeneratedCommandsNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_generated_commands_info: *const GeneratedCommandsInfoNV,
+    p_generated_commands_info: *const GeneratedCommandsInfoNV<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdExecuteGeneratedCommandsNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     is_preprocessed: Bool32,
-    p_generated_commands_info: *const GeneratedCommandsInfoNV,
+    p_generated_commands_info: *const GeneratedCommandsInfoNV<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBindPipelineShaderGroupNV = unsafe extern "system" fn(
@@ -13394,15 +13408,15 @@ pub type PFN_vkCmdBindPipelineShaderGroupNV = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateIndirectCommandsLayoutNV = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const IndirectCommandsLayoutCreateInfoNV,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const IndirectCommandsLayoutCreateInfoNV<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_indirect_commands_layout: *mut IndirectCommandsLayoutNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyIndirectCommandsLayoutNV = unsafe extern "system" fn(
     device: Device,
     indirect_commands_layout: IndirectCommandsLayoutNV,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[derive(Clone)]
 pub struct NvDeviceGeneratedCommandsFn {
@@ -13425,8 +13439,8 @@ impl NvDeviceGeneratedCommandsFn {
             get_generated_commands_memory_requirements_nv: unsafe {
                 unsafe extern "system" fn get_generated_commands_memory_requirements_nv(
                     _device: Device,
-                    _p_info: *const GeneratedCommandsMemoryRequirementsInfoNV,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const GeneratedCommandsMemoryRequirementsInfoNV<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -13446,7 +13460,7 @@ impl NvDeviceGeneratedCommandsFn {
             cmd_preprocess_generated_commands_nv: unsafe {
                 unsafe extern "system" fn cmd_preprocess_generated_commands_nv(
                     _command_buffer: CommandBuffer,
-                    _p_generated_commands_info: *const GeneratedCommandsInfoNV,
+                    _p_generated_commands_info: *const GeneratedCommandsInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -13467,7 +13481,7 @@ impl NvDeviceGeneratedCommandsFn {
                 unsafe extern "system" fn cmd_execute_generated_commands_nv(
                     _command_buffer: CommandBuffer,
                     _is_preprocessed: Bool32,
-                    _p_generated_commands_info: *const GeneratedCommandsInfoNV,
+                    _p_generated_commands_info: *const GeneratedCommandsInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -13509,8 +13523,8 @@ impl NvDeviceGeneratedCommandsFn {
             create_indirect_commands_layout_nv: unsafe {
                 unsafe extern "system" fn create_indirect_commands_layout_nv(
                     _device: Device,
-                    _p_create_info: *const IndirectCommandsLayoutCreateInfoNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const IndirectCommandsLayoutCreateInfoNV<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_indirect_commands_layout: *mut IndirectCommandsLayoutNV,
                 ) -> Result {
                     panic!(concat!(
@@ -13532,7 +13546,7 @@ impl NvDeviceGeneratedCommandsFn {
                 unsafe extern "system" fn destroy_indirect_commands_layout_nv(
                     _device: Device,
                     _indirect_commands_layout: IndirectCommandsLayoutNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -13649,7 +13663,7 @@ impl ExtDepthBiasControlFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthBias2EXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_depth_bias_info: *const DepthBiasInfoEXT,
+    p_depth_bias_info: *const DepthBiasInfoEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtDepthBiasControlFn {
@@ -13666,7 +13680,7 @@ impl ExtDepthBiasControlFn {
             cmd_set_depth_bias2_ext: unsafe {
                 unsafe extern "system" fn cmd_set_depth_bias2_ext(
                     _command_buffer: CommandBuffer,
-                    _p_depth_bias_info: *const DepthBiasInfoEXT,
+                    _p_depth_bias_info: *const DepthBiasInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -13870,15 +13884,15 @@ impl ExtPrivateDataFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreatePrivateDataSlot = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const PrivateDataSlotCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const PrivateDataSlotCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_private_data_slot: *mut PrivateDataSlot,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPrivateDataSlot = unsafe extern "system" fn(
     device: Device,
     private_data_slot: PrivateDataSlot,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetPrivateData = unsafe extern "system" fn(
@@ -13914,8 +13928,8 @@ impl ExtPrivateDataFn {
             create_private_data_slot_ext: unsafe {
                 unsafe extern "system" fn create_private_data_slot_ext(
                     _device: Device,
-                    _p_create_info: *const PrivateDataSlotCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const PrivateDataSlotCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_private_data_slot: *mut PrivateDataSlot,
                 ) -> Result {
                     panic!(concat!(
@@ -13937,7 +13951,7 @@ impl ExtPrivateDataFn {
                 unsafe extern "system" fn destroy_private_data_slot_ext(
                     _device: Device,
                     _private_data_slot: PrivateDataSlot,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14042,21 +14056,21 @@ impl KhrVideoEncodeQueueFn {
 pub type PFN_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR =
     unsafe extern "system" fn(
         physical_device: PhysicalDevice,
-        p_quality_level_info: *const PhysicalDeviceVideoEncodeQualityLevelInfoKHR,
-        p_quality_level_properties: *mut VideoEncodeQualityLevelPropertiesKHR,
+        p_quality_level_info: *const PhysicalDeviceVideoEncodeQualityLevelInfoKHR<'_>,
+        p_quality_level_properties: *mut VideoEncodeQualityLevelPropertiesKHR<'_>,
     ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetEncodedVideoSessionParametersKHR = unsafe extern "system" fn(
     device: Device,
-    p_video_session_parameters_info: *const VideoEncodeSessionParametersGetInfoKHR,
-    p_feedback_info: *mut VideoEncodeSessionParametersFeedbackInfoKHR,
+    p_video_session_parameters_info: *const VideoEncodeSessionParametersGetInfoKHR<'_>,
+    p_feedback_info: *mut VideoEncodeSessionParametersFeedbackInfoKHR<'_>,
     p_data_size: *mut usize,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEncodeVideoKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_encode_info: *const VideoEncodeInfoKHR,
+    p_encode_info: *const VideoEncodeInfoKHR<'_>,
 );
 #[derive(Clone)]
 pub struct KhrVideoEncodeQueueFn {
@@ -14076,8 +14090,8 @@ impl KhrVideoEncodeQueueFn {
             get_physical_device_video_encode_quality_level_properties_khr: unsafe {
                 unsafe extern "system" fn get_physical_device_video_encode_quality_level_properties_khr(
                     _physical_device: PhysicalDevice,
-                    _p_quality_level_info: *const PhysicalDeviceVideoEncodeQualityLevelInfoKHR,
-                    _p_quality_level_properties: *mut VideoEncodeQualityLevelPropertiesKHR,
+                    _p_quality_level_info: *const PhysicalDeviceVideoEncodeQualityLevelInfoKHR<'_>,
+                    _p_quality_level_properties: *mut VideoEncodeQualityLevelPropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -14097,8 +14111,10 @@ impl KhrVideoEncodeQueueFn {
             get_encoded_video_session_parameters_khr: unsafe {
                 unsafe extern "system" fn get_encoded_video_session_parameters_khr(
                     _device: Device,
-                    _p_video_session_parameters_info: *const VideoEncodeSessionParametersGetInfoKHR,
-                    _p_feedback_info: *mut VideoEncodeSessionParametersFeedbackInfoKHR,
+                    _p_video_session_parameters_info: *const VideoEncodeSessionParametersGetInfoKHR<
+                        '_,
+                    >,
+                    _p_feedback_info: *mut VideoEncodeSessionParametersFeedbackInfoKHR<'_>,
                     _p_data_size: *mut usize,
                     _p_data: *mut c_void,
                 ) -> Result {
@@ -14120,7 +14136,7 @@ impl KhrVideoEncodeQueueFn {
             cmd_encode_video_khr: unsafe {
                 unsafe extern "system" fn cmd_encode_video_khr(
                     _command_buffer: CommandBuffer,
-                    _p_encode_info: *const VideoEncodeInfoKHR,
+                    _p_encode_info: *const VideoEncodeInfoKHR<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_encode_video_khr)))
                 }
@@ -14245,8 +14261,8 @@ impl NvCudaKernelLaunchFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCudaModuleNV = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const CudaModuleCreateInfoNV,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const CudaModuleCreateInfoNV<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_module: *mut CudaModuleNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -14259,26 +14275,26 @@ pub type PFN_vkGetCudaModuleCacheNV = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCudaFunctionNV = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const CudaFunctionCreateInfoNV,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const CudaFunctionCreateInfoNV<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_function: *mut CudaFunctionNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCudaModuleNV = unsafe extern "system" fn(
     device: Device,
     module: CudaModuleNV,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCudaFunctionNV = unsafe extern "system" fn(
     device: Device,
     function: CudaFunctionNV,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCudaLaunchKernelNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_launch_info: *const CudaLaunchInfoNV,
+    p_launch_info: *const CudaLaunchInfoNV<'_>,
 );
 #[derive(Clone)]
 pub struct NvCudaKernelLaunchFn {
@@ -14300,8 +14316,8 @@ impl NvCudaKernelLaunchFn {
             create_cuda_module_nv: unsafe {
                 unsafe extern "system" fn create_cuda_module_nv(
                     _device: Device,
-                    _p_create_info: *const CudaModuleCreateInfoNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const CudaModuleCreateInfoNV<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_module: *mut CudaModuleNV,
                 ) -> Result {
                     panic!(concat!(
@@ -14342,8 +14358,8 @@ impl NvCudaKernelLaunchFn {
             create_cuda_function_nv: unsafe {
                 unsafe extern "system" fn create_cuda_function_nv(
                     _device: Device,
-                    _p_create_info: *const CudaFunctionCreateInfoNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const CudaFunctionCreateInfoNV<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_function: *mut CudaFunctionNV,
                 ) -> Result {
                     panic!(concat!(
@@ -14364,7 +14380,7 @@ impl NvCudaKernelLaunchFn {
                 unsafe extern "system" fn destroy_cuda_module_nv(
                     _device: Device,
                     _module: CudaModuleNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14384,7 +14400,7 @@ impl NvCudaKernelLaunchFn {
                 unsafe extern "system" fn destroy_cuda_function_nv(
                     _device: Device,
                     _function: CudaFunctionNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14403,7 +14419,7 @@ impl NvCudaKernelLaunchFn {
             cmd_cuda_launch_kernel_nv: unsafe {
                 unsafe extern "system" fn cmd_cuda_launch_kernel_nv(
                     _command_buffer: CommandBuffer,
-                    _p_launch_info: *const CudaLaunchInfoNV,
+                    _p_launch_info: *const CudaLaunchInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14457,8 +14473,10 @@ impl ExtMetalObjectsFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkExportMetalObjectsEXT =
-    unsafe extern "system" fn(device: Device, p_metal_objects_info: *mut ExportMetalObjectsInfoEXT);
+pub type PFN_vkExportMetalObjectsEXT = unsafe extern "system" fn(
+    device: Device,
+    p_metal_objects_info: *mut ExportMetalObjectsInfoEXT<'_>,
+);
 #[derive(Clone)]
 pub struct ExtMetalObjectsFn {
     pub export_metal_objects_ext: PFN_vkExportMetalObjectsEXT,
@@ -14474,7 +14492,7 @@ impl ExtMetalObjectsFn {
             export_metal_objects_ext: unsafe {
                 unsafe extern "system" fn export_metal_objects_ext(
                     _device: Device,
-                    _p_metal_objects_info: *mut ExportMetalObjectsInfoEXT,
+                    _p_metal_objects_info: *mut ExportMetalObjectsInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14517,7 +14535,7 @@ impl KhrSynchronization2Fn {
 pub type PFN_vkCmdSetEvent2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event: Event,
-    p_dependency_info: *const DependencyInfo,
+    p_dependency_info: *const DependencyInfo<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdResetEvent2 = unsafe extern "system" fn(
@@ -14530,12 +14548,12 @@ pub type PFN_vkCmdWaitEvents2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event_count: u32,
     p_events: *const Event,
-    p_dependency_infos: *const DependencyInfo,
+    p_dependency_infos: *const DependencyInfo<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdPipelineBarrier2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_dependency_info: *const DependencyInfo,
+    p_dependency_info: *const DependencyInfo<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdWriteTimestamp2 = unsafe extern "system" fn(
@@ -14548,7 +14566,7 @@ pub type PFN_vkCmdWriteTimestamp2 = unsafe extern "system" fn(
 pub type PFN_vkQueueSubmit2 = unsafe extern "system" fn(
     queue: Queue,
     submit_count: u32,
-    p_submits: *const SubmitInfo2,
+    p_submits: *const SubmitInfo2<'_>,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -14563,7 +14581,7 @@ pub type PFN_vkCmdWriteBufferMarker2AMD = unsafe extern "system" fn(
 pub type PFN_vkGetQueueCheckpointData2NV = unsafe extern "system" fn(
     queue: Queue,
     p_checkpoint_data_count: *mut u32,
-    p_checkpoint_data: *mut CheckpointData2NV,
+    p_checkpoint_data: *mut CheckpointData2NV<'_>,
 );
 #[derive(Clone)]
 pub struct KhrSynchronization2Fn {
@@ -14588,7 +14606,7 @@ impl KhrSynchronization2Fn {
                 unsafe extern "system" fn cmd_set_event2_khr(
                     _command_buffer: CommandBuffer,
                     _event: Event,
-                    _p_dependency_info: *const DependencyInfo,
+                    _p_dependency_info: *const DependencyInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_set_event2_khr)))
                 }
@@ -14622,7 +14640,7 @@ impl KhrSynchronization2Fn {
                     _command_buffer: CommandBuffer,
                     _event_count: u32,
                     _p_events: *const Event,
-                    _p_dependency_infos: *const DependencyInfo,
+                    _p_dependency_infos: *const DependencyInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_wait_events2_khr)))
                 }
@@ -14638,7 +14656,7 @@ impl KhrSynchronization2Fn {
             cmd_pipeline_barrier2_khr: unsafe {
                 unsafe extern "system" fn cmd_pipeline_barrier2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_dependency_info: *const DependencyInfo,
+                    _p_dependency_info: *const DependencyInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14679,7 +14697,7 @@ impl KhrSynchronization2Fn {
                 unsafe extern "system" fn queue_submit2_khr(
                     _queue: Queue,
                     _submit_count: u32,
-                    _p_submits: *const SubmitInfo2,
+                    _p_submits: *const SubmitInfo2<'_>,
                     _fence: Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_submit2_khr)))
@@ -14719,7 +14737,7 @@ impl KhrSynchronization2Fn {
                 unsafe extern "system" fn get_queue_checkpoint_data2_nv(
                     _queue: Queue,
                     _p_checkpoint_data_count: *mut u32,
-                    _p_checkpoint_data: *mut CheckpointData2NV,
+                    _p_checkpoint_data: *mut CheckpointData2NV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -14829,7 +14847,7 @@ pub type PFN_vkGetDescriptorSetLayoutBindingOffsetEXT = unsafe extern "system" f
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDescriptorEXT = unsafe extern "system" fn(
     device: Device,
-    p_descriptor_info: *const DescriptorGetInfoEXT,
+    p_descriptor_info: *const DescriptorGetInfoEXT<'_>,
     data_size: usize,
     p_descriptor: *mut c_void,
 );
@@ -14837,7 +14855,7 @@ pub type PFN_vkGetDescriptorEXT = unsafe extern "system" fn(
 pub type PFN_vkCmdBindDescriptorBuffersEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer_count: u32,
-    p_binding_infos: *const DescriptorBufferBindingInfoEXT,
+    p_binding_infos: *const DescriptorBufferBindingInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDescriptorBufferOffsetsEXT = unsafe extern "system" fn(
@@ -14859,32 +14877,32 @@ pub type PFN_vkCmdBindDescriptorBufferEmbeddedSamplersEXT = unsafe extern "syste
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferOpaqueCaptureDescriptorDataEXT = unsafe extern "system" fn(
     device: Device,
-    p_info: *const BufferCaptureDescriptorDataInfoEXT,
+    p_info: *const BufferCaptureDescriptorDataInfoEXT<'_>,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageOpaqueCaptureDescriptorDataEXT = unsafe extern "system" fn(
     device: Device,
-    p_info: *const ImageCaptureDescriptorDataInfoEXT,
+    p_info: *const ImageCaptureDescriptorDataInfoEXT<'_>,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageViewOpaqueCaptureDescriptorDataEXT = unsafe extern "system" fn(
     device: Device,
-    p_info: *const ImageViewCaptureDescriptorDataInfoEXT,
+    p_info: *const ImageViewCaptureDescriptorDataInfoEXT<'_>,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSamplerOpaqueCaptureDescriptorDataEXT = unsafe extern "system" fn(
     device: Device,
-    p_info: *const SamplerCaptureDescriptorDataInfoEXT,
+    p_info: *const SamplerCaptureDescriptorDataInfoEXT<'_>,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT =
     unsafe extern "system" fn(
         device: Device,
-        p_info: *const AccelerationStructureCaptureDescriptorDataInfoEXT,
+        p_info: *const AccelerationStructureCaptureDescriptorDataInfoEXT<'_>,
         p_data: *mut c_void,
     ) -> Result;
 #[derive(Clone)]
@@ -14960,7 +14978,7 @@ impl ExtDescriptorBufferFn {
             get_descriptor_ext: unsafe {
                 unsafe extern "system" fn get_descriptor_ext(
                     _device: Device,
-                    _p_descriptor_info: *const DescriptorGetInfoEXT,
+                    _p_descriptor_info: *const DescriptorGetInfoEXT<'_>,
                     _data_size: usize,
                     _p_descriptor: *mut c_void,
                 ) {
@@ -14979,7 +14997,7 @@ impl ExtDescriptorBufferFn {
                 unsafe extern "system" fn cmd_bind_descriptor_buffers_ext(
                     _command_buffer: CommandBuffer,
                     _buffer_count: u32,
-                    _p_binding_infos: *const DescriptorBufferBindingInfoEXT,
+                    _p_binding_infos: *const DescriptorBufferBindingInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -15046,7 +15064,7 @@ impl ExtDescriptorBufferFn {
             get_buffer_opaque_capture_descriptor_data_ext: unsafe {
                 unsafe extern "system" fn get_buffer_opaque_capture_descriptor_data_ext(
                     _device: Device,
-                    _p_info: *const BufferCaptureDescriptorDataInfoEXT,
+                    _p_info: *const BufferCaptureDescriptorDataInfoEXT<'_>,
                     _p_data: *mut c_void,
                 ) -> Result {
                     panic!(concat!(
@@ -15067,7 +15085,7 @@ impl ExtDescriptorBufferFn {
             get_image_opaque_capture_descriptor_data_ext: unsafe {
                 unsafe extern "system" fn get_image_opaque_capture_descriptor_data_ext(
                     _device: Device,
-                    _p_info: *const ImageCaptureDescriptorDataInfoEXT,
+                    _p_info: *const ImageCaptureDescriptorDataInfoEXT<'_>,
                     _p_data: *mut c_void,
                 ) -> Result {
                     panic!(concat!(
@@ -15088,7 +15106,7 @@ impl ExtDescriptorBufferFn {
             get_image_view_opaque_capture_descriptor_data_ext: unsafe {
                 unsafe extern "system" fn get_image_view_opaque_capture_descriptor_data_ext(
                     _device: Device,
-                    _p_info: *const ImageViewCaptureDescriptorDataInfoEXT,
+                    _p_info: *const ImageViewCaptureDescriptorDataInfoEXT<'_>,
                     _p_data: *mut c_void,
                 ) -> Result {
                     panic!(concat!(
@@ -15109,7 +15127,7 @@ impl ExtDescriptorBufferFn {
             get_sampler_opaque_capture_descriptor_data_ext: unsafe {
                 unsafe extern "system" fn get_sampler_opaque_capture_descriptor_data_ext(
                     _device: Device,
-                    _p_info: *const SamplerCaptureDescriptorDataInfoEXT,
+                    _p_info: *const SamplerCaptureDescriptorDataInfoEXT<'_>,
                     _p_data: *mut c_void,
                 ) -> Result {
                     panic!(concat!(
@@ -15130,7 +15148,7 @@ impl ExtDescriptorBufferFn {
             get_acceleration_structure_opaque_capture_descriptor_data_ext: unsafe {
                 unsafe extern "system" fn get_acceleration_structure_opaque_capture_descriptor_data_ext(
                     _device: Device,
-                    _p_info: *const AccelerationStructureCaptureDescriptorDataInfoEXT,
+                    _p_info: *const AccelerationStructureCaptureDescriptorDataInfoEXT<'_>,
                     _p_data: *mut c_void,
                 ) -> Result {
                     panic!(concat!(
@@ -15601,32 +15619,32 @@ impl KhrCopyCommands2Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyBuffer2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_buffer_info: *const CopyBufferInfo2,
+    p_copy_buffer_info: *const CopyBufferInfo2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_image_info: *const CopyImageInfo2,
+    p_copy_image_info: *const CopyImageInfo2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyBufferToImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
+    p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyImageToBuffer2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
+    p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBlitImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_blit_image_info: *const BlitImageInfo2,
+    p_blit_image_info: *const BlitImageInfo2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdResolveImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_resolve_image_info: *const ResolveImageInfo2,
+    p_resolve_image_info: *const ResolveImageInfo2<'_>,
 );
 #[derive(Clone)]
 pub struct KhrCopyCommands2Fn {
@@ -15648,7 +15666,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_buffer2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_buffer2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_buffer_info: *const CopyBufferInfo2,
+                    _p_copy_buffer_info: *const CopyBufferInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_copy_buffer2_khr)))
                 }
@@ -15664,7 +15682,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_image_info: *const CopyImageInfo2,
+                    _p_copy_image_info: *const CopyImageInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_copy_image2_khr)))
                 }
@@ -15680,7 +15698,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_buffer_to_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_buffer_to_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
+                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -15700,7 +15718,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_image_to_buffer2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_image_to_buffer2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
+                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -15720,7 +15738,7 @@ impl KhrCopyCommands2Fn {
             cmd_blit_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_blit_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_blit_image_info: *const BlitImageInfo2,
+                    _p_blit_image_info: *const BlitImageInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_blit_image2_khr)))
                 }
@@ -15736,7 +15754,7 @@ impl KhrCopyCommands2Fn {
             cmd_resolve_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_resolve_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_resolve_image_info: *const ResolveImageInfo2,
+                    _p_resolve_image_info: *const ResolveImageInfo2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -15791,8 +15809,8 @@ impl ExtImageCompressionControlFn {
                 unsafe extern "system" fn get_image_subresource_layout2_ext(
                     _device: Device,
                     _image: Image,
-                    _p_subresource: *const ImageSubresource2KHR,
-                    _p_layout: *mut SubresourceLayout2KHR,
+                    _p_subresource: *const ImageSubresource2KHR<'_>,
+                    _p_layout: *mut SubresourceLayout2KHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -15880,8 +15898,8 @@ impl ExtDeviceFaultFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceFaultInfoEXT = unsafe extern "system" fn(
     device: Device,
-    p_fault_counts: *mut DeviceFaultCountsEXT,
-    p_fault_info: *mut DeviceFaultInfoEXT,
+    p_fault_counts: *mut DeviceFaultCountsEXT<'_>,
+    p_fault_info: *mut DeviceFaultInfoEXT<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtDeviceFaultFn {
@@ -15898,8 +15916,8 @@ impl ExtDeviceFaultFn {
             get_device_fault_info_ext: unsafe {
                 unsafe extern "system" fn get_device_fault_info_ext(
                     _device: Device,
-                    _p_fault_counts: *mut DeviceFaultCountsEXT,
-                    _p_fault_info: *mut DeviceFaultInfoEXT,
+                    _p_fault_counts: *mut DeviceFaultCountsEXT<'_>,
+                    _p_fault_info: *mut DeviceFaultInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16046,8 +16064,8 @@ impl ExtDirectfbSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDirectFBSurfaceEXT = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const DirectFBSurfaceCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DirectFBSurfaceCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -16074,8 +16092,8 @@ impl ExtDirectfbSurfaceFn {
             create_direct_fb_surface_ext: unsafe {
                 unsafe extern "system" fn create_direct_fb_surface_ext(
                     _instance: Instance,
-                    _p_create_info: *const DirectFBSurfaceCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DirectFBSurfaceCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -16158,9 +16176,9 @@ impl ExtVertexInputDynamicStateFn {
 pub type PFN_vkCmdSetVertexInputEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     vertex_binding_description_count: u32,
-    p_vertex_binding_descriptions: *const VertexInputBindingDescription2EXT,
+    p_vertex_binding_descriptions: *const VertexInputBindingDescription2EXT<'_>,
     vertex_attribute_description_count: u32,
-    p_vertex_attribute_descriptions: *const VertexInputAttributeDescription2EXT,
+    p_vertex_attribute_descriptions: *const VertexInputAttributeDescription2EXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtVertexInputDynamicStateFn {
@@ -16178,9 +16196,11 @@ impl ExtVertexInputDynamicStateFn {
                 unsafe extern "system" fn cmd_set_vertex_input_ext(
                     _command_buffer: CommandBuffer,
                     _vertex_binding_description_count: u32,
-                    _p_vertex_binding_descriptions: *const VertexInputBindingDescription2EXT,
+                    _p_vertex_binding_descriptions: *const VertexInputBindingDescription2EXT<'_>,
                     _vertex_attribute_description_count: u32,
-                    _p_vertex_attribute_descriptions: *const VertexInputAttributeDescription2EXT,
+                    _p_vertex_attribute_descriptions: *const VertexInputAttributeDescription2EXT<
+                        '_,
+                    >,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -16282,7 +16302,7 @@ impl FuchsiaExternalMemoryFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMemoryZirconHandleFUCHSIA = unsafe extern "system" fn(
     device: Device,
-    p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA,
+    p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA<'_>,
     p_zircon_handle: *mut zx_handle_t,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -16290,7 +16310,7 @@ pub type PFN_vkGetMemoryZirconHandlePropertiesFUCHSIA = unsafe extern "system" f
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     zircon_handle: zx_handle_t,
-    p_memory_zircon_handle_properties: *mut MemoryZirconHandlePropertiesFUCHSIA,
+    p_memory_zircon_handle_properties: *mut MemoryZirconHandlePropertiesFUCHSIA<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct FuchsiaExternalMemoryFn {
@@ -16308,7 +16328,7 @@ impl FuchsiaExternalMemoryFn {
             get_memory_zircon_handle_fuchsia: unsafe {
                 unsafe extern "system" fn get_memory_zircon_handle_fuchsia(
                     _device: Device,
-                    _p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA,
+                    _p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA<'_>,
                     _p_zircon_handle: *mut zx_handle_t,
                 ) -> Result {
                     panic!(concat!(
@@ -16331,7 +16351,9 @@ impl FuchsiaExternalMemoryFn {
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _zircon_handle: zx_handle_t,
-                    _p_memory_zircon_handle_properties: *mut MemoryZirconHandlePropertiesFUCHSIA,
+                    _p_memory_zircon_handle_properties: *mut MemoryZirconHandlePropertiesFUCHSIA<
+                        '_,
+                    >,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16370,12 +16392,12 @@ impl FuchsiaExternalSemaphoreFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkImportSemaphoreZirconHandleFUCHSIA = unsafe extern "system" fn(
     device: Device,
-    p_import_semaphore_zircon_handle_info: *const ImportSemaphoreZirconHandleInfoFUCHSIA,
+    p_import_semaphore_zircon_handle_info: *const ImportSemaphoreZirconHandleInfoFUCHSIA<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSemaphoreZirconHandleFUCHSIA = unsafe extern "system" fn(
     device: Device,
-    p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA,
+    p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA<'_>,
     p_zircon_handle: *mut zx_handle_t,
 ) -> Result;
 #[derive(Clone)]
@@ -16394,7 +16416,7 @@ impl FuchsiaExternalSemaphoreFn {
             import_semaphore_zircon_handle_fuchsia: unsafe {
                 unsafe extern "system" fn import_semaphore_zircon_handle_fuchsia(
                     _device: Device,
-                    _p_import_semaphore_zircon_handle_info : * const ImportSemaphoreZirconHandleInfoFUCHSIA,
+                    _p_import_semaphore_zircon_handle_info : * const ImportSemaphoreZirconHandleInfoFUCHSIA < '_ >,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16414,7 +16436,7 @@ impl FuchsiaExternalSemaphoreFn {
             get_semaphore_zircon_handle_fuchsia: unsafe {
                 unsafe extern "system" fn get_semaphore_zircon_handle_fuchsia(
                     _device: Device,
-                    _p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA,
+                    _p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA<'_>,
                     _p_zircon_handle: *mut zx_handle_t,
                 ) -> Result {
                     panic!(concat!(
@@ -16453,33 +16475,33 @@ impl FuchsiaBufferCollectionFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateBufferCollectionFUCHSIA = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const BufferCollectionCreateInfoFUCHSIA,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const BufferCollectionCreateInfoFUCHSIA<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_collection: *mut BufferCollectionFUCHSIA,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetBufferCollectionImageConstraintsFUCHSIA = unsafe extern "system" fn(
     device: Device,
     collection: BufferCollectionFUCHSIA,
-    p_image_constraints_info: *const ImageConstraintsInfoFUCHSIA,
+    p_image_constraints_info: *const ImageConstraintsInfoFUCHSIA<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetBufferCollectionBufferConstraintsFUCHSIA = unsafe extern "system" fn(
     device: Device,
     collection: BufferCollectionFUCHSIA,
-    p_buffer_constraints_info: *const BufferConstraintsInfoFUCHSIA,
+    p_buffer_constraints_info: *const BufferConstraintsInfoFUCHSIA<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyBufferCollectionFUCHSIA = unsafe extern "system" fn(
     device: Device,
     collection: BufferCollectionFUCHSIA,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferCollectionPropertiesFUCHSIA = unsafe extern "system" fn(
     device: Device,
     collection: BufferCollectionFUCHSIA,
-    p_properties: *mut BufferCollectionPropertiesFUCHSIA,
+    p_properties: *mut BufferCollectionPropertiesFUCHSIA<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct FuchsiaBufferCollectionFn {
@@ -16502,8 +16524,8 @@ impl FuchsiaBufferCollectionFn {
             create_buffer_collection_fuchsia: unsafe {
                 unsafe extern "system" fn create_buffer_collection_fuchsia(
                     _device: Device,
-                    _p_create_info: *const BufferCollectionCreateInfoFUCHSIA,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const BufferCollectionCreateInfoFUCHSIA<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_collection: *mut BufferCollectionFUCHSIA,
                 ) -> Result {
                     panic!(concat!(
@@ -16525,7 +16547,7 @@ impl FuchsiaBufferCollectionFn {
                 unsafe extern "system" fn set_buffer_collection_image_constraints_fuchsia(
                     _device: Device,
                     _collection: BufferCollectionFUCHSIA,
-                    _p_image_constraints_info: *const ImageConstraintsInfoFUCHSIA,
+                    _p_image_constraints_info: *const ImageConstraintsInfoFUCHSIA<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16546,7 +16568,7 @@ impl FuchsiaBufferCollectionFn {
                 unsafe extern "system" fn set_buffer_collection_buffer_constraints_fuchsia(
                     _device: Device,
                     _collection: BufferCollectionFUCHSIA,
-                    _p_buffer_constraints_info: *const BufferConstraintsInfoFUCHSIA,
+                    _p_buffer_constraints_info: *const BufferConstraintsInfoFUCHSIA<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16567,7 +16589,7 @@ impl FuchsiaBufferCollectionFn {
                 unsafe extern "system" fn destroy_buffer_collection_fuchsia(
                     _device: Device,
                     _collection: BufferCollectionFUCHSIA,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -16588,7 +16610,7 @@ impl FuchsiaBufferCollectionFn {
                 unsafe extern "system" fn get_buffer_collection_properties_fuchsia(
                     _device: Device,
                     _collection: BufferCollectionFUCHSIA,
-                    _p_properties: *mut BufferCollectionPropertiesFUCHSIA,
+                    _p_properties: *mut BufferCollectionPropertiesFUCHSIA<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16791,7 +16813,7 @@ impl NvExternalMemoryRdmaFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMemoryRemoteAddressNV = unsafe extern "system" fn(
     device: Device,
-    p_memory_get_remote_address_info: *const MemoryGetRemoteAddressInfoNV,
+    p_memory_get_remote_address_info: *const MemoryGetRemoteAddressInfoNV<'_>,
     p_address: *mut RemoteAddressNV,
 ) -> Result;
 #[derive(Clone)]
@@ -16809,7 +16831,7 @@ impl NvExternalMemoryRdmaFn {
             get_memory_remote_address_nv: unsafe {
                 unsafe extern "system" fn get_memory_remote_address_nv(
                     _device: Device,
-                    _p_memory_get_remote_address_info: *const MemoryGetRemoteAddressInfoNV,
+                    _p_memory_get_remote_address_info: *const MemoryGetRemoteAddressInfoNV<'_>,
                     _p_address: *mut RemoteAddressNV,
                 ) -> Result {
                     panic!(concat!(
@@ -16859,7 +16881,7 @@ unsafe impl GetPipelinePropertiesEXTParamPipelineProperties
 pub type PFN_vkGetPipelinePropertiesEXT = unsafe extern "system" fn(
     device: Device,
     p_pipeline_info: *const PipelineInfoEXT,
-    p_pipeline_properties: *mut BaseOutStructure,
+    p_pipeline_properties: *mut BaseOutStructure<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtPipelinePropertiesFn {
@@ -16877,7 +16899,7 @@ impl ExtPipelinePropertiesFn {
                 unsafe extern "system" fn get_pipeline_properties_ext(
                     _device: Device,
                     _p_pipeline_info: *const PipelineInfoEXT,
-                    _p_pipeline_properties: *mut BaseOutStructure,
+                    _p_pipeline_properties: *mut BaseOutStructure<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -17095,8 +17117,8 @@ impl QnxScreenSurfaceFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateScreenSurfaceQNX = unsafe extern "system" fn(
     instance: Instance,
-    p_create_info: *const ScreenSurfaceCreateInfoQNX,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ScreenSurfaceCreateInfoQNX<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -17122,8 +17144,8 @@ impl QnxScreenSurfaceFn {
             create_screen_surface_qnx: unsafe {
                 unsafe extern "system" fn create_screen_surface_qnx(
                     _instance: Instance,
-                    _p_create_info: *const ScreenSurfaceCreateInfoQNX,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ScreenSurfaceCreateInfoQNX<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_surface: *mut SurfaceKHR,
                 ) -> Result {
                     panic!(concat!(
@@ -17468,46 +17490,46 @@ impl ExtOpacityMicromapFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateMicromapEXT = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const MicromapCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const MicromapCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_micromap: *mut MicromapEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyMicromapEXT = unsafe extern "system" fn(
     device: Device,
     micromap: MicromapEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBuildMicromapsEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     info_count: u32,
-    p_infos: *const MicromapBuildInfoEXT,
+    p_infos: *const MicromapBuildInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkBuildMicromapsEXT = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     info_count: u32,
-    p_infos: *const MicromapBuildInfoEXT,
+    p_infos: *const MicromapBuildInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyMicromapEXT = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
-    p_info: *const CopyMicromapInfoEXT,
+    p_info: *const CopyMicromapInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyMicromapToMemoryEXT = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
-    p_info: *const CopyMicromapToMemoryInfoEXT,
+    p_info: *const CopyMicromapToMemoryInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCopyMemoryToMicromapEXT = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
-    p_info: *const CopyMemoryToMicromapInfoEXT,
+    p_info: *const CopyMemoryToMicromapInfoEXT<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkWriteMicromapsPropertiesEXT = unsafe extern "system" fn(
@@ -17520,17 +17542,19 @@ pub type PFN_vkWriteMicromapsPropertiesEXT = unsafe extern "system" fn(
     stride: usize,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyMicromapEXT =
-    unsafe extern "system" fn(command_buffer: CommandBuffer, p_info: *const CopyMicromapInfoEXT);
+pub type PFN_vkCmdCopyMicromapEXT = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_info: *const CopyMicromapInfoEXT<'_>,
+);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyMicromapToMemoryEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_info: *const CopyMicromapToMemoryInfoEXT,
+    p_info: *const CopyMicromapToMemoryInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCopyMemoryToMicromapEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_info: *const CopyMemoryToMicromapInfoEXT,
+    p_info: *const CopyMemoryToMicromapInfoEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdWriteMicromapsPropertiesEXT = unsafe extern "system" fn(
@@ -17544,15 +17568,15 @@ pub type PFN_vkCmdWriteMicromapsPropertiesEXT = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceMicromapCompatibilityEXT = unsafe extern "system" fn(
     device: Device,
-    p_version_info: *const MicromapVersionInfoEXT,
+    p_version_info: *const MicromapVersionInfoEXT<'_>,
     p_compatibility: *mut AccelerationStructureCompatibilityKHR,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMicromapBuildSizesEXT = unsafe extern "system" fn(
     device: Device,
     build_type: AccelerationStructureBuildTypeKHR,
-    p_build_info: *const MicromapBuildInfoEXT,
-    p_size_info: *mut MicromapBuildSizesInfoEXT,
+    p_build_info: *const MicromapBuildInfoEXT<'_>,
+    p_size_info: *mut MicromapBuildSizesInfoEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtOpacityMicromapFn {
@@ -17582,8 +17606,8 @@ impl ExtOpacityMicromapFn {
             create_micromap_ext: unsafe {
                 unsafe extern "system" fn create_micromap_ext(
                     _device: Device,
-                    _p_create_info: *const MicromapCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const MicromapCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_micromap: *mut MicromapEXT,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_micromap_ext)))
@@ -17601,7 +17625,7 @@ impl ExtOpacityMicromapFn {
                 unsafe extern "system" fn destroy_micromap_ext(
                     _device: Device,
                     _micromap: MicromapEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_micromap_ext)))
                 }
@@ -17618,7 +17642,7 @@ impl ExtOpacityMicromapFn {
                 unsafe extern "system" fn cmd_build_micromaps_ext(
                     _command_buffer: CommandBuffer,
                     _info_count: u32,
-                    _p_infos: *const MicromapBuildInfoEXT,
+                    _p_infos: *const MicromapBuildInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -17639,7 +17663,7 @@ impl ExtOpacityMicromapFn {
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _info_count: u32,
-                    _p_infos: *const MicromapBuildInfoEXT,
+                    _p_infos: *const MicromapBuildInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(build_micromaps_ext)))
                 }
@@ -17656,7 +17680,7 @@ impl ExtOpacityMicromapFn {
                 unsafe extern "system" fn copy_micromap_ext(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
-                    _p_info: *const CopyMicromapInfoEXT,
+                    _p_info: *const CopyMicromapInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(copy_micromap_ext)))
                 }
@@ -17672,7 +17696,7 @@ impl ExtOpacityMicromapFn {
                 unsafe extern "system" fn copy_micromap_to_memory_ext(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
-                    _p_info: *const CopyMicromapToMemoryInfoEXT,
+                    _p_info: *const CopyMicromapToMemoryInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -17692,7 +17716,7 @@ impl ExtOpacityMicromapFn {
                 unsafe extern "system" fn copy_memory_to_micromap_ext(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
-                    _p_info: *const CopyMemoryToMicromapInfoEXT,
+                    _p_info: *const CopyMemoryToMicromapInfoEXT<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -17736,7 +17760,7 @@ impl ExtOpacityMicromapFn {
             cmd_copy_micromap_ext: unsafe {
                 unsafe extern "system" fn cmd_copy_micromap_ext(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const CopyMicromapInfoEXT,
+                    _p_info: *const CopyMicromapInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -17755,7 +17779,7 @@ impl ExtOpacityMicromapFn {
             cmd_copy_micromap_to_memory_ext: unsafe {
                 unsafe extern "system" fn cmd_copy_micromap_to_memory_ext(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const CopyMicromapToMemoryInfoEXT,
+                    _p_info: *const CopyMicromapToMemoryInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -17775,7 +17799,7 @@ impl ExtOpacityMicromapFn {
             cmd_copy_memory_to_micromap_ext: unsafe {
                 unsafe extern "system" fn cmd_copy_memory_to_micromap_ext(
                     _command_buffer: CommandBuffer,
-                    _p_info: *const CopyMemoryToMicromapInfoEXT,
+                    _p_info: *const CopyMemoryToMicromapInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -17819,7 +17843,7 @@ impl ExtOpacityMicromapFn {
             get_device_micromap_compatibility_ext: unsafe {
                 unsafe extern "system" fn get_device_micromap_compatibility_ext(
                     _device: Device,
-                    _p_version_info: *const MicromapVersionInfoEXT,
+                    _p_version_info: *const MicromapVersionInfoEXT<'_>,
                     _p_compatibility: *mut AccelerationStructureCompatibilityKHR,
                 ) {
                     panic!(concat!(
@@ -17841,8 +17865,8 @@ impl ExtOpacityMicromapFn {
                 unsafe extern "system" fn get_micromap_build_sizes_ext(
                     _device: Device,
                     _build_type: AccelerationStructureBuildTypeKHR,
-                    _p_build_info: *const MicromapBuildInfoEXT,
-                    _p_size_info: *mut MicromapBuildSizesInfoEXT,
+                    _p_build_info: *const MicromapBuildInfoEXT<'_>,
+                    _p_size_info: *mut MicromapBuildSizesInfoEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -18119,21 +18143,21 @@ impl KhrMaintenance4Fn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceBufferMemoryRequirements = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceBufferMemoryRequirements,
-    p_memory_requirements: *mut MemoryRequirements2,
+    p_info: *const DeviceBufferMemoryRequirements<'_>,
+    p_memory_requirements: *mut MemoryRequirements2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceImageMemoryRequirements = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceImageMemoryRequirements,
-    p_memory_requirements: *mut MemoryRequirements2,
+    p_info: *const DeviceImageMemoryRequirements<'_>,
+    p_memory_requirements: *mut MemoryRequirements2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceImageSparseMemoryRequirements = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceImageMemoryRequirements,
+    p_info: *const DeviceImageMemoryRequirements<'_>,
     p_sparse_memory_requirement_count: *mut u32,
-    p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+    p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2<'_>,
 );
 #[derive(Clone)]
 pub struct KhrMaintenance4Fn {
@@ -18153,8 +18177,8 @@ impl KhrMaintenance4Fn {
             get_device_buffer_memory_requirements_khr: unsafe {
                 unsafe extern "system" fn get_device_buffer_memory_requirements_khr(
                     _device: Device,
-                    _p_info: *const DeviceBufferMemoryRequirements,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const DeviceBufferMemoryRequirements<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -18174,8 +18198,8 @@ impl KhrMaintenance4Fn {
             get_device_image_memory_requirements_khr: unsafe {
                 unsafe extern "system" fn get_device_image_memory_requirements_khr(
                     _device: Device,
-                    _p_info: *const DeviceImageMemoryRequirements,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const DeviceImageMemoryRequirements<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -18195,9 +18219,9 @@ impl KhrMaintenance4Fn {
             get_device_image_sparse_memory_requirements_khr: unsafe {
                 unsafe extern "system" fn get_device_image_sparse_memory_requirements_khr(
                     _device: Device,
-                    _p_info: *const DeviceImageMemoryRequirements,
+                    _p_info: *const DeviceImageMemoryRequirements<'_>,
                     _p_sparse_memory_requirement_count: *mut u32,
-                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -18277,8 +18301,8 @@ impl ValveDescriptorSetHostMappingFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDescriptorSetLayoutHostMappingInfoVALVE = unsafe extern "system" fn(
     device: Device,
-    p_binding_reference: *const DescriptorSetBindingReferenceVALVE,
-    p_host_mapping: *mut DescriptorSetLayoutHostMappingInfoVALVE,
+    p_binding_reference: *const DescriptorSetBindingReferenceVALVE<'_>,
+    p_host_mapping: *mut DescriptorSetLayoutHostMappingInfoVALVE<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDescriptorSetHostMappingVALVE = unsafe extern "system" fn(
@@ -18303,8 +18327,8 @@ impl ValveDescriptorSetHostMappingFn {
             get_descriptor_set_layout_host_mapping_info_valve: unsafe {
                 unsafe extern "system" fn get_descriptor_set_layout_host_mapping_info_valve(
                     _device: Device,
-                    _p_binding_reference: *const DescriptorSetBindingReferenceVALVE,
-                    _p_host_mapping: *mut DescriptorSetLayoutHostMappingInfoVALVE,
+                    _p_binding_reference: *const DescriptorSetBindingReferenceVALVE<'_>,
+                    _p_host_mapping: *mut DescriptorSetLayoutHostMappingInfoVALVE<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -18580,8 +18604,8 @@ impl NvDeviceGeneratedCommandsComputeFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineIndirectMemoryRequirementsNV = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const ComputePipelineCreateInfo,
-    p_memory_requirements: *mut MemoryRequirements2,
+    p_create_info: *const ComputePipelineCreateInfo<'_>,
+    p_memory_requirements: *mut MemoryRequirements2<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdUpdatePipelineIndirectBufferNV = unsafe extern "system" fn(
@@ -18592,7 +18616,7 @@ pub type PFN_vkCmdUpdatePipelineIndirectBufferNV = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineIndirectDeviceAddressNV = unsafe extern "system" fn(
     device: Device,
-    p_info: *const PipelineIndirectDeviceAddressInfoNV,
+    p_info: *const PipelineIndirectDeviceAddressInfoNV<'_>,
 ) -> DeviceAddress;
 #[derive(Clone)]
 pub struct NvDeviceGeneratedCommandsComputeFn {
@@ -18611,8 +18635,8 @@ impl NvDeviceGeneratedCommandsComputeFn {
             get_pipeline_indirect_memory_requirements_nv: unsafe {
                 unsafe extern "system" fn get_pipeline_indirect_memory_requirements_nv(
                     _device: Device,
-                    _p_create_info: *const ComputePipelineCreateInfo,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_create_info: *const ComputePipelineCreateInfo<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -18653,7 +18677,7 @@ impl NvDeviceGeneratedCommandsComputeFn {
             get_pipeline_indirect_device_address_nv: unsafe {
                 unsafe extern "system" fn get_pipeline_indirect_device_address_nv(
                     _device: Device,
-                    _p_info: *const PipelineIndirectDeviceAddressInfoNV,
+                    _p_info: *const PipelineIndirectDeviceAddressInfoNV<'_>,
                 ) -> DeviceAddress {
                     panic!(concat!(
                         "Unable to load ",
@@ -19697,13 +19721,13 @@ impl ExtShaderModuleIdentifierFn {
 pub type PFN_vkGetShaderModuleIdentifierEXT = unsafe extern "system" fn(
     device: Device,
     shader_module: ShaderModule,
-    p_identifier: *mut ShaderModuleIdentifierEXT,
+    p_identifier: *mut ShaderModuleIdentifierEXT<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetShaderModuleCreateInfoIdentifierEXT = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const ShaderModuleCreateInfo,
-    p_identifier: *mut ShaderModuleIdentifierEXT,
+    p_create_info: *const ShaderModuleCreateInfo<'_>,
+    p_identifier: *mut ShaderModuleIdentifierEXT<'_>,
 );
 #[derive(Clone)]
 pub struct ExtShaderModuleIdentifierFn {
@@ -19722,7 +19746,7 @@ impl ExtShaderModuleIdentifierFn {
                 unsafe extern "system" fn get_shader_module_identifier_ext(
                     _device: Device,
                     _shader_module: ShaderModule,
-                    _p_identifier: *mut ShaderModuleIdentifierEXT,
+                    _p_identifier: *mut ShaderModuleIdentifierEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -19742,8 +19766,8 @@ impl ExtShaderModuleIdentifierFn {
             get_shader_module_create_info_identifier_ext: unsafe {
                 unsafe extern "system" fn get_shader_module_create_info_identifier_ext(
                     _device: Device,
-                    _p_create_info: *const ShaderModuleCreateInfo,
-                    _p_identifier: *mut ShaderModuleIdentifierEXT,
+                    _p_create_info: *const ShaderModuleCreateInfo<'_>,
+                    _p_identifier: *mut ShaderModuleIdentifierEXT<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -19808,22 +19832,22 @@ impl NvOpticalFlowFn {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceOpticalFlowImageFormatsNV = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_optical_flow_image_format_info: *const OpticalFlowImageFormatInfoNV,
+    p_optical_flow_image_format_info: *const OpticalFlowImageFormatInfoNV<'_>,
     p_format_count: *mut u32,
-    p_image_format_properties: *mut OpticalFlowImageFormatPropertiesNV,
+    p_image_format_properties: *mut OpticalFlowImageFormatPropertiesNV<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateOpticalFlowSessionNV = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const OpticalFlowSessionCreateInfoNV,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const OpticalFlowSessionCreateInfoNV<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_session: *mut OpticalFlowSessionNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyOpticalFlowSessionNV = unsafe extern "system" fn(
     device: Device,
     session: OpticalFlowSessionNV,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkBindOpticalFlowSessionImageNV = unsafe extern "system" fn(
@@ -19837,7 +19861,7 @@ pub type PFN_vkBindOpticalFlowSessionImageNV = unsafe extern "system" fn(
 pub type PFN_vkCmdOpticalFlowExecuteNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     session: OpticalFlowSessionNV,
-    p_execute_info: *const OpticalFlowExecuteInfoNV,
+    p_execute_info: *const OpticalFlowExecuteInfoNV<'_>,
 );
 #[derive(Clone)]
 pub struct NvOpticalFlowFn {
@@ -19859,9 +19883,9 @@ impl NvOpticalFlowFn {
             get_physical_device_optical_flow_image_formats_nv: unsafe {
                 unsafe extern "system" fn get_physical_device_optical_flow_image_formats_nv(
                     _physical_device: PhysicalDevice,
-                    _p_optical_flow_image_format_info: *const OpticalFlowImageFormatInfoNV,
+                    _p_optical_flow_image_format_info: *const OpticalFlowImageFormatInfoNV<'_>,
                     _p_format_count: *mut u32,
-                    _p_image_format_properties: *mut OpticalFlowImageFormatPropertiesNV,
+                    _p_image_format_properties: *mut OpticalFlowImageFormatPropertiesNV<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -19881,8 +19905,8 @@ impl NvOpticalFlowFn {
             create_optical_flow_session_nv: unsafe {
                 unsafe extern "system" fn create_optical_flow_session_nv(
                     _device: Device,
-                    _p_create_info: *const OpticalFlowSessionCreateInfoNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const OpticalFlowSessionCreateInfoNV<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_session: *mut OpticalFlowSessionNV,
                 ) -> Result {
                     panic!(concat!(
@@ -19904,7 +19928,7 @@ impl NvOpticalFlowFn {
                 unsafe extern "system" fn destroy_optical_flow_session_nv(
                     _device: Device,
                     _session: OpticalFlowSessionNV,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -19948,7 +19972,7 @@ impl NvOpticalFlowFn {
                 unsafe extern "system" fn cmd_optical_flow_execute_nv(
                     _command_buffer: CommandBuffer,
                     _session: OpticalFlowSessionNV,
-                    _p_execute_info: *const OpticalFlowExecuteInfoNV,
+                    _p_execute_info: *const OpticalFlowExecuteInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -20080,14 +20104,14 @@ pub type PFN_vkCmdBindIndexBuffer2KHR = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetRenderingAreaGranularityKHR = unsafe extern "system" fn(
     device: Device,
-    p_rendering_area_info: *const RenderingAreaInfoKHR,
+    p_rendering_area_info: *const RenderingAreaInfoKHR<'_>,
     p_granularity: *mut Extent2D,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceImageSubresourceLayoutKHR = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceImageSubresourceInfoKHR,
-    p_layout: *mut SubresourceLayout2KHR,
+    p_info: *const DeviceImageSubresourceInfoKHR<'_>,
+    p_layout: *mut SubresourceLayout2KHR<'_>,
 );
 #[derive(Clone)]
 pub struct KhrMaintenance5Fn {
@@ -20129,7 +20153,7 @@ impl KhrMaintenance5Fn {
             get_rendering_area_granularity_khr: unsafe {
                 unsafe extern "system" fn get_rendering_area_granularity_khr(
                     _device: Device,
-                    _p_rendering_area_info: *const RenderingAreaInfoKHR,
+                    _p_rendering_area_info: *const RenderingAreaInfoKHR<'_>,
                     _p_granularity: *mut Extent2D,
                 ) {
                     panic!(concat!(
@@ -20150,8 +20174,8 @@ impl KhrMaintenance5Fn {
             get_device_image_subresource_layout_khr: unsafe {
                 unsafe extern "system" fn get_device_image_subresource_layout_khr(
                     _device: Device,
-                    _p_info: *const DeviceImageSubresourceInfoKHR,
-                    _p_layout: *mut SubresourceLayout2KHR,
+                    _p_info: *const DeviceImageSubresourceInfoKHR<'_>,
+                    _p_layout: *mut SubresourceLayout2KHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -20172,8 +20196,8 @@ impl KhrMaintenance5Fn {
                 unsafe extern "system" fn get_image_subresource_layout2_khr(
                     _device: Device,
                     _image: Image,
-                    _p_subresource: *const ImageSubresource2KHR,
-                    _p_layout: *mut SubresourceLayout2KHR,
+                    _p_subresource: *const ImageSubresource2KHR<'_>,
+                    _p_layout: *mut SubresourceLayout2KHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -20291,15 +20315,15 @@ impl ExtShaderObjectFn {
 pub type PFN_vkCreateShadersEXT = unsafe extern "system" fn(
     device: Device,
     create_info_count: u32,
-    p_create_infos: *const ShaderCreateInfoEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const ShaderCreateInfoEXT<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_shaders: *mut ShaderEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyShaderEXT = unsafe extern "system" fn(
     device: Device,
     shader: ShaderEXT,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetShaderBinaryDataEXT = unsafe extern "system" fn(
@@ -20388,8 +20412,8 @@ impl ExtShaderObjectFn {
                 unsafe extern "system" fn create_shaders_ext(
                     _device: Device,
                     _create_info_count: u32,
-                    _p_create_infos: *const ShaderCreateInfoEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const ShaderCreateInfoEXT<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_shaders: *mut ShaderEXT,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_shaders_ext)))
@@ -20407,7 +20431,7 @@ impl ExtShaderObjectFn {
                 unsafe extern "system" fn destroy_shader_ext(
                     _device: Device,
                     _shader: ShaderEXT,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_shader_ext)))
                 }
@@ -20710,9 +20734,11 @@ impl ExtShaderObjectFn {
                 unsafe extern "system" fn cmd_set_vertex_input_ext(
                     _command_buffer: CommandBuffer,
                     _vertex_binding_description_count: u32,
-                    _p_vertex_binding_descriptions: *const VertexInputBindingDescription2EXT,
+                    _p_vertex_binding_descriptions: *const VertexInputBindingDescription2EXT<'_>,
                     _vertex_attribute_description_count: u32,
-                    _p_vertex_attribute_descriptions: *const VertexInputAttributeDescription2EXT,
+                    _p_vertex_attribute_descriptions: *const VertexInputAttributeDescription2EXT<
+                        '_,
+                    >,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21489,13 +21515,13 @@ pub type PFN_vkGetFramebufferTilePropertiesQCOM = unsafe extern "system" fn(
     device: Device,
     framebuffer: Framebuffer,
     p_properties_count: *mut u32,
-    p_properties: *mut TilePropertiesQCOM,
+    p_properties: *mut TilePropertiesQCOM<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDynamicRenderingTilePropertiesQCOM = unsafe extern "system" fn(
     device: Device,
-    p_rendering_info: *const RenderingInfo,
-    p_properties: *mut TilePropertiesQCOM,
+    p_rendering_info: *const RenderingInfo<'_>,
+    p_properties: *mut TilePropertiesQCOM<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct QcomTilePropertiesFn {
@@ -21515,7 +21541,7 @@ impl QcomTilePropertiesFn {
                     _device: Device,
                     _framebuffer: Framebuffer,
                     _p_properties_count: *mut u32,
-                    _p_properties: *mut TilePropertiesQCOM,
+                    _p_properties: *mut TilePropertiesQCOM<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -21535,8 +21561,8 @@ impl QcomTilePropertiesFn {
             get_dynamic_rendering_tile_properties_qcom: unsafe {
                 unsafe extern "system" fn get_dynamic_rendering_tile_properties_qcom(
                     _device: Device,
-                    _p_rendering_info: *const RenderingInfo,
-                    _p_properties: *mut TilePropertiesQCOM,
+                    _p_rendering_info: *const RenderingInfo<'_>,
+                    _p_properties: *mut TilePropertiesQCOM<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -21690,30 +21716,30 @@ impl NvLowLatency2Fn {
 pub type PFN_vkSetLatencySleepModeNV = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
-    p_sleep_mode_info: *const LatencySleepModeInfoNV,
+    p_sleep_mode_info: *const LatencySleepModeInfoNV<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkLatencySleepNV = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
-    p_sleep_info: *const LatencySleepInfoNV,
+    p_sleep_info: *const LatencySleepInfoNV<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetLatencyMarkerNV = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
-    p_latency_marker_info: *const SetLatencyMarkerInfoNV,
+    p_latency_marker_info: *const SetLatencyMarkerInfoNV<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetLatencyTimingsNV = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     p_timing_count: *mut u32,
-    p_latency_marker_info: *mut GetLatencyMarkerInfoNV,
+    p_latency_marker_info: *mut GetLatencyMarkerInfoNV<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueNotifyOutOfBandNV =
-    unsafe extern "system" fn(queue: Queue, p_queue_type_info: *const OutOfBandQueueTypeInfoNV);
+    unsafe extern "system" fn(queue: Queue, p_queue_type_info: *const OutOfBandQueueTypeInfoNV<'_>);
 #[derive(Clone)]
 pub struct NvLowLatency2Fn {
     pub set_latency_sleep_mode_nv: PFN_vkSetLatencySleepModeNV,
@@ -21734,7 +21760,7 @@ impl NvLowLatency2Fn {
                 unsafe extern "system" fn set_latency_sleep_mode_nv(
                     _device: Device,
                     _swapchain: SwapchainKHR,
-                    _p_sleep_mode_info: *const LatencySleepModeInfoNV,
+                    _p_sleep_mode_info: *const LatencySleepModeInfoNV<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -21754,7 +21780,7 @@ impl NvLowLatency2Fn {
                 unsafe extern "system" fn latency_sleep_nv(
                     _device: Device,
                     _swapchain: SwapchainKHR,
-                    _p_sleep_info: *const LatencySleepInfoNV,
+                    _p_sleep_info: *const LatencySleepInfoNV<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(latency_sleep_nv)))
                 }
@@ -21770,7 +21796,7 @@ impl NvLowLatency2Fn {
                 unsafe extern "system" fn set_latency_marker_nv(
                     _device: Device,
                     _swapchain: SwapchainKHR,
-                    _p_latency_marker_info: *const SetLatencyMarkerInfoNV,
+                    _p_latency_marker_info: *const SetLatencyMarkerInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21791,7 +21817,7 @@ impl NvLowLatency2Fn {
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _p_timing_count: *mut u32,
-                    _p_latency_marker_info: *mut GetLatencyMarkerInfoNV,
+                    _p_latency_marker_info: *mut GetLatencyMarkerInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21810,7 +21836,7 @@ impl NvLowLatency2Fn {
             queue_notify_out_of_band_nv: unsafe {
                 unsafe extern "system" fn queue_notify_out_of_band_nv(
                     _queue: Queue,
-                    _p_queue_type_info: *const OutOfBandQueueTypeInfoNV,
+                    _p_queue_type_info: *const OutOfBandQueueTypeInfoNV<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21851,7 +21877,7 @@ pub type PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR =
     unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
-        p_properties: *mut CooperativeMatrixPropertiesKHR,
+        p_properties: *mut CooperativeMatrixPropertiesKHR<'_>,
     ) -> Result;
 #[derive(Clone)]
 pub struct KhrCooperativeMatrixFn {
@@ -21870,7 +21896,7 @@ impl KhrCooperativeMatrixFn {
                 unsafe extern "system" fn get_physical_device_cooperative_matrix_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut CooperativeMatrixPropertiesKHR,
+                    _p_properties: *mut CooperativeMatrixPropertiesKHR<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -22032,7 +22058,7 @@ impl QnxExternalMemoryScreenBufferFn {
 pub type PFN_vkGetScreenBufferPropertiesQNX = unsafe extern "system" fn(
     device: Device,
     buffer: *const _screen_buffer,
-    p_properties: *mut ScreenBufferPropertiesQNX,
+    p_properties: *mut ScreenBufferPropertiesQNX<'_>,
 ) -> Result;
 #[derive(Clone)]
 pub struct QnxExternalMemoryScreenBufferFn {
@@ -22050,7 +22076,7 @@ impl QnxExternalMemoryScreenBufferFn {
                 unsafe extern "system" fn get_screen_buffer_properties_qnx(
                     _device: Device,
                     _buffer: *const _screen_buffer,
-                    _p_properties: *mut ScreenBufferPropertiesQNX,
+                    _p_properties: *mut ScreenBufferPropertiesQNX<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -9203,7 +9203,7 @@ pub type PFN_vkDestroyAccelerationStructureNV = unsafe extern "system" fn(
 pub type PFN_vkGetAccelerationStructureMemoryRequirementsNV = unsafe extern "system" fn(
     device: Device,
     p_info: *const AccelerationStructureMemoryRequirementsInfoNV<'_>,
-    p_memory_requirements: *mut MemoryRequirements2KHR,
+    p_memory_requirements: *mut MemoryRequirements2KHR<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkBindAccelerationStructureMemoryNV = unsafe extern "system" fn(
@@ -9349,7 +9349,7 @@ impl NvRayTracingFn {
                 unsafe extern "system" fn get_acceleration_structure_memory_requirements_nv(
                     _device: Device,
                     _p_info: *const AccelerationStructureMemoryRequirementsInfoNV<'_>,
-                    _p_memory_requirements: *mut MemoryRequirements2KHR,
+                    _p_memory_requirements: *mut MemoryRequirements2KHR<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -16880,7 +16880,7 @@ unsafe impl GetPipelinePropertiesEXTParamPipelineProperties
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelinePropertiesEXT = unsafe extern "system" fn(
     device: Device,
-    p_pipeline_info: *const PipelineInfoEXT,
+    p_pipeline_info: *const PipelineInfoEXT<'_>,
     p_pipeline_properties: *mut BaseOutStructure<'_>,
 ) -> Result;
 #[derive(Clone)]
@@ -16898,7 +16898,7 @@ impl ExtPipelinePropertiesFn {
             get_pipeline_properties_ext: unsafe {
                 unsafe extern "system" fn get_pipeline_properties_ext(
                     _device: Device,
-                    _p_pipeline_info: *const PipelineInfoEXT,
+                    _p_pipeline_info: *const PipelineInfoEXT<'_>,
                     _p_pipeline_properties: *mut BaseOutStructure<'_>,
                 ) -> Result {
                     panic!(concat!(

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -1,3 +1,4 @@
+#![allow(unused_qualifications)]
 use crate::vk::aliases::*;
 use crate::vk::bitflags::*;
 use crate::vk::definitions::*;

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -41,8 +41,8 @@ impl StaticFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateInstance = unsafe extern "system" fn(
-    p_create_info: *const InstanceCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const InstanceCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_instance: *mut Instance,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -72,8 +72,8 @@ impl EntryFnV1_0 {
         Self {
             create_instance: unsafe {
                 unsafe extern "system" fn create_instance(
-                    _p_create_info: *const InstanceCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const InstanceCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_instance: *mut Instance,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_instance)))
@@ -132,7 +132,7 @@ impl EntryFnV1_0 {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyInstance =
-    unsafe extern "system" fn(instance: Instance, p_allocator: *const AllocationCallbacks);
+    unsafe extern "system" fn(instance: Instance, p_allocator: *const AllocationCallbacks<'_>);
 #[allow(non_camel_case_types)]
 pub type PFN_vkEnumeratePhysicalDevices = unsafe extern "system" fn(
     instance: Instance,
@@ -182,8 +182,8 @@ pub type PFN_vkGetDeviceProcAddr =
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDevice = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
-    p_create_info: *const DeviceCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DeviceCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_device: *mut Device,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -238,7 +238,7 @@ impl InstanceFnV1_0 {
             destroy_instance: unsafe {
                 unsafe extern "system" fn destroy_instance(
                     _instance: Instance,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_instance)))
                 }
@@ -417,8 +417,8 @@ impl InstanceFnV1_0 {
             create_device: unsafe {
                 unsafe extern "system" fn create_device(
                     _physical_device: PhysicalDevice,
-                    _p_create_info: *const DeviceCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DeviceCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_device: *mut Device,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_device)))
@@ -505,7 +505,7 @@ impl InstanceFnV1_0 {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDevice =
-    unsafe extern "system" fn(device: Device, p_allocator: *const AllocationCallbacks);
+    unsafe extern "system" fn(device: Device, p_allocator: *const AllocationCallbacks<'_>);
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceQueue = unsafe extern "system" fn(
     device: Device,
@@ -517,7 +517,7 @@ pub type PFN_vkGetDeviceQueue = unsafe extern "system" fn(
 pub type PFN_vkQueueSubmit = unsafe extern "system" fn(
     queue: Queue,
     submit_count: u32,
-    p_submits: *const SubmitInfo,
+    p_submits: *const SubmitInfo<'_>,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -527,15 +527,15 @@ pub type PFN_vkDeviceWaitIdle = unsafe extern "system" fn(device: Device) -> Res
 #[allow(non_camel_case_types)]
 pub type PFN_vkAllocateMemory = unsafe extern "system" fn(
     device: Device,
-    p_allocate_info: *const MemoryAllocateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_allocate_info: *const MemoryAllocateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_memory: *mut DeviceMemory,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkFreeMemory = unsafe extern "system" fn(
     device: Device,
     memory: DeviceMemory,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkMapMemory = unsafe extern "system" fn(
@@ -552,13 +552,13 @@ pub type PFN_vkUnmapMemory = unsafe extern "system" fn(device: Device, memory: D
 pub type PFN_vkFlushMappedMemoryRanges = unsafe extern "system" fn(
     device: Device,
     memory_range_count: u32,
-    p_memory_ranges: *const MappedMemoryRange,
+    p_memory_ranges: *const MappedMemoryRange<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkInvalidateMappedMemoryRanges = unsafe extern "system" fn(
     device: Device,
     memory_range_count: u32,
-    p_memory_ranges: *const MappedMemoryRange,
+    p_memory_ranges: *const MappedMemoryRange<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceMemoryCommitment = unsafe extern "system" fn(
@@ -603,21 +603,21 @@ pub type PFN_vkGetImageSparseMemoryRequirements = unsafe extern "system" fn(
 pub type PFN_vkQueueBindSparse = unsafe extern "system" fn(
     queue: Queue,
     bind_info_count: u32,
-    p_bind_info: *const BindSparseInfo,
+    p_bind_info: *const BindSparseInfo<'_>,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateFence = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const FenceCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const FenceCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyFence = unsafe extern "system" fn(
     device: Device,
     fence: Fence,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetFences =
@@ -635,28 +635,28 @@ pub type PFN_vkWaitForFences = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateSemaphore = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const SemaphoreCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const SemaphoreCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_semaphore: *mut Semaphore,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySemaphore = unsafe extern "system" fn(
     device: Device,
     semaphore: Semaphore,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateEvent = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const EventCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const EventCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_event: *mut Event,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyEvent = unsafe extern "system" fn(
     device: Device,
     event: Event,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetEventStatus = unsafe extern "system" fn(device: Device, event: Event) -> Result;
@@ -667,15 +667,15 @@ pub type PFN_vkResetEvent = unsafe extern "system" fn(device: Device, event: Eve
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateQueryPool = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const QueryPoolCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const QueryPoolCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_query_pool: *mut QueryPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyQueryPool = unsafe extern "system" fn(
     device: Device,
     query_pool: QueryPool,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetQueryPoolResults = unsafe extern "system" fn(
@@ -691,41 +691,41 @@ pub type PFN_vkGetQueryPoolResults = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateBuffer = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const BufferCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const BufferCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_buffer: *mut Buffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyBuffer = unsafe extern "system" fn(
     device: Device,
     buffer: Buffer,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateBufferView = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const BufferViewCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const BufferViewCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_view: *mut BufferView,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyBufferView = unsafe extern "system" fn(
     device: Device,
     buffer_view: BufferView,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateImage = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const ImageCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ImageCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_image: *mut Image,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyImage = unsafe extern "system" fn(
     device: Device,
     image: Image,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageSubresourceLayout = unsafe extern "system" fn(
@@ -737,41 +737,41 @@ pub type PFN_vkGetImageSubresourceLayout = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateImageView = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const ImageViewCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ImageViewCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_view: *mut ImageView,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyImageView = unsafe extern "system" fn(
     device: Device,
     image_view: ImageView,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateShaderModule = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const ShaderModuleCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const ShaderModuleCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_shader_module: *mut ShaderModule,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyShaderModule = unsafe extern "system" fn(
     device: Device,
     shader_module: ShaderModule,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreatePipelineCache = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const PipelineCacheCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const PipelineCacheCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipeline_cache: *mut PipelineCache,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipelineCache = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineCacheData = unsafe extern "system" fn(
@@ -792,8 +792,8 @@ pub type PFN_vkCreateGraphicsPipelines = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
-    p_create_infos: *const GraphicsPipelineCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const GraphicsPipelineCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -801,67 +801,67 @@ pub type PFN_vkCreateComputePipelines = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
-    p_create_infos: *const ComputePipelineCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_infos: *const ComputePipelineCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipeline = unsafe extern "system" fn(
     device: Device,
     pipeline: Pipeline,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreatePipelineLayout = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const PipelineLayoutCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const PipelineLayoutCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_pipeline_layout: *mut PipelineLayout,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipelineLayout = unsafe extern "system" fn(
     device: Device,
     pipeline_layout: PipelineLayout,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateSampler = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const SamplerCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const SamplerCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_sampler: *mut Sampler,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySampler = unsafe extern "system" fn(
     device: Device,
     sampler: Sampler,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDescriptorSetLayout = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const DescriptorSetLayoutCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_set_layout: *mut DescriptorSetLayout,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDescriptorSetLayout = unsafe extern "system" fn(
     device: Device,
     descriptor_set_layout: DescriptorSetLayout,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDescriptorPool = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const DescriptorPoolCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const DescriptorPoolCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_descriptor_pool: *mut DescriptorPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDescriptorPool = unsafe extern "system" fn(
     device: Device,
     descriptor_pool: DescriptorPool,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetDescriptorPool = unsafe extern "system" fn(
@@ -872,7 +872,7 @@ pub type PFN_vkResetDescriptorPool = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkAllocateDescriptorSets = unsafe extern "system" fn(
     device: Device,
-    p_allocate_info: *const DescriptorSetAllocateInfo,
+    p_allocate_info: *const DescriptorSetAllocateInfo<'_>,
     p_descriptor_sets: *mut DescriptorSet,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -886,35 +886,35 @@ pub type PFN_vkFreeDescriptorSets = unsafe extern "system" fn(
 pub type PFN_vkUpdateDescriptorSets = unsafe extern "system" fn(
     device: Device,
     descriptor_write_count: u32,
-    p_descriptor_writes: *const WriteDescriptorSet,
+    p_descriptor_writes: *const WriteDescriptorSet<'_>,
     descriptor_copy_count: u32,
-    p_descriptor_copies: *const CopyDescriptorSet,
+    p_descriptor_copies: *const CopyDescriptorSet<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateFramebuffer = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const FramebufferCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const FramebufferCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_framebuffer: *mut Framebuffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyFramebuffer = unsafe extern "system" fn(
     device: Device,
     framebuffer: Framebuffer,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateRenderPass = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const RenderPassCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const RenderPassCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_render_pass: *mut RenderPass,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyRenderPass = unsafe extern "system" fn(
     device: Device,
     render_pass: RenderPass,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetRenderAreaGranularity = unsafe extern "system" fn(
@@ -925,15 +925,15 @@ pub type PFN_vkGetRenderAreaGranularity = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCommandPool = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const CommandPoolCreateInfo,
-    p_allocator: *const AllocationCallbacks,
+    p_create_info: *const CommandPoolCreateInfo<'_>,
+    p_allocator: *const AllocationCallbacks<'_>,
     p_command_pool: *mut CommandPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCommandPool = unsafe extern "system" fn(
     device: Device,
     command_pool: CommandPool,
-    p_allocator: *const AllocationCallbacks,
+    p_allocator: *const AllocationCallbacks<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetCommandPool = unsafe extern "system" fn(
@@ -944,7 +944,7 @@ pub type PFN_vkResetCommandPool = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkAllocateCommandBuffers = unsafe extern "system" fn(
     device: Device,
-    p_allocate_info: *const CommandBufferAllocateInfo,
+    p_allocate_info: *const CommandBufferAllocateInfo<'_>,
     p_command_buffers: *mut CommandBuffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -957,7 +957,7 @@ pub type PFN_vkFreeCommandBuffers = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkBeginCommandBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_begin_info: *const CommandBufferBeginInfo,
+    p_begin_info: *const CommandBufferBeginInfo<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkEndCommandBuffer =
@@ -1212,11 +1212,11 @@ pub type PFN_vkCmdWaitEvents = unsafe extern "system" fn(
     src_stage_mask: PipelineStageFlags,
     dst_stage_mask: PipelineStageFlags,
     memory_barrier_count: u32,
-    p_memory_barriers: *const MemoryBarrier,
+    p_memory_barriers: *const MemoryBarrier<'_>,
     buffer_memory_barrier_count: u32,
-    p_buffer_memory_barriers: *const BufferMemoryBarrier,
+    p_buffer_memory_barriers: *const BufferMemoryBarrier<'_>,
     image_memory_barrier_count: u32,
-    p_image_memory_barriers: *const ImageMemoryBarrier,
+    p_image_memory_barriers: *const ImageMemoryBarrier<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdPipelineBarrier = unsafe extern "system" fn(
@@ -1225,11 +1225,11 @@ pub type PFN_vkCmdPipelineBarrier = unsafe extern "system" fn(
     dst_stage_mask: PipelineStageFlags,
     dependency_flags: DependencyFlags,
     memory_barrier_count: u32,
-    p_memory_barriers: *const MemoryBarrier,
+    p_memory_barriers: *const MemoryBarrier<'_>,
     buffer_memory_barrier_count: u32,
-    p_buffer_memory_barriers: *const BufferMemoryBarrier,
+    p_buffer_memory_barriers: *const BufferMemoryBarrier<'_>,
     image_memory_barrier_count: u32,
-    p_image_memory_barriers: *const ImageMemoryBarrier,
+    p_image_memory_barriers: *const ImageMemoryBarrier<'_>,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginQuery = unsafe extern "system" fn(
@@ -1278,7 +1278,7 @@ pub type PFN_vkCmdPushConstants = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginRenderPass = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_render_pass_begin: *const RenderPassBeginInfo,
+    p_render_pass_begin: *const RenderPassBeginInfo<'_>,
     contents: SubpassContents,
 );
 #[allow(non_camel_case_types)]
@@ -1426,7 +1426,7 @@ impl DeviceFnV1_0 {
             destroy_device: unsafe {
                 unsafe extern "system" fn destroy_device(
                     _device: Device,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_device)))
                 }
@@ -1459,7 +1459,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn queue_submit(
                     _queue: Queue,
                     _submit_count: u32,
-                    _p_submits: *const SubmitInfo,
+                    _p_submits: *const SubmitInfo<'_>,
                     _fence: Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_submit)))
@@ -1499,8 +1499,8 @@ impl DeviceFnV1_0 {
             allocate_memory: unsafe {
                 unsafe extern "system" fn allocate_memory(
                     _device: Device,
-                    _p_allocate_info: *const MemoryAllocateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocate_info: *const MemoryAllocateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_memory: *mut DeviceMemory,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(allocate_memory)))
@@ -1517,7 +1517,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn free_memory(
                     _device: Device,
                     _memory: DeviceMemory,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(free_memory)))
                 }
@@ -1564,7 +1564,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn flush_mapped_memory_ranges(
                     _device: Device,
                     _memory_range_count: u32,
-                    _p_memory_ranges: *const MappedMemoryRange,
+                    _p_memory_ranges: *const MappedMemoryRange<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1584,7 +1584,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn invalidate_mapped_memory_ranges(
                     _device: Device,
                     _memory_range_count: u32,
-                    _p_memory_ranges: *const MappedMemoryRange,
+                    _p_memory_ranges: *const MappedMemoryRange<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -1725,7 +1725,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn queue_bind_sparse(
                     _queue: Queue,
                     _bind_info_count: u32,
-                    _p_bind_info: *const BindSparseInfo,
+                    _p_bind_info: *const BindSparseInfo<'_>,
                     _fence: Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_bind_sparse)))
@@ -1741,8 +1741,8 @@ impl DeviceFnV1_0 {
             create_fence: unsafe {
                 unsafe extern "system" fn create_fence(
                     _device: Device,
-                    _p_create_info: *const FenceCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const FenceCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_fence: *mut Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_fence)))
@@ -1759,7 +1759,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_fence(
                     _device: Device,
                     _fence: Fence,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_fence)))
                 }
@@ -1823,8 +1823,8 @@ impl DeviceFnV1_0 {
             create_semaphore: unsafe {
                 unsafe extern "system" fn create_semaphore(
                     _device: Device,
-                    _p_create_info: *const SemaphoreCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const SemaphoreCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_semaphore: *mut Semaphore,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_semaphore)))
@@ -1841,7 +1841,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_semaphore(
                     _device: Device,
                     _semaphore: Semaphore,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_semaphore)))
                 }
@@ -1857,8 +1857,8 @@ impl DeviceFnV1_0 {
             create_event: unsafe {
                 unsafe extern "system" fn create_event(
                     _device: Device,
-                    _p_create_info: *const EventCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const EventCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_event: *mut Event,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_event)))
@@ -1875,7 +1875,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_event(
                     _device: Device,
                     _event: Event,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_event)))
                 }
@@ -1929,8 +1929,8 @@ impl DeviceFnV1_0 {
             create_query_pool: unsafe {
                 unsafe extern "system" fn create_query_pool(
                     _device: Device,
-                    _p_create_info: *const QueryPoolCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const QueryPoolCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_query_pool: *mut QueryPool,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_query_pool)))
@@ -1947,7 +1947,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_query_pool(
                     _device: Device,
                     _query_pool: QueryPool,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_query_pool)))
                 }
@@ -1988,8 +1988,8 @@ impl DeviceFnV1_0 {
             create_buffer: unsafe {
                 unsafe extern "system" fn create_buffer(
                     _device: Device,
-                    _p_create_info: *const BufferCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const BufferCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_buffer: *mut Buffer,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_buffer)))
@@ -2006,7 +2006,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_buffer(
                     _device: Device,
                     _buffer: Buffer,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_buffer)))
                 }
@@ -2021,8 +2021,8 @@ impl DeviceFnV1_0 {
             create_buffer_view: unsafe {
                 unsafe extern "system" fn create_buffer_view(
                     _device: Device,
-                    _p_create_info: *const BufferViewCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const BufferViewCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_view: *mut BufferView,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_buffer_view)))
@@ -2040,7 +2040,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_buffer_view(
                     _device: Device,
                     _buffer_view: BufferView,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_buffer_view)))
                 }
@@ -2056,8 +2056,8 @@ impl DeviceFnV1_0 {
             create_image: unsafe {
                 unsafe extern "system" fn create_image(
                     _device: Device,
-                    _p_create_info: *const ImageCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ImageCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_image: *mut Image,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_image)))
@@ -2074,7 +2074,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_image(
                     _device: Device,
                     _image: Image,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_image)))
                 }
@@ -2111,8 +2111,8 @@ impl DeviceFnV1_0 {
             create_image_view: unsafe {
                 unsafe extern "system" fn create_image_view(
                     _device: Device,
-                    _p_create_info: *const ImageViewCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ImageViewCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_view: *mut ImageView,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_image_view)))
@@ -2129,7 +2129,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_image_view(
                     _device: Device,
                     _image_view: ImageView,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_image_view)))
                 }
@@ -2145,8 +2145,8 @@ impl DeviceFnV1_0 {
             create_shader_module: unsafe {
                 unsafe extern "system" fn create_shader_module(
                     _device: Device,
-                    _p_create_info: *const ShaderModuleCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const ShaderModuleCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_shader_module: *mut ShaderModule,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_shader_module)))
@@ -2164,7 +2164,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_shader_module(
                     _device: Device,
                     _shader_module: ShaderModule,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2183,8 +2183,8 @@ impl DeviceFnV1_0 {
             create_pipeline_cache: unsafe {
                 unsafe extern "system" fn create_pipeline_cache(
                     _device: Device,
-                    _p_create_info: *const PipelineCacheCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const PipelineCacheCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipeline_cache: *mut PipelineCache,
                 ) -> Result {
                     panic!(concat!(
@@ -2205,7 +2205,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_pipeline_cache(
                     _device: Device,
                     _pipeline_cache: PipelineCache,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2268,8 +2268,8 @@ impl DeviceFnV1_0 {
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
-                    _p_create_infos: *const GraphicsPipelineCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const GraphicsPipelineCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -2291,8 +2291,8 @@ impl DeviceFnV1_0 {
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
-                    _p_create_infos: *const ComputePipelineCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_infos: *const ComputePipelineCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -2313,7 +2313,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_pipeline(
                     _device: Device,
                     _pipeline: Pipeline,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_pipeline)))
                 }
@@ -2328,8 +2328,8 @@ impl DeviceFnV1_0 {
             create_pipeline_layout: unsafe {
                 unsafe extern "system" fn create_pipeline_layout(
                     _device: Device,
-                    _p_create_info: *const PipelineLayoutCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const PipelineLayoutCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_pipeline_layout: *mut PipelineLayout,
                 ) -> Result {
                     panic!(concat!(
@@ -2350,7 +2350,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_pipeline_layout(
                     _device: Device,
                     _pipeline_layout: PipelineLayout,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2369,8 +2369,8 @@ impl DeviceFnV1_0 {
             create_sampler: unsafe {
                 unsafe extern "system" fn create_sampler(
                     _device: Device,
-                    _p_create_info: *const SamplerCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const SamplerCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_sampler: *mut Sampler,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_sampler)))
@@ -2387,7 +2387,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_sampler(
                     _device: Device,
                     _sampler: Sampler,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_sampler)))
                 }
@@ -2402,8 +2402,8 @@ impl DeviceFnV1_0 {
             create_descriptor_set_layout: unsafe {
                 unsafe extern "system" fn create_descriptor_set_layout(
                     _device: Device,
-                    _p_create_info: *const DescriptorSetLayoutCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_set_layout: *mut DescriptorSetLayout,
                 ) -> Result {
                     panic!(concat!(
@@ -2425,7 +2425,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_descriptor_set_layout(
                     _device: Device,
                     _descriptor_set_layout: DescriptorSetLayout,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2445,8 +2445,8 @@ impl DeviceFnV1_0 {
             create_descriptor_pool: unsafe {
                 unsafe extern "system" fn create_descriptor_pool(
                     _device: Device,
-                    _p_create_info: *const DescriptorPoolCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DescriptorPoolCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_descriptor_pool: *mut DescriptorPool,
                 ) -> Result {
                     panic!(concat!(
@@ -2467,7 +2467,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_descriptor_pool(
                     _device: Device,
                     _descriptor_pool: DescriptorPool,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2506,7 +2506,7 @@ impl DeviceFnV1_0 {
             allocate_descriptor_sets: unsafe {
                 unsafe extern "system" fn allocate_descriptor_sets(
                     _device: Device,
-                    _p_allocate_info: *const DescriptorSetAllocateInfo,
+                    _p_allocate_info: *const DescriptorSetAllocateInfo<'_>,
                     _p_descriptor_sets: *mut DescriptorSet,
                 ) -> Result {
                     panic!(concat!(
@@ -2545,9 +2545,9 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn update_descriptor_sets(
                     _device: Device,
                     _descriptor_write_count: u32,
-                    _p_descriptor_writes: *const WriteDescriptorSet,
+                    _p_descriptor_writes: *const WriteDescriptorSet<'_>,
                     _descriptor_copy_count: u32,
-                    _p_descriptor_copies: *const CopyDescriptorSet,
+                    _p_descriptor_copies: *const CopyDescriptorSet<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -2566,8 +2566,8 @@ impl DeviceFnV1_0 {
             create_framebuffer: unsafe {
                 unsafe extern "system" fn create_framebuffer(
                     _device: Device,
-                    _p_create_info: *const FramebufferCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const FramebufferCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_framebuffer: *mut Framebuffer,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_framebuffer)))
@@ -2585,7 +2585,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_framebuffer(
                     _device: Device,
                     _framebuffer: Framebuffer,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_framebuffer)))
                 }
@@ -2601,8 +2601,8 @@ impl DeviceFnV1_0 {
             create_render_pass: unsafe {
                 unsafe extern "system" fn create_render_pass(
                     _device: Device,
-                    _p_create_info: *const RenderPassCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const RenderPassCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_render_pass: *mut RenderPass,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_render_pass)))
@@ -2620,7 +2620,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_render_pass(
                     _device: Device,
                     _render_pass: RenderPass,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_render_pass)))
                 }
@@ -2657,8 +2657,8 @@ impl DeviceFnV1_0 {
             create_command_pool: unsafe {
                 unsafe extern "system" fn create_command_pool(
                     _device: Device,
-                    _p_create_info: *const CommandPoolCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const CommandPoolCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_command_pool: *mut CommandPool,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_command_pool)))
@@ -2676,7 +2676,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_command_pool(
                     _device: Device,
                     _command_pool: CommandPool,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_command_pool)))
                 }
@@ -2709,7 +2709,7 @@ impl DeviceFnV1_0 {
             allocate_command_buffers: unsafe {
                 unsafe extern "system" fn allocate_command_buffers(
                     _device: Device,
-                    _p_allocate_info: *const CommandBufferAllocateInfo,
+                    _p_allocate_info: *const CommandBufferAllocateInfo<'_>,
                     _p_command_buffers: *mut CommandBuffer,
                 ) -> Result {
                     panic!(concat!(
@@ -2747,7 +2747,7 @@ impl DeviceFnV1_0 {
             begin_command_buffer: unsafe {
                 unsafe extern "system" fn begin_command_buffer(
                     _command_buffer: CommandBuffer,
-                    _p_begin_info: *const CommandBufferBeginInfo,
+                    _p_begin_info: *const CommandBufferBeginInfo<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(begin_command_buffer)))
                 }
@@ -3422,11 +3422,11 @@ impl DeviceFnV1_0 {
                     _src_stage_mask: PipelineStageFlags,
                     _dst_stage_mask: PipelineStageFlags,
                     _memory_barrier_count: u32,
-                    _p_memory_barriers: *const MemoryBarrier,
+                    _p_memory_barriers: *const MemoryBarrier<'_>,
                     _buffer_memory_barrier_count: u32,
-                    _p_buffer_memory_barriers: *const BufferMemoryBarrier,
+                    _p_buffer_memory_barriers: *const BufferMemoryBarrier<'_>,
                     _image_memory_barrier_count: u32,
-                    _p_image_memory_barriers: *const ImageMemoryBarrier,
+                    _p_image_memory_barriers: *const ImageMemoryBarrier<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_wait_events)))
                 }
@@ -3445,11 +3445,11 @@ impl DeviceFnV1_0 {
                     _dst_stage_mask: PipelineStageFlags,
                     _dependency_flags: DependencyFlags,
                     _memory_barrier_count: u32,
-                    _p_memory_barriers: *const MemoryBarrier,
+                    _p_memory_barriers: *const MemoryBarrier<'_>,
                     _buffer_memory_barrier_count: u32,
-                    _p_buffer_memory_barriers: *const BufferMemoryBarrier,
+                    _p_buffer_memory_barriers: *const BufferMemoryBarrier<'_>,
                     _image_memory_barrier_count: u32,
-                    _p_image_memory_barriers: *const ImageMemoryBarrier,
+                    _p_image_memory_barriers: *const ImageMemoryBarrier<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_pipeline_barrier)))
                 }
@@ -3579,7 +3579,7 @@ impl DeviceFnV1_0 {
             cmd_begin_render_pass: unsafe {
                 unsafe extern "system" fn cmd_begin_render_pass(
                     _command_buffer: CommandBuffer,
-                    _p_render_pass_begin: *const RenderPassBeginInfo,
+                    _p_render_pass_begin: *const RenderPassBeginInfo<'_>,
                     _contents: SubpassContents,
                 ) {
                     panic!(concat!(
@@ -3713,7 +3713,7 @@ impl InstanceFnV1_1 {
                 unsafe extern "system" fn enumerate_physical_device_groups(
                     _instance: Instance,
                     _p_physical_device_group_count: *mut u32,
-                    _p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
+                    _p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -3733,7 +3733,7 @@ impl InstanceFnV1_1 {
             get_physical_device_features2: unsafe {
                 unsafe extern "system" fn get_physical_device_features2(
                     _physical_device: PhysicalDevice,
-                    _p_features: *mut PhysicalDeviceFeatures2,
+                    _p_features: *mut PhysicalDeviceFeatures2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3753,7 +3753,7 @@ impl InstanceFnV1_1 {
             get_physical_device_properties2: unsafe {
                 unsafe extern "system" fn get_physical_device_properties2(
                     _physical_device: PhysicalDevice,
-                    _p_properties: *mut PhysicalDeviceProperties2,
+                    _p_properties: *mut PhysicalDeviceProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3774,7 +3774,7 @@ impl InstanceFnV1_1 {
                 unsafe extern "system" fn get_physical_device_format_properties2(
                     _physical_device: PhysicalDevice,
                     _format: Format,
-                    _p_format_properties: *mut FormatProperties2,
+                    _p_format_properties: *mut FormatProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3794,8 +3794,8 @@ impl InstanceFnV1_1 {
             get_physical_device_image_format_properties2: unsafe {
                 unsafe extern "system" fn get_physical_device_image_format_properties2(
                     _physical_device: PhysicalDevice,
-                    _p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
-                    _p_image_format_properties: *mut ImageFormatProperties2,
+                    _p_image_format_info: *const PhysicalDeviceImageFormatInfo2<'_>,
+                    _p_image_format_properties: *mut ImageFormatProperties2<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -3816,7 +3816,7 @@ impl InstanceFnV1_1 {
                 unsafe extern "system" fn get_physical_device_queue_family_properties2(
                     _physical_device: PhysicalDevice,
                     _p_queue_family_property_count: *mut u32,
-                    _p_queue_family_properties: *mut QueueFamilyProperties2,
+                    _p_queue_family_properties: *mut QueueFamilyProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3836,7 +3836,7 @@ impl InstanceFnV1_1 {
             get_physical_device_memory_properties2: unsafe {
                 unsafe extern "system" fn get_physical_device_memory_properties2(
                     _physical_device: PhysicalDevice,
-                    _p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
+                    _p_memory_properties: *mut PhysicalDeviceMemoryProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3856,9 +3856,9 @@ impl InstanceFnV1_1 {
             get_physical_device_sparse_image_format_properties2: unsafe {
                 unsafe extern "system" fn get_physical_device_sparse_image_format_properties2(
                     _physical_device: PhysicalDevice,
-                    _p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
+                    _p_format_info: *const PhysicalDeviceSparseImageFormatInfo2<'_>,
                     _p_property_count: *mut u32,
-                    _p_properties: *mut SparseImageFormatProperties2,
+                    _p_properties: *mut SparseImageFormatProperties2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3878,8 +3878,8 @@ impl InstanceFnV1_1 {
             get_physical_device_external_buffer_properties: unsafe {
                 unsafe extern "system" fn get_physical_device_external_buffer_properties(
                     _physical_device: PhysicalDevice,
-                    _p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
-                    _p_external_buffer_properties: *mut ExternalBufferProperties,
+                    _p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo<'_>,
+                    _p_external_buffer_properties: *mut ExternalBufferProperties<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3899,8 +3899,8 @@ impl InstanceFnV1_1 {
             get_physical_device_external_fence_properties: unsafe {
                 unsafe extern "system" fn get_physical_device_external_fence_properties(
                     _physical_device: PhysicalDevice,
-                    _p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
-                    _p_external_fence_properties: *mut ExternalFenceProperties,
+                    _p_external_fence_info: *const PhysicalDeviceExternalFenceInfo<'_>,
+                    _p_external_fence_properties: *mut ExternalFenceProperties<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3920,8 +3920,8 @@ impl InstanceFnV1_1 {
             get_physical_device_external_semaphore_properties: unsafe {
                 unsafe extern "system" fn get_physical_device_external_semaphore_properties(
                     _physical_device: PhysicalDevice,
-                    _p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
-                    _p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
+                    _p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo<'_>,
+                    _p_external_semaphore_properties: *mut ExternalSemaphoreProperties<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3944,7 +3944,7 @@ impl InstanceFnV1_1 {
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceQueue2 = unsafe extern "system" fn(
     device: Device,
-    p_queue_info: *const DeviceQueueInfo2,
+    p_queue_info: *const DeviceQueueInfo2<'_>,
     p_queue: *mut Queue,
 );
 #[derive(Clone)]
@@ -3978,7 +3978,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn bind_buffer_memory2(
                     _device: Device,
                     _bind_info_count: u32,
-                    _p_bind_infos: *const BindBufferMemoryInfo,
+                    _p_bind_infos: *const BindBufferMemoryInfo<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(bind_buffer_memory2)))
                 }
@@ -3995,7 +3995,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn bind_image_memory2(
                     _device: Device,
                     _bind_info_count: u32,
-                    _p_bind_infos: *const BindImageMemoryInfo,
+                    _p_bind_infos: *const BindImageMemoryInfo<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(bind_image_memory2)))
                 }
@@ -4070,8 +4070,8 @@ impl DeviceFnV1_1 {
             get_image_memory_requirements2: unsafe {
                 unsafe extern "system" fn get_image_memory_requirements2(
                     _device: Device,
-                    _p_info: *const ImageMemoryRequirementsInfo2,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const ImageMemoryRequirementsInfo2<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4091,8 +4091,8 @@ impl DeviceFnV1_1 {
             get_buffer_memory_requirements2: unsafe {
                 unsafe extern "system" fn get_buffer_memory_requirements2(
                     _device: Device,
-                    _p_info: *const BufferMemoryRequirementsInfo2,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const BufferMemoryRequirementsInfo2<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4112,9 +4112,9 @@ impl DeviceFnV1_1 {
             get_image_sparse_memory_requirements2: unsafe {
                 unsafe extern "system" fn get_image_sparse_memory_requirements2(
                     _device: Device,
-                    _p_info: *const ImageSparseMemoryRequirementsInfo2,
+                    _p_info: *const ImageSparseMemoryRequirementsInfo2<'_>,
                     _p_sparse_memory_requirement_count: *mut u32,
-                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4150,7 +4150,7 @@ impl DeviceFnV1_1 {
             get_device_queue2: unsafe {
                 unsafe extern "system" fn get_device_queue2(
                     _device: Device,
-                    _p_queue_info: *const DeviceQueueInfo2,
+                    _p_queue_info: *const DeviceQueueInfo2<'_>,
                     _p_queue: *mut Queue,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(get_device_queue2)))
@@ -4166,8 +4166,8 @@ impl DeviceFnV1_1 {
             create_sampler_ycbcr_conversion: unsafe {
                 unsafe extern "system" fn create_sampler_ycbcr_conversion(
                     _device: Device,
-                    _p_create_info: *const SamplerYcbcrConversionCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const SamplerYcbcrConversionCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_ycbcr_conversion: *mut SamplerYcbcrConversion,
                 ) -> Result {
                     panic!(concat!(
@@ -4189,7 +4189,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn destroy_sampler_ycbcr_conversion(
                     _device: Device,
                     _ycbcr_conversion: SamplerYcbcrConversion,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4209,8 +4209,8 @@ impl DeviceFnV1_1 {
             create_descriptor_update_template: unsafe {
                 unsafe extern "system" fn create_descriptor_update_template(
                     _device: Device,
-                    _p_create_info: *const DescriptorUpdateTemplateCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const DescriptorUpdateTemplateCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_descriptor_update_template: *mut DescriptorUpdateTemplate,
                 ) -> Result {
                     panic!(concat!(
@@ -4232,7 +4232,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn destroy_descriptor_update_template(
                     _device: Device,
                     _descriptor_update_template: DescriptorUpdateTemplate,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4274,8 +4274,8 @@ impl DeviceFnV1_1 {
             get_descriptor_set_layout_support: unsafe {
                 unsafe extern "system" fn get_descriptor_set_layout_support(
                     _device: Device,
-                    _p_create_info: *const DescriptorSetLayoutCreateInfo,
-                    _p_support: *mut DescriptorSetLayoutSupport,
+                    _p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
+                    _p_support: *mut DescriptorSetLayoutSupport<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4376,8 +4376,8 @@ impl DeviceFnV1_2 {
             create_render_pass2: unsafe {
                 unsafe extern "system" fn create_render_pass2(
                     _device: Device,
-                    _p_create_info: *const RenderPassCreateInfo2,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const RenderPassCreateInfo2<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_render_pass: *mut RenderPass,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_render_pass2)))
@@ -4394,8 +4394,8 @@ impl DeviceFnV1_2 {
             cmd_begin_render_pass2: unsafe {
                 unsafe extern "system" fn cmd_begin_render_pass2(
                     _command_buffer: CommandBuffer,
-                    _p_render_pass_begin: *const RenderPassBeginInfo,
-                    _p_subpass_begin_info: *const SubpassBeginInfo,
+                    _p_render_pass_begin: *const RenderPassBeginInfo<'_>,
+                    _p_subpass_begin_info: *const SubpassBeginInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4414,8 +4414,8 @@ impl DeviceFnV1_2 {
             cmd_next_subpass2: unsafe {
                 unsafe extern "system" fn cmd_next_subpass2(
                     _command_buffer: CommandBuffer,
-                    _p_subpass_begin_info: *const SubpassBeginInfo,
-                    _p_subpass_end_info: *const SubpassEndInfo,
+                    _p_subpass_begin_info: *const SubpassBeginInfo<'_>,
+                    _p_subpass_end_info: *const SubpassEndInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_next_subpass2)))
                 }
@@ -4430,7 +4430,7 @@ impl DeviceFnV1_2 {
             cmd_end_render_pass2: unsafe {
                 unsafe extern "system" fn cmd_end_render_pass2(
                     _command_buffer: CommandBuffer,
-                    _p_subpass_end_info: *const SubpassEndInfo,
+                    _p_subpass_end_info: *const SubpassEndInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_end_render_pass2)))
                 }
@@ -4484,7 +4484,7 @@ impl DeviceFnV1_2 {
             wait_semaphores: unsafe {
                 unsafe extern "system" fn wait_semaphores(
                     _device: Device,
-                    _p_wait_info: *const SemaphoreWaitInfo,
+                    _p_wait_info: *const SemaphoreWaitInfo<'_>,
                     _timeout: u64,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(wait_semaphores)))
@@ -4500,7 +4500,7 @@ impl DeviceFnV1_2 {
             signal_semaphore: unsafe {
                 unsafe extern "system" fn signal_semaphore(
                     _device: Device,
-                    _p_signal_info: *const SemaphoreSignalInfo,
+                    _p_signal_info: *const SemaphoreSignalInfo<'_>,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(signal_semaphore)))
                 }
@@ -4515,7 +4515,7 @@ impl DeviceFnV1_2 {
             get_buffer_device_address: unsafe {
                 unsafe extern "system" fn get_buffer_device_address(
                     _device: Device,
-                    _p_info: *const BufferDeviceAddressInfo,
+                    _p_info: *const BufferDeviceAddressInfo<'_>,
                 ) -> DeviceAddress {
                     panic!(concat!(
                         "Unable to load ",
@@ -4534,7 +4534,7 @@ impl DeviceFnV1_2 {
             get_buffer_opaque_capture_address: unsafe {
                 unsafe extern "system" fn get_buffer_opaque_capture_address(
                     _device: Device,
-                    _p_info: *const BufferDeviceAddressInfo,
+                    _p_info: *const BufferDeviceAddressInfo<'_>,
                 ) -> u64 {
                     panic!(concat!(
                         "Unable to load ",
@@ -4554,7 +4554,7 @@ impl DeviceFnV1_2 {
             get_device_memory_opaque_capture_address: unsafe {
                 unsafe extern "system" fn get_device_memory_opaque_capture_address(
                     _device: Device,
-                    _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
+                    _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo<'_>,
                 ) -> u64 {
                     panic!(concat!(
                         "Unable to load ",
@@ -4592,7 +4592,7 @@ impl InstanceFnV1_3 {
                 unsafe extern "system" fn get_physical_device_tool_properties(
                     _physical_device: PhysicalDevice,
                     _p_tool_count: *mut u32,
-                    _p_tool_properties: *mut PhysicalDeviceToolProperties,
+                    _p_tool_properties: *mut PhysicalDeviceToolProperties<'_>,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -4663,8 +4663,8 @@ impl DeviceFnV1_3 {
             create_private_data_slot: unsafe {
                 unsafe extern "system" fn create_private_data_slot(
                     _device: Device,
-                    _p_create_info: *const PrivateDataSlotCreateInfo,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_create_info: *const PrivateDataSlotCreateInfo<'_>,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                     _p_private_data_slot: *mut PrivateDataSlot,
                 ) -> Result {
                     panic!(concat!(
@@ -4685,7 +4685,7 @@ impl DeviceFnV1_3 {
                 unsafe extern "system" fn destroy_private_data_slot(
                     _device: Device,
                     _private_data_slot: PrivateDataSlot,
-                    _p_allocator: *const AllocationCallbacks,
+                    _p_allocator: *const AllocationCallbacks<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4741,7 +4741,7 @@ impl DeviceFnV1_3 {
                 unsafe extern "system" fn cmd_set_event2(
                     _command_buffer: CommandBuffer,
                     _event: Event,
-                    _p_dependency_info: *const DependencyInfo,
+                    _p_dependency_info: *const DependencyInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_set_event2)))
                 }
@@ -4774,7 +4774,7 @@ impl DeviceFnV1_3 {
                     _command_buffer: CommandBuffer,
                     _event_count: u32,
                     _p_events: *const Event,
-                    _p_dependency_infos: *const DependencyInfo,
+                    _p_dependency_infos: *const DependencyInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_wait_events2)))
                 }
@@ -4789,7 +4789,7 @@ impl DeviceFnV1_3 {
             cmd_pipeline_barrier2: unsafe {
                 unsafe extern "system" fn cmd_pipeline_barrier2(
                     _command_buffer: CommandBuffer,
-                    _p_dependency_info: *const DependencyInfo,
+                    _p_dependency_info: *const DependencyInfo<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4827,7 +4827,7 @@ impl DeviceFnV1_3 {
                 unsafe extern "system" fn queue_submit2(
                     _queue: Queue,
                     _submit_count: u32,
-                    _p_submits: *const SubmitInfo2,
+                    _p_submits: *const SubmitInfo2<'_>,
                     _fence: Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_submit2)))
@@ -4843,7 +4843,7 @@ impl DeviceFnV1_3 {
             cmd_copy_buffer2: unsafe {
                 unsafe extern "system" fn cmd_copy_buffer2(
                     _command_buffer: CommandBuffer,
-                    _p_copy_buffer_info: *const CopyBufferInfo2,
+                    _p_copy_buffer_info: *const CopyBufferInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_copy_buffer2)))
                 }
@@ -4858,7 +4858,7 @@ impl DeviceFnV1_3 {
             cmd_copy_image2: unsafe {
                 unsafe extern "system" fn cmd_copy_image2(
                     _command_buffer: CommandBuffer,
-                    _p_copy_image_info: *const CopyImageInfo2,
+                    _p_copy_image_info: *const CopyImageInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_copy_image2)))
                 }
@@ -4873,7 +4873,7 @@ impl DeviceFnV1_3 {
             cmd_copy_buffer_to_image2: unsafe {
                 unsafe extern "system" fn cmd_copy_buffer_to_image2(
                     _command_buffer: CommandBuffer,
-                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
+                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4892,7 +4892,7 @@ impl DeviceFnV1_3 {
             cmd_copy_image_to_buffer2: unsafe {
                 unsafe extern "system" fn cmd_copy_image_to_buffer2(
                     _command_buffer: CommandBuffer,
-                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
+                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4911,7 +4911,7 @@ impl DeviceFnV1_3 {
             cmd_blit_image2: unsafe {
                 unsafe extern "system" fn cmd_blit_image2(
                     _command_buffer: CommandBuffer,
-                    _p_blit_image_info: *const BlitImageInfo2,
+                    _p_blit_image_info: *const BlitImageInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_blit_image2)))
                 }
@@ -4926,7 +4926,7 @@ impl DeviceFnV1_3 {
             cmd_resolve_image2: unsafe {
                 unsafe extern "system" fn cmd_resolve_image2(
                     _command_buffer: CommandBuffer,
-                    _p_resolve_image_info: *const ResolveImageInfo2,
+                    _p_resolve_image_info: *const ResolveImageInfo2<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_resolve_image2)))
                 }
@@ -4942,7 +4942,7 @@ impl DeviceFnV1_3 {
             cmd_begin_rendering: unsafe {
                 unsafe extern "system" fn cmd_begin_rendering(
                     _command_buffer: CommandBuffer,
-                    _p_rendering_info: *const RenderingInfo,
+                    _p_rendering_info: *const RenderingInfo<'_>,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_begin_rendering)))
                 }
@@ -5257,8 +5257,8 @@ impl DeviceFnV1_3 {
             get_device_buffer_memory_requirements: unsafe {
                 unsafe extern "system" fn get_device_buffer_memory_requirements(
                     _device: Device,
-                    _p_info: *const DeviceBufferMemoryRequirements,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const DeviceBufferMemoryRequirements<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5278,8 +5278,8 @@ impl DeviceFnV1_3 {
             get_device_image_memory_requirements: unsafe {
                 unsafe extern "system" fn get_device_image_memory_requirements(
                     _device: Device,
-                    _p_info: *const DeviceImageMemoryRequirements,
-                    _p_memory_requirements: *mut MemoryRequirements2,
+                    _p_info: *const DeviceImageMemoryRequirements<'_>,
+                    _p_memory_requirements: *mut MemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -5299,9 +5299,9 @@ impl DeviceFnV1_3 {
             get_device_image_sparse_memory_requirements: unsafe {
                 unsafe extern "system" fn get_device_image_sparse_memory_requirements(
                     _device: Device,
-                    _p_info: *const DeviceImageMemoryRequirements,
+                    _p_info: *const DeviceImageMemoryRequirements<'_>,
                     _p_sparse_memory_requirement_count: *mut u32,
-                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2<'_>,
                 ) {
                     panic!(concat!(
                         "Unable to load ",

--- a/ash/src/vk/macros.rs
+++ b/ash/src/vk/macros.rs
@@ -106,12 +106,12 @@ macro_rules! handle_nondispatchable {
             }
         }
         impl fmt::Pointer for $name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "0x{:x}", self.0)
             }
         }
         impl fmt::Debug for $name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "0x{:x}", self.0)
             }
         }
@@ -149,12 +149,12 @@ macro_rules! define_handle {
             }
         }
         impl fmt::Pointer for $name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt::Pointer::fmt(&self.0, f)
             }
         }
         impl fmt::Debug for $name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt::Debug::fmt(&self.0, f)
             }
         }

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -720,7 +720,7 @@ fn main() {
                 base.draw_command_buffer,
                 base.draw_commands_reuse_fence,
                 base.present_queue,
-                &[vk::PipelineStageFlags::BOTTOM_OF_PIPE],
+                &[vk::PipelineStageFlags<'_>::BOTTOM_OF_PIPE],
                 &[base.present_complete_semaphore],
                 &[base.rendering_complete_semaphore],
                 |device, draw_command_buffer| {

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -720,7 +720,7 @@ fn main() {
                 base.draw_command_buffer,
                 base.draw_commands_reuse_fence,
                 base.present_queue,
-                &[vk::PipelineStageFlags<'_>::BOTTOM_OF_PIPE],
+                &[vk::PipelineStageFlags::BOTTOM_OF_PIPE],
                 &[base.present_complete_semaphore],
                 &[base.rendering_complete_semaphore],
                 |device, draw_command_buffer| {

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -381,7 +381,7 @@ fn main() {
                 base.draw_command_buffer,
                 base.draw_commands_reuse_fence,
                 base.present_queue,
-                &[vk::PipelineStageFlags<'_>::COLOR_ATTACHMENT_OUTPUT],
+                &[vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT],
                 &[base.present_complete_semaphore],
                 &[base.rendering_complete_semaphore],
                 |device, draw_command_buffer| {

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -381,7 +381,7 @@ fn main() {
                 base.draw_command_buffer,
                 base.draw_commands_reuse_fence,
                 base.present_queue,
-                &[vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT],
+                &[vk::PipelineStageFlags<'_>::COLOR_ATTACHMENT_OUTPUT],
                 &[base.present_complete_semaphore],
                 &[base.rendering_complete_semaphore],
                 |device, draw_command_buffer| {

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -47,9 +47,9 @@ pub fn record_submit_commandbuffer<F: FnOnce(&Device, vk::CommandBuffer)>(
     command_buffer: vk::CommandBuffer,
     command_buffer_reuse_fence: vk::Fence,
     submit_queue: vk::Queue,
-    wait_mask: &[vk::PipelineStageFlags<'_>],
-    wait_semaphores: &[vk::Semaphore<'_>],
-    signal_semaphores: &[vk::Semaphore<'_>],
+    wait_mask: &[vk::PipelineStageFlags],
+    wait_semaphores: &[vk::Semaphore],
+    signal_semaphores: &[vk::Semaphore],
     f: F,
 ) {
     unsafe {
@@ -122,8 +122,8 @@ unsafe extern "system" fn vulkan_debug_callback(
 }
 
 pub fn find_memorytype_index(
-    memory_req: &vk::MemoryRequirements<'_>,
-    memory_prop: &vk::PhysicalDeviceMemoryProperties<'_>,
+    memory_req: &vk::MemoryRequirements,
+    memory_prop: &vk::PhysicalDeviceMemoryProperties,
     flags: vk::MemoryPropertyFlags,
 ) -> Option<u32> {
     memory_prop.memory_types[..memory_prop.memory_type_count as _]

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,5 +1,11 @@
-extern crate ash;
-extern crate winit;
+#![warn(
+    clippy::use_self,
+    deprecated_in_future,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
 
 use ash::extensions::{
     ext::DebugUtils,
@@ -54,7 +60,7 @@ pub fn record_submit_commandbuffer<F: FnOnce(&Device, vk::CommandBuffer)>(
 ) {
     unsafe {
         device
-            .wait_for_fences(&[command_buffer_reuse_fence], true, std::u64::MAX)
+            .wait_for_fences(&[command_buffer_reuse_fence], true, u64::MAX)
             .expect("Wait for fence failed.");
 
         device
@@ -96,7 +102,7 @@ pub fn record_submit_commandbuffer<F: FnOnce(&Device, vk::CommandBuffer)>(
 unsafe extern "system" fn vulkan_debug_callback(
     message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,
-    p_callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT,
+    p_callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT<'_>,
     _user_data: *mut std::os::raw::c_void,
 ) -> vk::Bool32 {
     let callback_data = *p_callback_data;
@@ -355,7 +361,7 @@ impl ExampleBase {
                 desired_image_count = surface_capabilities.max_image_count;
             }
             let surface_resolution = match surface_capabilities.current_extent.width {
-                std::u32::MAX => vk::Extent2D {
+                u32::MAX => vk::Extent2D {
                     width: window_width,
                     height: window_height,
                 },
@@ -541,7 +547,7 @@ impl ExampleBase {
                 .create_semaphore(&semaphore_create_info, None)
                 .unwrap();
 
-            ExampleBase {
+            Self {
                 event_loop: RefCell::new(event_loop),
                 entry,
                 instance,

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -47,9 +47,9 @@ pub fn record_submit_commandbuffer<F: FnOnce(&Device, vk::CommandBuffer)>(
     command_buffer: vk::CommandBuffer,
     command_buffer_reuse_fence: vk::Fence,
     submit_queue: vk::Queue,
-    wait_mask: &[vk::PipelineStageFlags],
-    wait_semaphores: &[vk::Semaphore],
-    signal_semaphores: &[vk::Semaphore],
+    wait_mask: &[vk::PipelineStageFlags<'_>],
+    wait_semaphores: &[vk::Semaphore<'_>],
+    signal_semaphores: &[vk::Semaphore<'_>],
     f: F,
 ) {
     unsafe {
@@ -122,8 +122,8 @@ unsafe extern "system" fn vulkan_debug_callback(
 }
 
 pub fn find_memorytype_index(
-    memory_req: &vk::MemoryRequirements,
-    memory_prop: &vk::PhysicalDeviceMemoryProperties,
+    memory_req: &vk::MemoryRequirements<'_>,
+    memory_prop: &vk::PhysicalDeviceMemoryProperties<'_>,
     flags: vk::MemoryPropertyFlags,
 ) -> Option<u32> {
     memory_prop.memory_types[..memory_prop.memory_type_count as _]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -3011,6 +3011,19 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
             _ => continue,
         };
     }
+    for type_ in spec2
+        .0
+        .iter()
+        .filter_map(get_variant!(vk_parse::RegistryChild::Types))
+        .flat_map(|types| &types.children)
+        .filter_map(get_variant!(vk_parse::TypesChild::Type))
+    {
+        if let (Some(name), Some(alias)) = (&type_.name, &type_.alias) {
+            if has_lifetimes.contains(&name_to_tokens(alias)) {
+                has_lifetimes.insert(name_to_tokens(name));
+            }
+        }
+    }
 
     let extension_code = extensions
         .iter()


### PR DESCRIPTION
These are 3 non-default lints that cause find a lot of violations in this project that are sensible to resolve.
