### PR TITLE
extensions/khr/ray_tracing_pipeline: Pass indirect SBT regions as single item

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VK_KHR_device_group_creation`: Take borrow of `Entry` in `fn new()` (#753)
 - `VK_KHR_device_group_creation`: Rename `vk::Instance`-returning function from `device()` to `instance()` (#759)
 - Windows `HANDLE` types (`HWND`, `HINSTANCE`, `HMONITOR`) are now defined as `isize` instead of `*const c_void` (#797)
+- extensions/ext/ray_tracing_pipeline: Pass indirect SBT regions as single item reference. (#829)
 
 ### Removed
 

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -122,18 +122,18 @@ impl RayTracingPipeline {
     pub unsafe fn cmd_trace_rays_indirect(
         &self,
         command_buffer: vk::CommandBuffer,
-        raygen_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
-        miss_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
-        hit_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
-        callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
+        raygen_shader_binding_table: &vk::StridedDeviceAddressRegionKHR,
+        miss_shader_binding_table: &vk::StridedDeviceAddressRegionKHR,
+        hit_shader_binding_table: &vk::StridedDeviceAddressRegionKHR,
+        callable_shader_binding_table: &vk::StridedDeviceAddressRegionKHR,
         indirect_device_address: vk::DeviceAddress,
     ) {
         (self.fp.cmd_trace_rays_indirect_khr)(
             command_buffer,
-            raygen_shader_binding_table.as_ptr(),
-            miss_shader_binding_table.as_ptr(),
-            hit_shader_binding_table.as_ptr(),
-            callable_shader_binding_table.as_ptr(),
+            raygen_shader_binding_table,
+            miss_shader_binding_table,
+            hit_shader_binding_table,
+            callable_shader_binding_table,
             indirect_device_address,
         );
     }


### PR DESCRIPTION
In an identical fashion to commit 84624fd ("ray_tracing_pipeline: Pass SBT regions as reference instead of slice (#350)") `cmd_trace_rays_indirect()` also only needs a pointer to a single `StridedDeviceAddressRegionKHR` structure.  After all no length is ever passed to the API anywhere, and this could also lead to users passing empty slices, or passing too many elements that are never used.

Clear up the confusion by replacing the slice argument with a direct borrow of the struct.
