### PR TITLE
Don't check MSRV for ash-examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
       - run: cargo check --workspace --all-targets --all-features
 
   check_msrv:
-    name: Check ash and ash-window MSRV (1.69.0)
+    name: Check ash, ash-window and ash-rewrite MSRV (1.69.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.69.0
-      - run: cargo check -p ash -p ash-rewrite -p ash-window -p ash-examples --all-features
+      - run: cargo check -p ash -p ash-rewrite -p ash-window --all-features
 
   # TODO: add a similar job for the rewrite once that generates code
   generated:


### PR DESCRIPTION
ash-examples has a lot of dependencies (mostly through winit), and so it's not unlikely for it to break the MSRV check. Here's the current CI error:
```
error: package `half v2.4.0` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.69.0
Either upgrade to rustc 1.70 or newer, or use
cargo update -p half@2.4.0 --precise ver
where `ver` is the latest version of `half` supporting rustc 1.69.0
```

It doesn't make much sense to have our MSRV influenced by it IMO.