### PR TITLE
Update repository links and crate keywords/categories

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -435,20 +435,20 @@ flags: vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER_BIT,
 - `ash::util::Align` is a helper struct that
   can write to aligned memory.
 
-[Unreleased]: https://github.com/MaikKlein/ash/compare/0.37.2...HEAD
-[0.37.2]: https://github.com/MaikKlein/ash/releases/tag/0.37.2
-[0.37.1]: https://github.com/MaikKlein/ash/releases/tag/0.37.1
-[0.37.0]: https://github.com/MaikKlein/ash/releases/tag/0.37.0
-[0.36.0]: https://github.com/MaikKlein/ash/releases/tag/0.36.0
-[0.35.2]: https://github.com/MaikKlein/ash/releases/tag/0.35.2
-[0.35.1]: https://github.com/MaikKlein/ash/releases/tag/0.35.1
-[0.35.0]: https://github.com/MaikKlein/ash/releases/tag/0.35.0
-[0.34.0]: https://github.com/MaikKlein/ash/releases/tag/0.34.0
-[0.33.3]: https://github.com/MaikKlein/ash/releases/tag/0.33.3
-[0.33.2]: https://github.com/MaikKlein/ash/releases/tag/0.33.2
-[0.33.1]: https://github.com/MaikKlein/ash/releases/tag/0.33.1
-[0.33.0]: https://github.com/MaikKlein/ash/releases/tag/0.33.0
-[0.32.1]: https://github.com/MaikKlein/ash/releases/tag/0.32.1
-[0.32.0]: https://github.com/MaikKlein/ash/releases/tag/0.32.0
-[0.31.0]: https://github.com/MaikKlein/ash/releases/tag/0.31.0
-[0.30.0]: https://github.com/MaikKlein/ash/releases/tag/0.30.0
+[Unreleased]: https://github.com/ash-rs/ash/compare/0.37.2...HEAD
+[0.37.2]: https://github.com/ash-rs/ash/releases/tag/0.37.2
+[0.37.1]: https://github.com/ash-rs/ash/releases/tag/0.37.1
+[0.37.0]: https://github.com/ash-rs/ash/releases/tag/0.37.0
+[0.36.0]: https://github.com/ash-rs/ash/releases/tag/0.36.0
+[0.35.2]: https://github.com/ash-rs/ash/releases/tag/0.35.2
+[0.35.1]: https://github.com/ash-rs/ash/releases/tag/0.35.1
+[0.35.0]: https://github.com/ash-rs/ash/releases/tag/0.35.0
+[0.34.0]: https://github.com/ash-rs/ash/releases/tag/0.34.0
+[0.33.3]: https://github.com/ash-rs/ash/releases/tag/0.33.3
+[0.33.2]: https://github.com/ash-rs/ash/releases/tag/0.33.2
+[0.33.1]: https://github.com/ash-rs/ash/releases/tag/0.33.1
+[0.33.0]: https://github.com/ash-rs/ash/releases/tag/0.33.0
+[0.32.1]: https://github.com/ash-rs/ash/releases/tag/0.32.1
+[0.32.0]: https://github.com/ash-rs/ash/releases/tag/0.32.0
+[0.31.0]: https://github.com/ash-rs/ash/releases/tag/0.31.0
+[0.30.0]: https://github.com/ash-rs/ash/releases/tag/0.30.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A very lightweight wrapper around Vulkan
 
 [![Crates.io Version](https://img.shields.io/crates/v/ash.svg)](https://crates.io/crates/ash)
 [![Documentation](https://docs.rs/ash/badge.svg)](https://docs.rs/ash)
-[![Build Status](https://github.com/MaikKlein/ash/workflows/CI/badge.svg)](https://github.com/MaikKlein/ash/actions?workflow=CI)
+[![Build Status](https://github.com/ash-rs/ash/workflows/CI/badge.svg)](https://github.com/ash-rs/ash/actions?workflow=CI)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE-APACHE)
 [![Join the chat at https://gitter.im/MaikKlein/ash](https://badges.gitter.im/MaikKlein/ash.svg)](https://gitter.im/MaikKlein/ash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -145,7 +145,7 @@ Custom loaders can be implemented.
 
 ### Extension loading
 
-Additionally, every Vulkan extension has to be loaded explicitly. You can find all extensions under [ash::extensions](https://github.com/MaikKlein/ash/tree/master/ash/src/extensions).
+Additionally, every Vulkan extension has to be loaded explicitly. You can find all extensions under [`ash::extensions`](https://github.com/ash-rs/ash/tree/master/ash/src/extensions).
 
 ```rust
 use ash::extensions::khr::Swapchain;
@@ -195,7 +195,7 @@ If, on the other hand, your application cannot handle Vulkan being missing at ru
 
 ## Example
 
-You can find the examples [here](https://github.com/MaikKlein/ash/tree/master/examples).
+You can find the examples [here](https://github.com/ash-rs/ash/tree/master/examples).
 All examples currently require: the LunarG Validation layers and a Vulkan library that is visible in your `PATH`. An easy way to get started is to use the [LunarG Vulkan SDK](https://lunarg.com/vulkan-sdk/)
 
 #### Windows
@@ -218,7 +218,7 @@ VK_LAYER_PATH=$VULKAN_SDK/share/vulkan/explicit_layer.d \
 cargo run ...
 ```
 
-### [Triangle](https://github.com/MaikKlein/ash/blob/master/examples/src/bin/triangle.rs)
+### [Triangle](https://github.com/ash-rs/ash/blob/master/examples/src/bin/triangle.rs)
 
 Displays a triangle with vertex colors.
 
@@ -229,7 +229,7 @@ cargo run --bin triangle
 
 ![screenshot](http://i.imgur.com/PQZcL6w.jpg)
 
-### [Texture](https://github.com/MaikKlein/ash/blob/master/examples/src/bin/texture.rs)
+### [Texture](https://github.com/ash-rs/ash/blob/master/examples/src/bin/texture.rs)
 
 Displays a texture on a quad.
 
@@ -252,7 +252,7 @@ cargo run --bin texture
 
 - [vk-sync](https://github.com/gwihlidal/vk-sync-rs) - Simplified Vulkan synchronization logic, written in rust.
 - [vk-mem-rs](https://github.com/gwihlidal/vk-mem-rs) - This crate provides an FFI layer and idiomatic rust wrappers for the excellent AMD Vulkan Memory Allocator (VMA) C/C++ library.
-- [gpu-allocator](https://github.com/Traverse-Research/gpu-allocator) - Memory allocator written in pure Rust for GPU memory in Vulkan and in the future DirectX 12
+- [gpu-allocator](https://github.com/Traverse-Research/gpu-allocator) - GPU Memory allocator written in pure Rust for Vulkan and DirectX 12.
 - [lahar](https://github.com/Ralith/lahar) - Tools for asynchronously uploading data to a Vulkan device.
 
 ### Libraries that use ash

--- a/ash-rewrite/Cargo.toml
+++ b/ash-rewrite/Cargo.toml
@@ -9,10 +9,12 @@ readme = "../README.md"
 keywords = ["gamedev", "graphics", "vulkan", "bindings"]
 categories = [
     "api-bindings",
+    "external-ffi-bindings",
     "game-development",
     "graphics",
     "rendering::graphics-api",
 ]
+# TODO: Remove when crate is renamed, this is the default
 documentation = "https://docs.rs/ash"
 edition = "2021"
 # TODO: reevaluate, then update in ci.yml

--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "ash-window"
 version = "0.12.0"
-authors = ["msiglreith <m.siglreith@gmail.com>"]
+authors = [
+    "msiglreith <m.siglreith@gmail.com>",
+    "Marijn Suijten <marijn@traverseresearch.nl>",
+]
 license = "MIT OR Apache-2.0"
 description = "Interop library between ash and raw-window-handle"
-documentation = "https://docs.rs/ash-window"
-repository = "https://github.com/MaikKlein/ash"
-readme = "README.md"
-keywords = ["window", "ash", "graphics"]
-categories = ["game-engines", "graphics"]
-exclude = [".github/*"]
-workspace = ".."
+repository = "https://github.com/ash-rs/ash"
+keywords = ["windowing", "ash", "graphics", "vulkan", "raw-window-handle"]
+categories = [
+    "api-bindings",
+    "game-development",
+    "graphics",
+    "rendering::graphics-api"
+]
 edition = "2021"
 rust-version = "1.64.0"
 

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -21,38 +21,38 @@
 
 ### Changed
 
-- Bumped `ash` version to [`0.37`](https://github.com/MaikKlein/ash/releases/tag/0.37.0) (#600)
+- Bumped `ash` version to [`0.37`](https://github.com/ash-rs/ash/releases/tag/0.37.0) (#600)
 - Make `enumerate_required_extensions()` return `&[*const c_char]` instead of `Vec<&CStr>` to match `ash::vk::InstanceCreateInfo` (#590)
 
 ## [0.9.1] - 2022-02-21
 
 ### Changed
 
-- Convert `ash` version to a range, allowing [`0.34`](https://github.com/MaikKlein/ash/releases/tag/0.34.0)-[`0.36`](https://github.com/MaikKlein/ash/releases/tag/0.36.0) (#585)
+- Convert `ash` version to a range, allowing [`0.34`](https://github.com/ash-rs/ash/releases/tag/0.34.0)-[`0.36`](https://github.com/ash-rs/ash/releases/tag/0.36.0) (#585)
 
 ## [0.9.0] - 2021-12-27
 
 ### Changed
 
-- Bumped `ash` version to [`0.35`](https://github.com/MaikKlein/ash/releases/tag/0.35.0)
+- Bumped `ash` version to [`0.35`](https://github.com/ash-rs/ash/releases/tag/0.35.0)
 
 ## [0.8.0] - 2021-12-22
 
 ### Changed
 
-- Bumped `ash` version to [`0.34`](https://github.com/MaikKlein/ash/releases/tag/0.34.0)
+- Bumped `ash` version to [`0.34`](https://github.com/ash-rs/ash/releases/tag/0.34.0)
 
 ## [0.7.0] - 2021-07-30
 
 ### Changed
 
-- Bumped `ash` version to [`0.33`](https://github.com/MaikKlein/ash/releases/tag/0.33.0)
+- Bumped `ash` version to [`0.33`](https://github.com/ash-rs/ash/releases/tag/0.33.0)
 
 ## [0.6.0]
 
 ### Changed
 
-- Bumped `ash` version to [`0.32`](https://github.com/MaikKlein/ash/releases/tag/0.32.0)
+- Bumped `ash` version to [`0.32`](https://github.com/ash-rs/ash/releases/tag/0.32.0)
 
 ## [0.5.0]
 
@@ -85,13 +85,13 @@
 ## Version 0.1.0
 Initial release for `raw-window-handle = "0.3"` with Windows, Linux, Android, MacOS/iOS support.
 
-[Unreleased]: https://github.com/MaikKlein/ash/compare/ash-window-0.12.0...HEAD
-[0.12.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.12.0
-[0.11.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.11.0
-[0.10.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.10.0
-[0.9.1]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.9.1
-[0.9.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.9.0
-[0.8.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.8.0
-[0.7.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.7.0
-[0.6.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.6.0
-[0.5.0]: https://github.com/MaikKlein/ash/releases/tag/ash-window-0.5.0
+[Unreleased]: https://github.com/ash-rs/ash/compare/ash-window-0.12.0...HEAD
+[0.12.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.12.0
+[0.11.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.11.0
+[0.10.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.10.0
+[0.9.1]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.9.1
+[0.9.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.9.0
+[0.8.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.8.0
+[0.7.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.7.0
+[0.6.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.6.0
+[0.5.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.5.0

--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -1,10 +1,10 @@
 ## Ash-window
 
-Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
+Interoperability between [`ash`](https://github.com/ash-rs/ash) and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
 
 [![Crates.io Version](https://img.shields.io/crates/v/ash-window.svg)](https://crates.io/crates/ash-window)
 [![Documentation](https://docs.rs/ash-window/badge.svg)](https://docs.rs/ash-window)
-[![Build Status](https://github.com/MaikKlein/ash/workflows/CI/badge.svg)](https://github.com/MaikKlein/ash/actions?workflow=CI)
+[![Build Status](https://github.com/ash-rs/ash/workflows/CI/badge.svg)](https://github.com/ash-rs/ash/actions?workflow=CI)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
 [![Join the chat at https://gitter.im/MaikKlein/ash](https://badges.gitter.im/MaikKlein/ash.svg)](https://gitter.im/MaikKlein/ash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -8,10 +8,16 @@ authors = [
 ]
 description = "Vulkan bindings for Rust"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/MaikKlein/ash"
+repository = "https://github.com/ash-rs/ash"
 readme = "../README.md"
-keywords = ["vulkan", "graphic"]
-documentation = "https://docs.rs/ash"
+keywords = ["gamedev", "graphics", "vulkan", "bindings"]
+categories = [
+    "api-bindings",
+    "external-ffi-bindings",
+    "game-development",
+    "graphics",
+    "rendering::graphics-api"
+]
 edition = "2021"
 rust-version = "1.60.0"
 

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -117,7 +117,7 @@ pub fn read_spv<R: io::Read + io::Seek>(x: &mut R) -> io::Result<Vec<u32>> {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "input too long"));
     }
     let words = (size / 4) as usize;
-    // https://github.com/MaikKlein/ash/issues/354:
+    // https://github.com/ash-rs/ash/issues/354:
     // Zero-initialize the result to prevent read_exact from possibly
     // reading uninitialized memory.
     let mut result = vec![0u32; words];


### PR DESCRIPTION
Some links were still pointing to the (moved) `MaikKlein/ash` repo, instead of the new shared `ash-rs/ash` repository under this organisation, GitHub still provides a redirect, but we should aim to provide the correct link from the get-go.  Only the gitter channel remains as it was impossible to get the room to be renamed.  The `ash-rs/ash` channel exists but there is currently no activity.

---

We should probably also seek to update some other external project links like the NV raytracing example, now that it has been deprecated and superseded for a while.
