### PR TITLE
Enable `descriptor_count()` setter on `ash::vk::WriteDescriptorSet`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VK_NV_low_latency2` device extension (#802)
 - Added `VK_EXT_hdr_metadata` device extension (#804)
 - Added `VK_NV_cuda_kernel_launch` device extension (#805)
+- Added `descriptor_count()` setter on `ash::vk::WriteDescriptorSet` (#809)
 
 ### Changed
 

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -1835,6 +1835,11 @@ impl<'a> WriteDescriptorSet<'a> {
         self
     }
     #[inline]
+    pub fn descriptor_count(mut self, descriptor_count: u32) -> Self {
+        self.descriptor_count = descriptor_count;
+        self
+    }
+    #[inline]
     pub fn descriptor_type(mut self, descriptor_type: DescriptorType) -> Self {
         self.descriptor_type = descriptor_type;
         self

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1893,6 +1893,9 @@ fn derive_setters(
         ("VkDescriptorSetLayoutBinding", "descriptorCount"),
         // No ImageView attachments when VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT is set
         ("VkFramebufferCreateInfo", "attachmentCount"),
+        // descriptorCount also describes descriptor length in pNext extension structures
+        // https://github.com/ash-rs/ash/issues/806
+        ("VkWriteDescriptorSet", "descriptorCount"),
     ];
     let skip_members = members
         .iter()


### PR DESCRIPTION
Fixes #806

This parameter is not only used for the length of `pImageInfo`, `pBufferInfo` or `pTexelBufferView`, but also matching the value of `dataSize` when `VkWriteDescriptorSetInlineUniformBlock` is appended in `pNext`, or the value of `accelerationStructureCount` when `VkWriteDescriptorSetAccelerationStructureKHR` is in `pNext`. Having the count setter directly avaialble makes builder code more natural, instead of having to use a `mut` variable and manually assign `.descriptor_count = xx.len();` afterwards.

https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkWriteDescriptorSet.html
