### PR TITLE
gitmodules: Disable `update` to prevent cloning on cargo checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-        with:
-          submodules: true
+      - name: Checkout submodule
+        # Manually update submodules with --checkout because they are configured with update=none and will be skipped otherwise
+        run: git submodule update --recursive --init --force --checkout
       - name: Run generator
         run: cargo run -p generator
       - name: Diff autogen result

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "generator/Vulkan-Headers"]
 	path = generator/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers
+	update = none


### PR DESCRIPTION
When using a `git` reference on this repo, `cargo` will unnecessarily clone the `Vulkan-Headers` submodule (which is only needed by maintainers together with the `generator`).  By setting the update mode to `none` (https://git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-submoduleltnamegtupdate) this is disabled, and `git submodule update` will now also no longer fetch/clone/update the repository unless `--checkout` is used (https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-checkout).

I.e. running `cargo update` on a repo with a `git` dependency on `ash`:

    Updating git repository `https://github.com/ash-rs/ash`
    Skipping git submodule `https://github.com/KhronosGroup/Vulkan-Headers` due to update strategy in .gitmodules
