### PR TITLE
extension/ext: Add missing length-rounding in `cmd_set_sample_mask()` assert

### DIFF
--- a/ash/src/extensions/ext/extended_dynamic_state3.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state3.rs
@@ -69,7 +69,7 @@ impl Device {
             samples.as_raw().is_power_of_two(),
             "Only one SampleCount bit must be set"
         );
-        assert_eq!(samples.as_raw() as usize / 32, sample_mask.len());
+        assert_eq!((samples.as_raw() as usize + 31) / 32, sample_mask.len());
         (self.fp.cmd_set_sample_mask_ext)(command_buffer, samples, sample_mask.as_ptr())
     }
 

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -374,7 +374,7 @@ impl Device {
             samples.as_raw().is_power_of_two(),
             "Only one SampleCount bit must be set"
         );
-        assert_eq!(samples.as_raw() as usize / 32, sample_mask.len());
+        assert_eq!((samples.as_raw() as usize + 31) / 32, sample_mask.len());
         (self.fp.cmd_set_sample_mask_ext)(command_buffer, samples, sample_mask.as_ptr())
     }
 


### PR DESCRIPTION
As stated in the vulkan specification for `vkCmdSetSampleMaskEXT`: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdSetSampleMaskEXT.html

`sample_mask` must be an array of size `ceil(samples/32)`. However right now the ash wrapper for this function is checking that it is of size `floor(samples/32)`, making this wrapper unusable for any sample count less than 32.