### PR TITLE
generator: Work around invariance for assigning mutable pointer of lifetimed slice

### DIFF
--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -52045,9 +52045,9 @@ unsafe impl<'a> TaggedStructure for GetLatencyMarkerInfoNV<'a> {
 }
 impl<'a> GetLatencyMarkerInfoNV<'a> {
     #[inline]
-    pub fn timings(mut self, timings: &'a mut [LatencyTimingsFrameReportNV<'a>]) -> Self {
+    pub fn timings(mut self, timings: &'a mut [LatencyTimingsFrameReportNV<'_>]) -> Self {
         self.timing_count = timings.len() as _;
-        self.p_timings = timings.as_mut_ptr();
+        self.p_timings = timings.as_mut_ptr().cast();
         self
     }
 }


### PR DESCRIPTION
Fixes #837

@Ralith I'm in quite a hurry but managed to piece together a rather minimal generator change to solve the issue, but probably did a **horrible** job of understanding, summarizing and re-explaining the issues with variance.  Feel free to suggest something better, otherwise I'll revisit it when I return.

---

In essence this builder function needs to adhere to two rules:
1. No ref-after-free: the slice must outlive (uses of) the builder object;
2. No aliasing: the slice cannot be (im)mutably used while it is mutably borrowed within a live builder object.

These two rules have been tested and are satisfied by the given builder implementation.  Without this change `timings` seems to be borrowing itself, hence is not allowed to be used after it has been temporarily mutably borrowed inside the builder, even after that builder was dropped.  Thus defeating the purpose of this "getter" API via a struct.

Without the `.cast()`, because mutable raw pointers are invariant (i.e. there is no subtyping relationship) the compiler complains about requiring `self` to outlive `timings` instead, which does not satisfy the two rules above.
