### PR TITLE
Fix Rust 1.75 clippy lints

### DIFF
--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -5,7 +5,6 @@
 )]
 #[macro_use]
 mod macros;
-pub use macros::*;
 mod aliases;
 pub use aliases::*;
 mod bitflags;
@@ -21,7 +20,6 @@ pub use enums::*;
 mod extensions;
 pub use extensions::*;
 mod feature_extensions;
-pub use feature_extensions::*;
 mod features;
 pub use features::*;
 mod prelude;

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -566,7 +566,7 @@ pub trait CommandExt {
 
 impl CommandExt for vk_parse::CommandDefinition {
     fn function_type(&self) -> FunctionType {
-        let is_first_param_device = self.params.get(0).map_or(false, |field| {
+        let is_first_param_device = self.params.first().map_or(false, |field| {
             matches!(
                 field.definition.type_name.as_deref(),
                 Some("VkDevice" | "VkCommandBuffer" | "VkQueue")


### PR DESCRIPTION
Rust 1.75 has once again gotten a bit more complete/strict when linting code.  `.get(0)` is now recommended to be replaced with `.first()`, and needless glob reexports are equally denied (the modules in question either contain macros which are already reexported via `#[macro_export]`, or contain `impl` blocks exclusively which cannot be referred to as item paths either).
