### PR TITLE
unify slice interfaces

### DIFF
--- a/ash-examples/src/bin/texture.rs
+++ b/ash-examples/src/bin/texture.rs
@@ -501,9 +501,11 @@ fn main() {
         let desc_alloc_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(&desc_set_layouts);
-        let descriptor_sets = base
+
+        let mut descriptor_sets = [vk::DescriptorSet::null()];
+        base
             .device
-            .allocate_descriptor_sets(&desc_alloc_info)
+            .allocate_descriptor_sets(&desc_alloc_info,&mut descriptor_sets)
             .unwrap();
 
         let uniform_color_buffer_descriptor = vk::DescriptorBufferInfo {
@@ -679,9 +681,10 @@ fn main() {
             .layout(pipeline_layout)
             .render_pass(renderpass);
 
-        let graphics_pipelines = base
+        let mut graphics_pipelines = [vk::Pipeline::null()];
+        base
             .device
-            .create_graphics_pipelines(vk::PipelineCache::null(), &[graphic_pipeline_infos], None)
+            .create_graphics_pipelines(vk::PipelineCache::null(), &[graphic_pipeline_infos],&mut graphics_pipelines, None)
             .unwrap();
 
         let graphic_pipeline = graphics_pipelines[0];

--- a/ash-examples/src/bin/triangle.rs
+++ b/ash-examples/src/bin/triangle.rs
@@ -341,9 +341,10 @@ fn main() {
             .layout(pipeline_layout)
             .render_pass(renderpass);
 
-        let graphics_pipelines = base
+        let mut graphics_pipelines = [vk::Pipeline::null()]; 
+        base
             .device
-            .create_graphics_pipelines(vk::PipelineCache::null(), &[graphic_pipeline_info], None)
+            .create_graphics_pipelines(vk::PipelineCache::null(), &[graphic_pipeline_info],&mut graphics_pipelines, None)
             .expect("Unable to create graphics pipeline");
 
         let graphic_pipeline = graphics_pipelines[0];

--- a/ash-examples/src/lib.rs
+++ b/ash-examples/src/lib.rs
@@ -414,8 +414,9 @@ impl ExampleBase {
                 .command_pool(pool)
                 .level(vk::CommandBufferLevel::PRIMARY);
 
-            let command_buffers = device
-                .allocate_command_buffers(&command_buffer_allocate_info)
+            let mut command_buffers = [vk::CommandBuffer::null();2];            
+            device
+                .allocate_command_buffers(&command_buffer_allocate_info,&mut command_buffers)
                 .unwrap();
             let setup_command_buffer = command_buffers[0];
             let draw_command_buffer = command_buffers[1];

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1539,14 +1539,14 @@ impl Device {
     pub unsafe fn allocate_descriptor_sets(
         &self,
         allocate_info: &vk::DescriptorSetAllocateInfo<'_>,
-    ) -> VkResult<Vec<vk::DescriptorSet>> {
-        let mut desc_set = Vec::with_capacity(allocate_info.descriptor_set_count as usize);
+        descriptor_sets: &mut[vk::DescriptorSet]
+    ) -> VkResult<()> {
+        assert_eq!(allocate_info.descriptor_set_count,descriptor_sets.len() as u32);
         (self.device_fn_1_0.allocate_descriptor_sets)(
             self.handle(),
             allocate_info,
-            desc_set.as_mut_ptr(),
-        )
-        .set_vec_len_on_success(desc_set, allocate_info.descriptor_set_count as usize)
+            descriptor_sets.as_mut_ptr()
+        ).result()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateDescriptorSetLayout.html>
@@ -2140,9 +2140,10 @@ impl Device {
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::GraphicsPipelineCreateInfo<'_>],
+        pipelines: &mut [vk::Pipeline],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
-    ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+    ) -> Result<(), vk::Result> {
+        debug_assert_eq!(pipelines.len(),create_infos.len());
         let err_code = (self.device_fn_1_0.create_graphics_pipelines)(
             self.handle(),
             pipeline_cache,
@@ -2151,10 +2152,10 @@ impl Device {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         );
-        pipelines.set_len(create_infos.len());
+
         match err_code {
-            vk::Result::SUCCESS => Ok(pipelines),
-            _ => Err((pipelines, err_code)),
+            vk::Result::SUCCESS => Ok(()),
+            _ => Err(err_code),
         }
     }
 
@@ -2164,9 +2165,10 @@ impl Device {
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::ComputePipelineCreateInfo<'_>],
+        pipelines: &mut [vk::Pipeline],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
-    ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+    ) -> Result<(),vk::Result> {
+        debug_assert_eq!(create_infos.len(),pipelines.len());
         let err_code = (self.device_fn_1_0.create_compute_pipelines)(
             self.handle(),
             pipeline_cache,
@@ -2175,10 +2177,10 @@ impl Device {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         );
-        pipelines.set_len(create_infos.len());
+
         match err_code {
-            vk::Result::SUCCESS => Ok(pipelines),
-            _ => Err((pipelines, err_code)),
+            vk::Result::SUCCESS => Ok(()),
+            _ => Err(err_code),
         }
     }
 
@@ -2526,14 +2528,15 @@ impl Device {
     pub unsafe fn allocate_command_buffers(
         &self,
         allocate_info: &vk::CommandBufferAllocateInfo<'_>,
-    ) -> VkResult<Vec<vk::CommandBuffer>> {
-        let mut buffers = Vec::with_capacity(allocate_info.command_buffer_count as usize);
+        buffers: &mut [vk::CommandBuffer]
+    ) -> VkResult<()> {
+        debug_assert_eq!(allocate_info.command_buffer_count,buffers.len() as u32);
         (self.device_fn_1_0.allocate_command_buffers)(
             self.handle(),
             allocate_info,
             buffers.as_mut_ptr(),
         )
-        .set_vec_len_on_success(buffers, allocate_info.command_buffer_count as usize)
+        .result()
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateCommandPool.html>


### PR DESCRIPTION
One thing I noticed messing with Ash is some of the handcrafted method's return a Vec, but some methods don't. This seems weird, unnecessary and kinda against the spirit of matching the C++ code with no major compromises in release build. 

Ex: Forces Vec
```rs
    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkAllocateDescriptorSets.html>
    #[inline]
    pub unsafe fn allocate_descriptor_sets(
        &self,
        allocate_info: &vk::DescriptorSetAllocateInfo<'_>,
    ) -> VkResult<Vec<vk::DescriptorSet>> {
        let mut desc_set = Vec::with_capacity(allocate_info.descriptor_set_count as usize);
        (self.device_fn_1_0.allocate_descriptor_sets)(
            self.handle(),
            allocate_info,
            desc_set.as_mut_ptr(),
        )
        .set_vec_len_on_success(desc_set, allocate_info.descriptor_set_count as usize)
    }

```

Ex: Does not return Vec
```rs
    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetImageSparseMemoryRequirements2.html>
    ///
    /// Call [`get_image_sparse_memory_requirements2_len()`][Self::get_image_sparse_memory_requirements2_len()] to query the number of elements to pass to `out`.
    /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
    #[inline]
    pub unsafe fn get_image_sparse_memory_requirements2(
        &self,
        info: &vk::ImageSparseMemoryRequirementsInfo2<'_>,
        out: &mut [vk::SparseImageMemoryRequirements2<'_>],
    ) {
        let mut count = out.len() as u32;
        (self.device_fn_1_1.get_image_sparse_memory_requirements2)(
            self.handle(),
            info,
            &mut count,
            out.as_mut_ptr(),
        );
        assert_eq!(count as usize, out.len());
    }
```

Imo, the library should move all methods to match the C++ version so the end user can determine how they want to allocate the memory or potentially reuse existing memory.

Ex: Update descriptor sets to not use Vec
```rs
    /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkAllocateDescriptorSets.html>
    #[inline]
    pub unsafe fn allocate_descriptor_sets(
        &self,
        allocate_info: &vk::DescriptorSetAllocateInfo<'_>,
        descriptor_sets: &mut[vk::DescriptorSet]
    ) -> VkResult<()> {
        assert_eq!(allocate_info.descriptor_set_count,descriptor_sets.len() as u32);
        (self.device_fn_1_0.allocate_descriptor_sets)(
            self.handle(),
            allocate_info,
            descriptor_sets.as_mut_ptr()
        ).result()
    }
```