### PR TITLE
Provide mutable access to function-pointer tables

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -63,6 +63,11 @@ impl Device {
         &self.device_fn_1_3
     }
 
+    #[inline]
+    pub unsafe fn fp_v1_3_mut(&mut self) -> &mut vk::DeviceFnV1_3 {
+        &mut self.device_fn_1_3
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreatePrivateDataSlot.html>
     #[inline]
     pub unsafe fn create_private_data_slot(
@@ -553,6 +558,11 @@ impl Device {
         &self.device_fn_1_2
     }
 
+    #[inline]
+    pub unsafe fn fp_v1_2_mut(&mut self) -> &mut vk::DeviceFnV1_2 {
+        &mut self.device_fn_1_2
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdDrawIndirectCount.html>
     #[inline]
     pub unsafe fn cmd_draw_indirect_count(
@@ -731,6 +741,11 @@ impl Device {
     #[inline]
     pub fn fp_v1_1(&self) -> &vk::DeviceFnV1_1 {
         &self.device_fn_1_1
+    }
+
+    #[inline]
+    pub unsafe fn fp_v1_1_mut(&mut self) -> &mut vk::DeviceFnV1_1 {
+        &mut self.device_fn_1_1
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkBindBufferMemory2.html>
@@ -977,6 +992,11 @@ impl Device {
     #[inline]
     pub fn fp_v1_0(&self) -> &vk::DeviceFnV1_0 {
         &self.device_fn_1_0
+    }
+
+    #[inline]
+    pub unsafe fn fp_v1_0_mut(&mut self) -> &mut vk::DeviceFnV1_0 {
+        &mut self.device_fn_1_0
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyDevice.html>

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -193,8 +193,18 @@ impl Entry {
     }
 
     #[inline]
+    pub unsafe fn fp_v1_0_mut(&mut self) -> &mut vk::EntryFnV1_0 {
+        &mut self.entry_fn_1_0
+    }
+
+    #[inline]
     pub fn static_fn(&self) -> &vk::StaticFn {
         &self.static_fn
+    }
+
+    #[inline]
+    pub unsafe fn static_fn_mut(&mut self) -> &mut vk::StaticFn {
+        &mut self.static_fn
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkEnumerateInstanceVersion.html>
@@ -302,6 +312,11 @@ impl Entry {
     #[inline]
     pub fn fp_v1_1(&self) -> &vk::EntryFnV1_1 {
         &self.entry_fn_1_1
+    }
+
+    #[inline]
+    pub unsafe fn fp_v1_1_mut(&mut self) -> &mut vk::EntryFnV1_1 {
+        &mut self.entry_fn_1_1
     }
 
     #[deprecated = "This function is unavailable and therefore panics on Vulkan 1.0, please use `try_enumerate_instance_version()` instead"]

--- a/ash/src/extensions/amd/buffer_marker.rs
+++ b/ash/src/extensions/amd/buffer_marker.rs
@@ -42,4 +42,9 @@ impl BufferMarker {
     pub fn fp(&self) -> &vk::AmdBufferMarkerFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::AmdBufferMarkerFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/amd/shader_info.rs
+++ b/ash/src/extensions/amd/shader_info.rs
@@ -72,6 +72,11 @@ impl ShaderInfo {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::AmdShaderInfoFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -124,6 +124,11 @@ impl ShaderEnqueue {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::AmdxShaderEnqueueFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
+++ b/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
@@ -50,6 +50,11 @@ impl ExternalMemoryAndroidHardwareBuffer {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::AndroidExternalMemoryAndroidHardwareBufferFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/acquire_drm_display.rs
+++ b/ash/src/extensions/ext/acquire_drm_display.rs
@@ -49,4 +49,9 @@ impl AcquireDrmDisplay {
     pub fn fp(&self) -> &vk::ExtAcquireDrmDisplayFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtAcquireDrmDisplayFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/buffer_device_address.rs
+++ b/ash/src/extensions/ext/buffer_device_address.rs
@@ -35,6 +35,11 @@ impl BufferDeviceAddress {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtBufferDeviceAddressFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -65,6 +65,11 @@ impl CalibratedTimestamps {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtCalibratedTimestampsFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -62,6 +62,11 @@ impl DebugMarker {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtDebugMarkerFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -59,6 +59,11 @@ impl DebugReport {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtDebugReportFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -142,6 +142,11 @@ impl DebugUtils {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtDebugUtilsFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/ext/descriptor_buffer.rs
+++ b/ash/src/extensions/ext/descriptor_buffer.rs
@@ -202,6 +202,11 @@ impl DescriptorBuffer {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtDescriptorBufferFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -190,4 +190,9 @@ impl ExtendedDynamicState {
     pub fn fp(&self) -> &vk::ExtExtendedDynamicStateFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtExtendedDynamicStateFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/extended_dynamic_state2.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state2.rs
@@ -79,4 +79,9 @@ impl ExtendedDynamicState2 {
     pub fn fp(&self) -> &vk::ExtExtendedDynamicState2Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtExtendedDynamicState2Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/extended_dynamic_state3.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state3.rs
@@ -403,4 +403,9 @@ impl ExtendedDynamicState3 {
     pub fn fp(&self) -> &vk::ExtExtendedDynamicState3Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtExtendedDynamicState3Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -77,6 +77,11 @@ impl FullScreenExclusive {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtFullScreenExclusiveFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/hdr_metadata.rs
+++ b/ash/src/extensions/ext/hdr_metadata.rs
@@ -43,6 +43,11 @@ impl HdrMetadata {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtHdrMetadataFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/headless_surface.rs
+++ b/ash/src/extensions/ext/headless_surface.rs
@@ -46,6 +46,11 @@ impl HeadlessSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtHeadlessSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/ext/host_image_copy.rs
+++ b/ash/src/extensions/ext/host_image_copy.rs
@@ -91,6 +91,11 @@ impl HostImageCopy {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtHostImageCopyFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/image_compression_control.rs
+++ b/ash/src/extensions/ext/image_compression_control.rs
@@ -49,6 +49,11 @@ impl ImageCompressionControl {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtImageCompressionControlFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/image_drm_format_modifier.rs
+++ b/ash/src/extensions/ext/image_drm_format_modifier.rs
@@ -39,6 +39,11 @@ impl ImageDrmFormatModifier {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtImageDrmFormatModifierFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/mesh_shader.rs
+++ b/ash/src/extensions/ext/mesh_shader.rs
@@ -88,4 +88,9 @@ impl MeshShader {
     pub fn fp(&self) -> &vk::ExtMeshShaderFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtMeshShaderFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -45,6 +45,11 @@ impl MetalSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtMetalSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/ext/pipeline_properties.rs
+++ b/ash/src/extensions/ext/pipeline_properties.rs
@@ -43,6 +43,11 @@ impl PipelineProperties {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtPipelinePropertiesFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/private_data.rs
+++ b/ash/src/extensions/ext/private_data.rs
@@ -96,6 +96,11 @@ impl PrivateData {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtPrivateDataFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/sample_locations.rs
+++ b/ash/src/extensions/ext/sample_locations.rs
@@ -48,4 +48,9 @@ impl SampleLocations {
     pub fn fp(&self) -> &vk::ExtSampleLocationsFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtSampleLocationsFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -709,6 +709,11 @@ impl ShaderObject {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtShaderObjectFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/swapchain_maintenance1.rs
+++ b/ash/src/extensions/ext/swapchain_maintenance1.rs
@@ -37,6 +37,11 @@ impl SwapchainMaintenance1 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtSwapchainMaintenance1Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -34,4 +34,9 @@ impl ToolingInfo {
     pub fn fp(&self) -> &vk::ExtToolingInfoFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtToolingInfoFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/ext/vertex_input_dynamic_state.rs
+++ b/ash/src/extensions/ext/vertex_input_dynamic_state.rs
@@ -40,4 +40,9 @@ impl VertexInputDynamicState {
     pub fn fp(&self) -> &vk::ExtVertexInputDynamicStateFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::ExtVertexInputDynamicStateFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/google/display_timing.rs
+++ b/ash/src/extensions/google/display_timing.rs
@@ -50,6 +50,11 @@ impl DisplayTiming {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::GoogleDisplayTimingFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -296,6 +296,11 @@ impl AccelerationStructure {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrAccelerationStructureFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -45,6 +45,11 @@ impl AndroidSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrAndroidSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/buffer_device_address.rs
+++ b/ash/src/extensions/khr/buffer_device_address.rs
@@ -53,6 +53,11 @@ impl BufferDeviceAddress {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrBufferDeviceAddressFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/cooperative_matrix.rs
+++ b/ash/src/extensions/khr/cooperative_matrix.rs
@@ -42,4 +42,9 @@ impl CooperativeMatrix {
     pub fn fp(&self) -> &vk::KhrCooperativeMatrixFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrCooperativeMatrixFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/copy_commands2.rs
+++ b/ash/src/extensions/khr/copy_commands2.rs
@@ -78,4 +78,9 @@ impl CopyCommands2 {
     pub fn fp(&self) -> &vk::KhrCopyCommands2Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrCopyCommands2Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -81,6 +81,11 @@ impl CreateRenderPass2 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrCreateRenderpass2Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -84,6 +84,11 @@ impl DeferredHostOperations {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDeferredHostOperationsFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/device_group.rs
+++ b/ash/src/extensions/khr/device_group.rs
@@ -165,6 +165,11 @@ impl DeviceGroup {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDeviceGroupFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/device_group_creation.rs
+++ b/ash/src/extensions/khr/device_group_creation.rs
@@ -58,6 +58,11 @@ impl DeviceGroupCreation {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDeviceGroupCreationFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -134,6 +134,11 @@ impl Display {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDisplayFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -46,6 +46,11 @@ impl DisplaySwapchain {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDisplaySwapchainFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/draw_indirect_count.rs
+++ b/ash/src/extensions/khr/draw_indirect_count.rs
@@ -68,4 +68,9 @@ impl DrawIndirectCount {
     pub fn fp(&self) -> &vk::KhrDrawIndirectCountFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDrawIndirectCountFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -38,4 +38,9 @@ impl DynamicRendering {
     pub fn fp(&self) -> &vk::KhrDynamicRenderingFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrDynamicRenderingFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -44,6 +44,11 @@ impl ExternalFenceFd {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrExternalFenceFdFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/external_fence_win32.rs
+++ b/ash/src/extensions/khr/external_fence_win32.rs
@@ -48,6 +48,11 @@ impl ExternalFenceWin32 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrExternalFenceWin32Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -48,6 +48,11 @@ impl ExternalMemoryFd {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrExternalMemoryFdFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -56,6 +56,11 @@ impl ExternalMemoryWin32 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrExternalMemoryWin32Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -47,6 +47,11 @@ impl ExternalSemaphoreFd {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrExternalSemaphoreFdFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/external_semaphore_win32.rs
+++ b/ash/src/extensions/khr/external_semaphore_win32.rs
@@ -48,6 +48,11 @@ impl ExternalSemaphoreWin32 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrExternalSemaphoreWin32Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -83,6 +83,11 @@ impl GetMemoryRequirements2 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrGetMemoryRequirements2Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -161,4 +161,9 @@ impl GetPhysicalDeviceProperties2 {
     pub fn fp(&self) -> &vk::KhrGetPhysicalDeviceProperties2Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrGetPhysicalDeviceProperties2Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -80,4 +80,9 @@ impl GetSurfaceCapabilities2 {
     pub fn fp(&self) -> &vk::KhrGetSurfaceCapabilities2Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrGetSurfaceCapabilities2Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/maintenance1.rs
+++ b/ash/src/extensions/khr/maintenance1.rs
@@ -37,6 +37,11 @@ impl Maintenance1 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrMaintenance1Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/maintenance3.rs
+++ b/ash/src/extensions/khr/maintenance3.rs
@@ -37,6 +37,11 @@ impl Maintenance3 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrMaintenance3Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -84,6 +84,11 @@ impl Maintenance4 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrMaintenance4Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/maintenance5.rs
+++ b/ash/src/extensions/khr/maintenance5.rs
@@ -87,6 +87,11 @@ impl Maintenance5 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrMaintenance5Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/performance_query.rs
+++ b/ash/src/extensions/khr/performance_query.rs
@@ -113,6 +113,11 @@ impl PerformanceQuery {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrPerformanceQueryFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -75,6 +75,11 @@ impl PipelineExecutableProperties {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrPipelineExecutablePropertiesFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/present_wait.rs
+++ b/ash/src/extensions/khr/present_wait.rs
@@ -38,6 +38,11 @@ impl PresentWait {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrPresentWaitFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/push_descriptor.rs
+++ b/ash/src/extensions/khr/push_descriptor.rs
@@ -62,4 +62,9 @@ impl PushDescriptor {
     pub fn fp(&self) -> &vk::KhrPushDescriptorFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrPushDescriptorFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/ray_tracing_maintenance1.rs
+++ b/ash/src/extensions/khr/ray_tracing_maintenance1.rs
@@ -36,4 +36,9 @@ impl RayTracingMaintenance1 {
     pub fn fp(&self) -> &vk::KhrRayTracingMaintenance1Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrRayTracingMaintenance1Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -168,6 +168,11 @@ impl RayTracingPipeline {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrRayTracingPipelineFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
+++ b/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
@@ -60,6 +60,11 @@ impl SamplerYcbcrConversion {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrSamplerYcbcrConversionFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -102,6 +102,11 @@ impl Surface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -207,6 +207,11 @@ impl Swapchain {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrSwapchainFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -95,4 +95,9 @@ impl Synchronization2 {
     pub fn fp(&self) -> &vk::KhrSynchronization2Fn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrSynchronization2Fn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -54,6 +54,11 @@ impl TimelineSemaphore {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrTimelineSemaphoreFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -62,6 +62,11 @@ impl WaylandSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrWaylandSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -60,6 +60,11 @@ impl Win32Surface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrWin32SurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -64,6 +64,11 @@ impl XcbSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrXcbSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -64,6 +64,11 @@ impl XlibSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::KhrXlibSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -45,6 +45,11 @@ impl IOSSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::MvkIosSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -45,6 +45,11 @@ impl MacOSSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::MvkMacosSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -45,6 +45,11 @@ impl ViSurface {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NnViSurfaceFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn instance(&self) -> vk::Instance {
         self.handle
     }

--- a/ash/src/extensions/nv/coverage_reduction_mode.rs
+++ b/ash/src/extensions/nv/coverage_reduction_mode.rs
@@ -66,4 +66,9 @@ impl CoverageReductionMode {
     pub fn fp(&self) -> &vk::NvCoverageReductionModeFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvCoverageReductionModeFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/nv/cuda_kernel_launch.rs
+++ b/ash/src/extensions/nv/cuda_kernel_launch.rs
@@ -101,6 +101,11 @@ impl CudaKernelLaunch {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvCudaKernelLaunchFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -58,4 +58,9 @@ impl DeviceDiagnosticCheckpoints {
     pub fn fp(&self) -> &vk::NvDeviceDiagnosticCheckpointsFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvDeviceDiagnosticCheckpointsFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/nv/device_generated_commands_compute.rs
+++ b/ash/src/extensions/nv/device_generated_commands_compute.rs
@@ -65,6 +65,11 @@ impl DeviceGeneratedCommandsCompute {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvDeviceGeneratedCommandsComputeFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/nv/low_latency2.rs
+++ b/ash/src/extensions/nv/low_latency2.rs
@@ -80,6 +80,11 @@ impl LowLatency2 {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvLowLatency2Fn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/extensions/nv/memory_decompression.rs
+++ b/ash/src/extensions/nv/memory_decompression.rs
@@ -51,4 +51,9 @@ impl MemoryDecompression {
     pub fn fp(&self) -> &vk::NvMemoryDecompressionFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvMemoryDecompressionFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -75,4 +75,9 @@ impl MeshShader {
     pub fn fp(&self) -> &vk::NvMeshShaderFn {
         &self.fp
     }
+
+    #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvMeshShaderFn {
+        &mut self.fp
+    }
 }

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -248,6 +248,11 @@ impl RayTracing {
     }
 
     #[inline]
+    pub unsafe fn fp_mut(&mut self) -> &mut vk::NvRayTracingFn {
+        &mut self.fp
+    }
+
+    #[inline]
     pub fn device(&self) -> vk::Device {
         self.handle
     }

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -346,7 +346,7 @@ impl Instance {
     pub fn fp_v1_0(&self) -> &vk::InstanceFnV1_0 {
         &self.instance_fn_1_0
     }
-    
+
     #[inline]
     pub unsafe fn fp_v1_0_mut(&mut self) -> &mut vk::InstanceFnV1_0 {
         &mut self.instance_fn_1_0

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -61,6 +61,11 @@ impl Instance {
         &self.instance_fn_1_3
     }
 
+    #[inline]
+    pub unsafe fn fp_v1_3_mut(&mut self) -> &mut vk::InstanceFnV1_3 {
+        &mut self.instance_fn_1_3
+    }
+
     /// Retrieve the number of elements to pass to [`get_physical_device_tool_properties()`][Self::get_physical_device_tool_properties()]
     #[inline]
     pub unsafe fn get_physical_device_tool_properties_len(
@@ -104,6 +109,11 @@ impl Instance {
     #[inline]
     pub fn fp_v1_1(&self) -> &vk::InstanceFnV1_1 {
         &self.instance_fn_1_1
+    }
+
+    #[inline]
+    pub unsafe fn fp_v1_1_mut(&mut self) -> &mut vk::InstanceFnV1_1 {
+        &mut self.instance_fn_1_1
     }
 
     /// Retrieve the number of elements to pass to [`enumerate_physical_device_groups()`][Self::enumerate_physical_device_groups()]
@@ -335,6 +345,11 @@ impl Instance {
     #[inline]
     pub fn fp_v1_0(&self) -> &vk::InstanceFnV1_0 {
         &self.instance_fn_1_0
+    }
+    
+    #[inline]
+    pub unsafe fn fp_v1_0_mut(&mut self) -> &mut vk::InstanceFnV1_0 {
+        &mut self.instance_fn_1_0
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateDevice.html>


### PR DESCRIPTION
Sometimes it may be necessary to patch function pointer values at runtime, for example when integrating third-party SDKs. This PR exposes mutable references to the function pointers, allowing applications to modify their values.