### PR TITLE
extensions/khr: Re-add erroneously removed `mod acceleration_structure`

### DIFF
--- a/ash/src/extensions/khr/mod.rs
+++ b/ash/src/extensions/khr/mod.rs
@@ -1,3 +1,4 @@
+pub mod acceleration_structure;
 pub mod android_surface;
 pub mod buffer_device_address;
 pub mod calibrated_timestamps;


### PR DESCRIPTION
While rush-rebasing 5 extensions in a row #889 seems to have ended up deleting the first line of `mod.rs`, which was defining the `acceleration_structure` module.  Restore that.
