### PR TITLE
extensions: Expose `NAME` via reexport instead of `const`

### DIFF
--- a/ash/src/extensions/amd/buffer_marker.rs
+++ b/ash/src/extensions/amd/buffer_marker.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_AMD_buffer_marker.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::amd::buffer_marker::NAME;
+pub use vk::amd::buffer_marker::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/amd/shader_info.rs
+++ b/ash/src/extensions/amd/shader_info.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::amd::shader_info::NAME;
+pub use vk::amd::shader_info::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::amdx::shader_enqueue::NAME;
+pub use vk::amdx::shader_enqueue::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
+++ b/ash/src/extensions/android/external_memory_android_hardware_buffer.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::android::external_memory_android_hardware_buffer::NAME;
+pub use vk::android::external_memory_android_hardware_buffer::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/acquire_drm_display.rs
+++ b/ash/src/extensions/ext/acquire_drm_display.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::acquire_drm_display::NAME;
+pub use vk::ext::acquire_drm_display::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/ext/buffer_device_address.rs
+++ b/ash/src/extensions/ext/buffer_device_address.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_buffer_device_address.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::buffer_device_address::NAME;
+pub use vk::ext::buffer_device_address::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::calibrated_timestamps::NAME;
+pub use vk::ext::calibrated_timestamps::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::debug_marker::NAME;
+pub use vk::ext::debug_marker::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::debug_report::NAME;
+pub use vk::ext::debug_report::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::debug_utils::NAME;
+pub use vk::ext::debug_utils::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/ext/descriptor_buffer.rs
+++ b/ash/src/extensions/ext/descriptor_buffer.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::descriptor_buffer::NAME;
+pub use vk::ext::descriptor_buffer::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -1,11 +1,9 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::ext::extended_dynamic_state::NAME;
+pub use vk::ext::extended_dynamic_state::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/extended_dynamic_state2.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state2.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state2.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::extended_dynamic_state2::NAME;
+pub use vk::ext::extended_dynamic_state2::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/extended_dynamic_state3.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state3.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state3.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::extended_dynamic_state3::NAME;
+pub use vk::ext::extended_dynamic_state3::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::full_screen_exclusive::NAME;
+pub use vk::ext::full_screen_exclusive::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/ext/hdr_metadata.rs
+++ b/ash/src/extensions/ext/hdr_metadata.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_hdr_metadata.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::hdr_metadata::NAME;
+pub use vk::ext::hdr_metadata::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/headless_surface.rs
+++ b/ash/src/extensions/ext/headless_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::headless_surface::NAME;
+pub use vk::ext::headless_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/ext/host_image_copy.rs
+++ b/ash/src/extensions/ext/host_image_copy.rs
@@ -4,10 +4,8 @@
 use super::{super::khr::maintenance5, image_compression_control};
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::host_image_copy::NAME;
+pub use vk::ext::host_image_copy::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/image_compression_control.rs
+++ b/ash/src/extensions/ext/image_compression_control.rs
@@ -3,10 +3,8 @@
 #[cfg(doc)]
 use super::{super::khr::maintenance5, host_image_copy};
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::image_compression_control::NAME;
+pub use vk::ext::image_compression_control::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/image_drm_format_modifier.rs
+++ b/ash/src/extensions/ext/image_drm_format_modifier.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::image_drm_format_modifier::NAME;
+pub use vk::ext::image_drm_format_modifier::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/mesh_shader.rs
+++ b/ash/src/extensions/ext/mesh_shader.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_mesh_shader.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::mesh_shader::NAME;
+pub use vk::ext::mesh_shader::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::metal_surface::NAME;
+pub use vk::ext::metal_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/ext/pipeline_properties.rs
+++ b/ash/src/extensions/ext/pipeline_properties.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::pipeline_properties::NAME;
+pub use vk::ext::pipeline_properties::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/private_data.rs
+++ b/ash/src/extensions/ext/private_data.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::private_data::NAME;
+pub use vk::ext::private_data::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/sample_locations.rs
+++ b/ash/src/extensions/ext/sample_locations.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_sample_locations.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::sample_locations::NAME;
+pub use vk::ext::sample_locations::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -4,11 +4,9 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::ext::shader_object::NAME;
+pub use vk::ext::shader_object::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/swapchain_maintenance1.rs
+++ b/ash/src/extensions/ext/swapchain_maintenance1.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::swapchain_maintenance1::NAME;
+pub use vk::ext::swapchain_maintenance1::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::tooling_info::NAME;
+pub use vk::ext::tooling_info::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/ext/vertex_input_dynamic_state.rs
+++ b/ash/src/extensions/ext/vertex_input_dynamic_state.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_vertex_input_dynamic_state.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::ext::vertex_input_dynamic_state::NAME;
+pub use vk::ext::vertex_input_dynamic_state::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/google/display_timing.rs
+++ b/ash/src/extensions/google/display_timing.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::google::display_timing::NAME;
+pub use vk::google::display_timing::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::acceleration_structure::NAME;
+pub use vk::khr::acceleration_structure::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::android_surface::NAME;
+pub use vk::khr::android_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/buffer_device_address.rs
+++ b/ash/src/extensions/khr/buffer_device_address.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::buffer_device_address::NAME;
+pub use vk::khr::buffer_device_address::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/cooperative_matrix.rs
+++ b/ash/src/extensions/khr/cooperative_matrix.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::cooperative_matrix::NAME;
+pub use vk::khr::cooperative_matrix::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/copy_commands2.rs
+++ b/ash/src/extensions/khr/copy_commands2.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_copy_commands2.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::copy_commands2::NAME;
+pub use vk::khr::copy_commands2::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::create_renderpass2::NAME;
+pub use vk::khr::create_renderpass2::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::deferred_host_operations::NAME;
+pub use vk::khr::deferred_host_operations::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/device_group.rs
+++ b/ash/src/extensions/khr/device_group.rs
@@ -5,10 +5,8 @@ use super::swapchain;
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::device_group::NAME;
+pub use vk::khr::device_group::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/khr/device_group_creation.rs
+++ b/ash/src/extensions/khr/device_group_creation.rs
@@ -2,11 +2,9 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::khr::device_group_creation::NAME;
+pub use vk::khr::device_group_creation::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::display::NAME;
+pub use vk::khr::display::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::display_swapchain::NAME;
+pub use vk::khr::display_swapchain::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/draw_indirect_count.rs
+++ b/ash/src/extensions/khr/draw_indirect_count.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_draw_indirect_count.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::draw_indirect_count::NAME;
+pub use vk::khr::draw_indirect_count::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_dynamic_rendering.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::dynamic_rendering::NAME;
+pub use vk::khr::dynamic_rendering::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::external_fence_fd::NAME;
+pub use vk::khr::external_fence_fd::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/external_fence_win32.rs
+++ b/ash/src/extensions/khr/external_fence_win32.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::external_fence_win32::NAME;
+pub use vk::khr::external_fence_win32::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::external_memory_fd::NAME;
+pub use vk::khr::external_memory_fd::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::external_memory_win32::NAME;
+pub use vk::khr::external_memory_win32::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::external_semaphore_fd::NAME;
+pub use vk::khr::external_semaphore_fd::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/external_semaphore_win32.rs
+++ b/ash/src/extensions/khr/external_semaphore_win32.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::external_semaphore_win32::NAME;
+pub use vk::khr::external_semaphore_win32::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -1,11 +1,9 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_get_memory_requirements2.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::khr::get_memory_requirements2::NAME;
+pub use vk::khr::get_memory_requirements2::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -2,11 +2,9 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::khr::get_physical_device_properties2::NAME;
+pub use vk::khr::get_physical_device_properties2::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -2,11 +2,9 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::khr::get_surface_capabilities2::NAME;
+pub use vk::khr::get_surface_capabilities2::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/maintenance1.rs
+++ b/ash/src/extensions/khr/maintenance1.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance1.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::maintenance1::NAME;
+pub use vk::khr::maintenance1::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/maintenance3.rs
+++ b/ash/src/extensions/khr/maintenance3.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance3.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::maintenance3::NAME;
+pub use vk::khr::maintenance3::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -1,11 +1,9 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance4.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::khr::maintenance4::NAME;
+pub use vk::khr::maintenance4::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/maintenance5.rs
+++ b/ash/src/extensions/khr/maintenance5.rs
@@ -3,10 +3,8 @@
 #[cfg(doc)]
 use super::super::ext::{host_image_copy, image_compression_control};
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::maintenance5::NAME;
+pub use vk::khr::maintenance5::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/performance_query.rs
+++ b/ash/src/extensions/khr/performance_query.rs
@@ -2,11 +2,9 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::khr::performance_query::NAME;
+pub use vk::khr::performance_query::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::pipeline_executable_properties::NAME;
+pub use vk::khr::pipeline_executable_properties::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/present_wait.rs
+++ b/ash/src/extensions/khr/present_wait.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::present_wait::NAME;
+pub use vk::khr::present_wait::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/push_descriptor.rs
+++ b/ash/src/extensions/khr/push_descriptor.rs
@@ -3,8 +3,7 @@
 use crate::vk;
 use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::push_descriptor::NAME;
+pub use vk::khr::push_descriptor::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/ray_tracing_maintenance1.rs
+++ b/ash/src/extensions/khr/ray_tracing_maintenance1.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_tracing_maintenance1.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::ray_tracing_maintenance1::NAME;
+pub use vk::khr::ray_tracing_maintenance1::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::ray_tracing_pipeline::NAME;
+pub use vk::khr::ray_tracing_pipeline::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
+++ b/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::sampler_ycbcr_conversion::NAME;
+pub use vk::khr::sampler_ycbcr_conversion::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::surface::NAME;
+pub use vk::khr::surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -6,10 +6,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::swapchain::NAME;
+pub use vk::khr::swapchain::NAME;
 
 /// High-level device function wrapper
 #[derive(Clone)]

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::synchronization2::NAME;
+pub use vk::khr::synchronization2::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -2,10 +2,8 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::timeline_semaphore::NAME;
+pub use vk::khr::timeline_semaphore::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::wayland_surface::NAME;
+pub use vk::khr::wayland_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::win32_surface::NAME;
+pub use vk::khr::win32_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::xcb_surface::NAME;
+pub use vk::khr::xcb_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::khr::xlib_surface::NAME;
+pub use vk::khr::xlib_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::mvk::ios_surface::NAME;
+pub use vk::mvk::ios_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::mvk::macos_surface::NAME;
+pub use vk::mvk::macos_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nn::vi_surface::NAME;
+pub use vk::nn::vi_surface::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/nv/coverage_reduction_mode.rs
+++ b/ash/src/extensions/nv/coverage_reduction_mode.rs
@@ -2,11 +2,9 @@
 
 use crate::prelude::*;
 use crate::vk;
-use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::nv::coverage_reduction_mode::NAME;
+pub use vk::nv::coverage_reduction_mode::NAME;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/ash/src/extensions/nv/cuda_kernel_launch.rs
+++ b/ash/src/extensions/nv/cuda_kernel_launch.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nv::cuda_kernel_launch::NAME;
+pub use vk::nv::cuda_kernel_launch::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -4,8 +4,7 @@ use crate::vk;
 use core::ffi;
 use core::mem;
 use core::ptr;
-
-pub const NAME: &ffi::CStr = vk::nv::device_diagnostic_checkpoints::NAME;
+pub use vk::nv::device_diagnostic_checkpoints::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/nv/device_generated_commands_compute.rs
+++ b/ash/src/extensions/nv/device_generated_commands_compute.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_NV_device_generated_commands_compute.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nv::device_generated_commands_compute::NAME;
+pub use vk::nv::device_generated_commands_compute::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/nv/low_latency2.rs
+++ b/ash/src/extensions/nv/low_latency2.rs
@@ -3,10 +3,8 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nv::low_latency2::NAME;
+pub use vk::nv::low_latency2::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/nv/memory_decompression.rs
+++ b/ash/src/extensions/nv/memory_decompression.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_NV_memory_decompression.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nv::memory_decompression::NAME;
+pub use vk::nv::memory_decompression::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -1,10 +1,8 @@
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_NV_mesh_shader.html>
 
 use crate::vk;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nv::mesh_shader::NAME;
+pub use vk::nv::mesh_shader::NAME;
 
 #[derive(Clone)]
 pub struct Device {

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -4,10 +4,8 @@ use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
-use core::ffi;
 use core::mem;
-
-pub const NAME: &ffi::CStr = vk::nv::ray_tracing::NAME;
+pub use vk::nv::ray_tracing::NAME;
 
 #[derive(Clone)]
 pub struct Device {


### PR DESCRIPTION
Now that hand-written extension wrappers are exposed as `mod`ules instead of `struct`s it is no longer needed to expose `NAME` as associated `const` when a more-concise `pub use` reexport will do.

---

I'm still ambivalent what to do about `NAME`. Time and time again the question comes up why extension `X` isn't available in `ash::extensions::`, and we have to explain that this is only for hand-writen extensions for which no wrapepr has been written yet, or is more often than not a command-less extension that does not need a wrapper.
Veterans will know that `ash::extensions::` is only for those hand-written wrappers - and `NAME` is re-exposed from `ash::vk::` there purely for convenience - but anyone else seems to expect all extensions to be available there. Not to mention that my extension lists in various apps look funky when mixed with `ash::extensions::XXX::name()` and `ash::vk::XXXFn::name()` (old 0.37 syntax).
This was also brought up recently in different form (citation needed): why not combine the autogenerated `ExtensionFn` with the hand-written wrapper (effectively have the handwritten wrapper extend it)? Regardless of if/how/when we implement that, such an approach could also eliminate having multiple `NAME`s in different places.
