### PR TITLE
device,instance: Provide `load_with()` constructor for get_proc_addr closure

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `descriptor_count()` setter on `ash::vk::WriteDescriptorSet` (#809)
 - Added `*_as_c_str()` getters for `c_char` pointers and `c_char` arrays (#831)
 - Added `#[must_use]` to Vulkan structs to make it more clear that they are moved by the builder pattern (#845)
+- Added `load_with()` function on `Device` and `Instance` for providing custom `get_xxx_proc_addr()` implementations (#846)
 - Added `Send`/`Sync` to all Vulkan structs (#869)
 
 ### Changed


### PR DESCRIPTION
While working on a GStreamer Vulkan interop example (where GStreamer-Vulkan opens the ICD and creates most objects for us, which need to be imported in an `ash::Instance` and `ash::Device`), it wasn't feasible to construct a `vk::EntryFnV1_0` and `vk::InstanceFnV1_0` with `extern` functions while keeping object data in some global static, especially `vk::InstanceFnV1_0` which contains many more functions that are not consumed by `Instance::load()`. GStreamer provides function loaders directly on its `GstVulkanInstance` and `GstVulkanDevice` which are desired to be used rather than attempting to open the same ICD and loading the same functions by hand.
The  original `Device::load()` and `Instance::load()` already create a closure internally, which is exactly what we need to expose to have a single callback that can hold the `&gst_vulkan::VulkanInstance/Device` state, and respond to a char-pointer name with a function pointer.

Note that this doesn't map very clearly to `Entry`, where the `load()` constructor is named `from_static_fn()` and a closure signature is equally lacking.
