### PR TITLE
Add simple dependabot config for `cargo` and `github-actions`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Even though we don't have many dependencies, our GitHub Actions are getting severely out of date and are best updated to the latest version. Let dependabot help us with this, together with the few `cargo` crate dependencies that we have (mainly in examples).
