### PR TITLE
Updated: raw-window-handle & winit

### DIFF
--- a/ash-examples/Cargo.toml
+++ b/ash-examples/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 image = "0.24"
-raw-window-handle = "0.5"
-winit = "0.28.0"
+raw-window-handle = "0.6"
+winit = "0.29.4"
 # The examples require the validation layers, which means the SDK or
 # equivalent development packages should be present, so we can link
 # directly and benefit from the infallible `Entry` constructor.

--- a/ash-examples/src/bin/texture.rs
+++ b/ash-examples/src/bin/texture.rs
@@ -7,6 +7,7 @@ use std::os::raw::c_void;
 use ash::util::*;
 use ash::vk;
 use ash_examples::*;
+use winit::event_loop::EventLoop;
 
 #[derive(Clone, Debug, Copy)]
 struct Vertex {
@@ -23,8 +24,9 @@ pub struct Vector3 {
 }
 
 fn main() {
+    let event_loop = EventLoop::new().unwrap();
     unsafe {
-        let base = ExampleBase::new(1920, 1080);
+        let base = ExampleBase::new(1920, 1080, &event_loop);
 
         let renderpass_attachments = [
             vk::AttachmentDescription {
@@ -684,7 +686,7 @@ fn main() {
 
         let graphic_pipeline = graphics_pipelines[0];
 
-        base.render_loop(|| {
+        base.render_loop(event_loop,|| {
             let (present_index, _) = base
                 .swapchain_loader
                 .acquire_next_image(
@@ -780,11 +782,11 @@ fn main() {
             base.swapchain_loader
                 .queue_present(base.present_queue, &present_info)
                 .unwrap();
-        });
-        base.device.device_wait_idle().unwrap();
+        }, ||{
+            base.device.device_wait_idle().unwrap();
 
-        for pipeline in graphics_pipelines {
-            base.device.destroy_pipeline(pipeline, None);
+        for pipeline in &graphics_pipelines {
+            base.device.destroy_pipeline(*pipeline, None);
         }
         base.device.destroy_pipeline_layout(pipeline_layout, None);
         base.device
@@ -808,9 +810,11 @@ fn main() {
         }
         base.device.destroy_descriptor_pool(descriptor_pool, None);
         base.device.destroy_sampler(sampler, None);
-        for framebuffer in framebuffers {
-            base.device.destroy_framebuffer(framebuffer, None);
+        for framebuffer in &framebuffers {
+            base.device.destroy_framebuffer(*framebuffer, None);
         }
         base.device.destroy_render_pass(renderpass, None);
+        });
+        
     }
 }

--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -20,13 +20,13 @@ rust-version = "1.64.0"
 
 [dependencies]
 ash = { path = "../ash", version = "0.37", default-features = false }
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 raw-window-metal = "0.3"
 
 [dev-dependencies]
-winit = "0.28.0"
+winit = "0.29.4"
 ash = { path = "../ash", version = "0.37", default-features = false, features = ["linked"] }
 
 [[example]]


### PR DESCRIPTION
Not my finest work.
This pull request updates the following dependencies:
raw-window-handle = "0.6"
winit = "0.29.4"

I'm aware of a pull request to update raw-window-handle to 0.6, (after I was done with this pull request >_>)
This pull request also updates the latest Winit version.

I ran and tested the code, on exit it outputs "zwp_linux_dmabuf_v1@38 still attached".
This is a improvement over the dozen Wayland warnings it gives using the current git master Winit version.

Please validate for correctness.