### PR TITLE
extensions/nv/low_latency2: Use `count` parameter for `p_timings` "array" member

### DIFF
--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -4319,8 +4319,8 @@ impl<'a> PipelineMultisampleStateCreateInfo<'a> {
         self.min_sample_shading = min_sample_shading;
         self
     }
-    #[doc = r" Sets `p_sample_mask` to `null` if the slice is empty. The mask will"]
-    #[doc = r" be treated as if it has all bits set to `1`."]
+    #[doc = r" Sets [`Self::p_sample_mask`] to [`std::ptr::null()`] if the slice is empty. The"]
+    #[doc = r" mask will be treated as if it has all bits set to `1`."]
     #[doc = r""]
     #[doc = r" See <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineMultisampleStateCreateInfo.html#_description>"]
     #[doc = r" for more details."]
@@ -51890,9 +51890,22 @@ unsafe impl<'a> TaggedStructure for GetLatencyMarkerInfoNV<'a> {
     const STRUCTURE_TYPE: StructureType = StructureType::GET_LATENCY_MARKER_INFO_NV;
 }
 impl<'a> GetLatencyMarkerInfoNV<'a> {
+    #[doc = r" This only sets the slice pointer. Users must manually pass the length of"]
+    #[doc = r" `timings` to [`crate::extensions::nv::LowLatency2::get_latency_timings()`]."]
+    #[doc = r""]
+    #[doc = r" [`Self::p_timings`] will be set to to [`std::ptr::null_mut()`] if the"]
+    #[doc = r" slice is empty, which is necessary to query the length of the array via"]
+    #[doc = r" [`crate::extensions::nv::LowLatency2::get_latency_timings_len()`]."]
+    #[doc = r""]
+    #[doc = r" See <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetLatencyTimingsNV.html#_description>"]
+    #[doc = r" for more details."]
     #[inline]
-    pub fn timings(mut self, timings: &'a mut LatencyTimingsFrameReportNV<'a>) -> Self {
-        self.p_timings = timings;
+    pub fn timings(mut self, timings: &'a mut [LatencyTimingsFrameReportNV<'a>]) -> Self {
+        self.p_timings = if timings.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            timings.as_mut_ptr()
+        };
         self
     }
 }


### PR DESCRIPTION
Fixes #814, CC @repi @vzout

As it turns out this extension has a rather suboptimal layout where the `vk::GetLatencyMarkerInfoNV` struct is not aware that its own `p_timings` field is an array, because it does not have a count field. Instead the length of this array is passed around via the `pTimingCount` pointer parameter of `get_latency_timings()`.

A couple things are needed to set this straight:
1. The struct builder must be adjusted to accept a slice (without storing the length anywhere...);
2. The `get_latency_timings()` wrapper function should no longer accept a mutable slice of `vk::GetLatencyMarkerInfoNV`, but instead accept a single object that contains a pointer to the array (and `p_next`...);
3. This function must have a separate parameter to pass the length of the `p_timings` slice mentioned at 1., as we cannot reconstruct it from `vk::GetLatencyMarkerInfoNV` nor via its `p_timings` pointer;
4. The mutable struct and initialized `p_timings` array must still be passed fully by the user because both `vk::GetLatencyMarkerInfoNV` and `vk::LatencyTimingsFrameReportNV` have a `p_next` field that the user could initialize to point to some extension structure that they desire to be filled in.  This info might also be relevant in the `_len()` query;
5. Asserts have been put in place to ensure correct use of this API with regards to `p_timings` being (not) NULL for querying the count or actual values, respectively.
