### PR TITLE
Bump `libloading` to `0.8`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VK_EXT_hdr_metadata` device extension (#804)
 - Added `VK_NV_cuda_kernel_launch` device extension (#805)
 - Added `descriptor_count()` setter on `ash::vk::WriteDescriptorSet` (#809)
+- Bumped `libloading` crate dependency to 0.8
 
 ### Changed
 

--- a/ash-rewrite/Cargo.toml
+++ b/ash-rewrite/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 rust-version = "1.60.0"
 
 [dependencies]
-libloading = { version = "0.7", optional = true }
+libloading = { version = "0.8", optional = true }
 
 [features]
 default = ["loaded", "debug"]

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.60.0"
 
 [dependencies]
-libloading = { version = "0.7", optional = true }
+libloading = { version = "0.8", optional = true }
 
 [features]
 default = ["loaded", "debug"]


### PR DESCRIPTION
Main motivation is that in my projects, many dependencies use windows-sys to interface Windows API so and only ash keeps using `winapi` crate because of libloading. Libloading 0.8 switched to `windows-sys` so problem solved.