### PR TITLE
Outline monomorphic load functions

### DIFF
--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -73,10 +73,7 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -203,10 +200,7 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -303,10 +297,7 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -398,10 +389,7 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -501,10 +489,7 @@ pub mod amdx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -705,10 +690,7 @@ pub mod android {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -847,10 +829,7 @@ pub mod android {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -994,10 +973,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1123,10 +1099,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1271,10 +1244,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1505,10 +1475,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1595,10 +1562,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1660,10 +1624,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1751,10 +1712,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1824,10 +1782,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -1959,10 +1914,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2093,10 +2045,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2177,10 +2126,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2289,10 +2235,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2513,10 +2456,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2575,10 +2515,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2660,10 +2597,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2733,10 +2667,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2897,10 +2828,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2971,10 +2899,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3033,10 +2958,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3128,10 +3050,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3246,10 +3165,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3314,10 +3230,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3425,10 +3338,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3491,10 +3401,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3601,10 +3508,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3671,10 +3575,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3748,10 +3649,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3833,10 +3731,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4123,10 +4018,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4294,10 +4186,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4378,10 +4267,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4454,10 +4340,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4559,10 +4442,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4693,10 +4573,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -4778,10 +4655,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5071,10 +4945,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5211,10 +5082,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5298,10 +5166,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5377,10 +5242,7 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5468,10 +5330,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5578,10 +5437,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5667,10 +5523,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5809,10 +5662,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -5903,10 +5753,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -6024,10 +5871,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -6361,10 +6205,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -6513,10 +6354,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -7191,10 +7029,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -7363,10 +7198,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -8488,10 +8320,7 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -8560,10 +8389,7 @@ pub mod fuchsia {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -8633,10 +8459,7 @@ pub mod fuchsia {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -8726,10 +8549,7 @@ pub mod fuchsia {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -8825,10 +8645,7 @@ pub mod fuchsia {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -8983,10 +8800,7 @@ pub mod ggp {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9066,10 +8880,7 @@ pub mod google {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9195,10 +9006,7 @@ pub mod huawei {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9283,10 +9091,7 @@ pub mod huawei {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9353,10 +9158,7 @@ pub mod huawei {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9491,10 +9293,7 @@ pub mod intel {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9730,10 +9529,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9883,10 +9679,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -9955,10 +9748,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10167,10 +9957,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10367,10 +10154,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10440,10 +10224,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10534,10 +10315,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10627,10 +10405,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10718,10 +10493,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10790,10 +10562,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10891,10 +10660,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -10985,10 +10751,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11239,10 +11002,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11328,10 +11088,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11432,10 +11189,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11627,10 +11381,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11697,10 +11448,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11879,10 +11627,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -11947,10 +11692,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12020,10 +11762,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12099,10 +11838,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12193,10 +11929,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12288,10 +12021,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12369,10 +12099,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12459,10 +12186,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12545,10 +12269,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12668,10 +12389,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12816,10 +12534,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -12944,10 +12659,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13013,10 +12725,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13092,10 +12801,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13183,10 +12889,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13266,10 +12969,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13351,10 +13051,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13447,10 +13144,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13552,10 +13246,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13712,10 +13403,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -13858,10 +13546,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -14264,10 +13949,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -14481,10 +14163,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -14574,10 +14253,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -14670,10 +14346,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -14741,10 +14414,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -14921,10 +14591,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15038,10 +14705,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15102,10 +14766,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15175,10 +14836,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15296,10 +14954,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15373,10 +15028,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15486,10 +15138,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15637,10 +15286,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15753,10 +15399,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15866,10 +15509,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -15933,10 +15573,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16027,10 +15664,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16261,10 +15895,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16419,10 +16050,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16498,10 +16126,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16630,10 +16255,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16774,10 +16396,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16892,10 +16511,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -16962,10 +16578,7 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17024,10 +16637,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17110,10 +16720,7 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17301,10 +16908,7 @@ pub mod mvk {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17370,10 +16974,7 @@ pub mod mvk {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17443,10 +17044,7 @@ pub mod nn {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17537,10 +17135,7 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17620,10 +17215,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17698,10 +17290,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17834,10 +17423,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -17959,10 +17545,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18305,10 +17888,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18437,10 +18017,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18530,10 +18107,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18626,10 +18200,7 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18697,10 +18268,7 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18770,10 +18338,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -18975,10 +18540,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19152,10 +18714,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19231,10 +18790,7 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19315,10 +18871,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19395,10 +18948,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19491,10 +19041,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19585,10 +19132,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19705,10 +19249,7 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19773,10 +19314,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -19926,10 +19464,7 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -20115,10 +19650,7 @@ pub mod nvx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -20260,10 +19792,7 @@ pub mod nvx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -20409,10 +19938,7 @@ pub mod qcom {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -20554,10 +20080,7 @@ pub mod qnx {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -20645,10 +20168,7 @@ pub mod qnx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -20739,10 +20259,7 @@ pub mod valve {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut f: F) -> Self
-            where
-                F: FnMut(&CStr) -> *const c_void,
-            {
+            pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                 Self::load_erased(&mut f)
             }
             fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {

--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -73,10 +73,13 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_draw_indirect_count_amd: unsafe {
                         unsafe extern "system" fn cmd_draw_indirect_count_amd(
@@ -200,10 +203,13 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_shader_info_amd: unsafe {
                         unsafe extern "system" fn get_shader_info_amd(
@@ -297,10 +303,13 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_write_buffer_marker_amd: unsafe {
                         unsafe extern "system" fn cmd_write_buffer_marker_amd(
@@ -389,10 +398,13 @@ pub mod amd {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     set_local_dimming_amd: unsafe {
                         unsafe extern "system" fn set_local_dimming_amd(
@@ -489,10 +501,13 @@ pub mod amdx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_execution_graph_pipelines_amdx: unsafe {
                         unsafe extern "system" fn create_execution_graph_pipelines_amdx(
@@ -690,10 +705,13 @@ pub mod android {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_swapchain_gralloc_usage_android: unsafe {
                         unsafe extern "system" fn get_swapchain_gralloc_usage_android(
@@ -829,10 +847,13 @@ pub mod android {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_android_hardware_buffer_properties_android: unsafe {
                         unsafe extern "system" fn get_android_hardware_buffer_properties_android(
@@ -973,10 +994,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_debug_report_callback_ext: unsafe {
                         unsafe extern "system" fn create_debug_report_callback_ext(
@@ -1099,10 +1123,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     debug_marker_set_object_tag_ext: unsafe {
                         unsafe extern "system" fn debug_marker_set_object_tag_ext(
@@ -1244,10 +1271,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_bind_transform_feedback_buffers_ext: unsafe {
                         unsafe extern "system" fn cmd_bind_transform_feedback_buffers_ext(
@@ -1475,10 +1505,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_begin_conditional_rendering_ext: unsafe {
                         unsafe extern "system" fn cmd_begin_conditional_rendering_ext(
@@ -1562,10 +1595,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     release_display_ext: unsafe {
                         unsafe extern "system" fn release_display_ext(
@@ -1624,10 +1660,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     acquire_xlib_display_ext: unsafe {
                         unsafe extern "system" fn acquire_xlib_display_ext(
@@ -1712,10 +1751,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_surface_capabilities2_ext: unsafe {
                         unsafe extern "system" fn get_physical_device_surface_capabilities2_ext(
@@ -1782,10 +1824,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     display_power_control_ext: unsafe {
                         unsafe extern "system" fn display_power_control_ext(
@@ -1914,10 +1959,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_discard_rectangle_ext: unsafe {
                         unsafe extern "system" fn cmd_set_discard_rectangle_ext(
@@ -2045,10 +2093,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     set_hdr_metadata_ext: unsafe {
                         unsafe extern "system" fn set_hdr_metadata_ext(
@@ -2126,10 +2177,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_debug_utils_messenger_ext: unsafe {
                         unsafe extern "system" fn create_debug_utils_messenger_ext(
@@ -2235,10 +2289,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     set_debug_utils_object_name_ext: unsafe {
                         unsafe extern "system" fn set_debug_utils_object_name_ext(
@@ -2456,10 +2513,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_multisample_properties_ext: unsafe {
                         unsafe extern "system" fn get_physical_device_multisample_properties_ext(
@@ -2515,10 +2575,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_sample_locations_ext: unsafe {
                         unsafe extern "system" fn cmd_set_sample_locations_ext(
@@ -2597,10 +2660,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_image_drm_format_modifier_properties_ext: unsafe {
                         unsafe extern "system" fn get_image_drm_format_modifier_properties_ext(
@@ -2667,10 +2733,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_validation_cache_ext: unsafe {
                         unsafe extern "system" fn create_validation_cache_ext(
@@ -2828,10 +2897,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_memory_host_pointer_properties_ext: unsafe {
                         unsafe extern "system" fn get_memory_host_pointer_properties_ext(
@@ -2899,10 +2971,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_calibrateable_time_domains_ext: unsafe {
                         unsafe extern "system" fn get_physical_device_calibrateable_time_domains_ext(
@@ -2958,10 +3033,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_calibrated_timestamps_ext: unsafe {
                         unsafe extern "system" fn get_calibrated_timestamps_ext(
@@ -3050,10 +3128,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_metal_surface_ext: unsafe {
                         unsafe extern "system" fn create_metal_surface_ext(
@@ -3165,10 +3246,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_buffer_device_address_ext: unsafe {
                         unsafe extern "system" fn get_buffer_device_address_ext(
@@ -3230,10 +3314,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_tool_properties_ext: unsafe {
                         unsafe extern "system" fn get_physical_device_tool_properties_ext(
@@ -3338,10 +3425,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_surface_present_modes2_ext: unsafe {
                         unsafe extern "system" fn get_physical_device_surface_present_modes2_ext(
@@ -3401,10 +3491,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     acquire_full_screen_exclusive_mode_ext: unsafe {
                         unsafe extern "system" fn acquire_full_screen_exclusive_mode_ext(
@@ -3508,10 +3601,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_headless_surface_ext: unsafe {
                         unsafe extern "system" fn create_headless_surface_ext(
@@ -3575,10 +3671,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_line_stipple_ext: unsafe {
                         unsafe extern "system" fn cmd_set_line_stipple_ext(
@@ -3649,10 +3748,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     reset_query_pool_ext: unsafe {
                         unsafe extern "system" fn reset_query_pool_ext(
@@ -3731,10 +3833,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_cull_mode_ext: unsafe {
                         unsafe extern "system" fn cmd_set_cull_mode_ext(
@@ -4018,10 +4123,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     copy_memory_to_image_ext: unsafe {
                         unsafe extern "system" fn copy_memory_to_image_ext(
@@ -4186,10 +4294,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     release_swapchain_images_ext: unsafe {
                         unsafe extern "system" fn release_swapchain_images_ext(
@@ -4267,10 +4378,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_depth_bias2_ext: unsafe {
                         unsafe extern "system" fn cmd_set_depth_bias2_ext(
@@ -4340,10 +4454,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     acquire_drm_display_ext: unsafe {
                         unsafe extern "system" fn acquire_drm_display_ext(
@@ -4442,10 +4559,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_private_data_slot_ext: unsafe {
                         unsafe extern "system" fn create_private_data_slot_ext(
@@ -4573,10 +4693,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     export_metal_objects_ext: unsafe {
                         unsafe extern "system" fn export_metal_objects_ext(
@@ -4655,10 +4778,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_descriptor_set_layout_size_ext: unsafe {
                         unsafe extern "system" fn get_descriptor_set_layout_size_ext(
@@ -4945,10 +5071,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_draw_mesh_tasks_ext: unsafe {
                         unsafe extern "system" fn cmd_draw_mesh_tasks_ext(
@@ -5082,10 +5211,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_image_subresource_layout2_ext: unsafe {
                         unsafe extern "system" fn get_image_subresource_layout2_ext(
@@ -5166,10 +5298,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_device_fault_info_ext: unsafe {
                         unsafe extern "system" fn get_device_fault_info_ext(
@@ -5242,10 +5377,13 @@ pub mod ext {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_direct_fb_surface_ext: unsafe {
                         unsafe extern "system" fn create_direct_fb_surface_ext(
@@ -5330,10 +5468,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_vertex_input_ext: unsafe {
                         unsafe extern "system" fn cmd_set_vertex_input_ext(
@@ -5437,10 +5578,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_pipeline_properties_ext: unsafe {
                         unsafe extern "system" fn get_pipeline_properties_ext(
@@ -5523,10 +5667,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_patch_control_points_ext: unsafe {
                         unsafe extern "system" fn cmd_set_patch_control_points_ext(
@@ -5662,10 +5809,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_color_write_enable_ext: unsafe {
                         unsafe extern "system" fn cmd_set_color_write_enable_ext(
@@ -5753,10 +5903,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_draw_multi_ext: unsafe {
                         unsafe extern "system" fn cmd_draw_multi_ext(
@@ -5871,10 +6024,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_micromap_ext: unsafe {
                         unsafe extern "system" fn create_micromap_ext(
@@ -6205,10 +6361,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     set_device_memory_priority_ext: unsafe {
                         unsafe extern "system" fn set_device_memory_priority_ext(
@@ -6354,10 +6513,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_depth_clamp_enable_ext: unsafe {
                         unsafe extern "system" fn cmd_set_depth_clamp_enable_ext(
@@ -7029,10 +7191,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_shader_module_identifier_ext: unsafe {
                         unsafe extern "system" fn get_shader_module_identifier_ext(
@@ -7198,10 +7363,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_shaders_ext: unsafe {
                         unsafe extern "system" fn create_shaders_ext(
@@ -8320,10 +8488,13 @@ pub mod ext {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_attachment_feedback_loop_enable_ext: unsafe {
                         unsafe extern "system" fn cmd_set_attachment_feedback_loop_enable_ext(
@@ -8389,10 +8560,13 @@ pub mod fuchsia {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_image_pipe_surface_fuchsia: unsafe {
                         unsafe extern "system" fn create_image_pipe_surface_fuchsia(
@@ -8459,10 +8633,13 @@ pub mod fuchsia {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_memory_zircon_handle_fuchsia: unsafe {
                         unsafe extern "system" fn get_memory_zircon_handle_fuchsia(
@@ -8549,10 +8726,13 @@ pub mod fuchsia {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     import_semaphore_zircon_handle_fuchsia: unsafe {
                         unsafe extern "system" fn import_semaphore_zircon_handle_fuchsia(
@@ -8645,10 +8825,13 @@ pub mod fuchsia {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_buffer_collection_fuchsia: unsafe {
                         unsafe extern "system" fn create_buffer_collection_fuchsia(
@@ -8800,10 +8983,13 @@ pub mod ggp {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_stream_descriptor_surface_ggp: unsafe {
                         unsafe extern "system" fn create_stream_descriptor_surface_ggp(
@@ -8880,10 +9066,13 @@ pub mod google {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_refresh_cycle_duration_google: unsafe {
                         unsafe extern "system" fn get_refresh_cycle_duration_google(
@@ -9006,10 +9195,13 @@ pub mod huawei {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_device_subpass_shading_max_workgroup_size_huawei: unsafe {
                         unsafe extern "system" fn get_device_subpass_shading_max_workgroup_size_huawei(
@@ -9091,10 +9283,13 @@ pub mod huawei {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_bind_invocation_mask_huawei: unsafe {
                         unsafe extern "system" fn cmd_bind_invocation_mask_huawei(
@@ -9158,10 +9353,13 @@ pub mod huawei {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_draw_cluster_huawei: unsafe {
                         unsafe extern "system" fn cmd_draw_cluster_huawei(
@@ -9293,10 +9491,13 @@ pub mod intel {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     initialize_performance_api_intel: unsafe {
                         unsafe extern "system" fn initialize_performance_api_intel(
@@ -9529,10 +9730,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     destroy_surface_khr: unsafe {
                         unsafe extern "system" fn destroy_surface_khr(
@@ -9679,10 +9883,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_present_rectangles_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_present_rectangles_khr(
@@ -9748,10 +9955,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_swapchain_khr: unsafe {
                         unsafe extern "system" fn create_swapchain_khr(
@@ -9957,10 +10167,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_display_properties_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_display_properties_khr(
@@ -10154,10 +10367,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_shared_swapchains_khr: unsafe {
                         unsafe extern "system" fn create_shared_swapchains_khr(
@@ -10224,10 +10440,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_xlib_surface_khr: unsafe {
                         unsafe extern "system" fn create_xlib_surface_khr(
@@ -10315,10 +10534,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_xcb_surface_khr: unsafe {
                         unsafe extern "system" fn create_xcb_surface_khr(
@@ -10405,10 +10627,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_wayland_surface_khr: unsafe {
                         unsafe extern "system" fn create_wayland_surface_khr(
@@ -10493,10 +10718,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_android_surface_khr: unsafe {
                         unsafe extern "system" fn create_android_surface_khr(
@@ -10562,10 +10790,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_win32_surface_khr: unsafe {
                         unsafe extern "system" fn create_win32_surface_khr(
@@ -10660,10 +10891,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_video_capabilities_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_video_capabilities_khr(
@@ -10751,10 +10985,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_video_session_khr: unsafe {
                         unsafe extern "system" fn create_video_session_khr(
@@ -11002,10 +11239,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_decode_video_khr: unsafe {
                         unsafe extern "system" fn cmd_decode_video_khr(
@@ -11088,10 +11328,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_begin_rendering_khr: unsafe {
                         unsafe extern "system" fn cmd_begin_rendering_khr(
@@ -11189,10 +11432,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_features2_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_features2_khr(
@@ -11381,10 +11627,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_present_rectangles_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_present_rectangles_khr(
@@ -11448,10 +11697,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_device_group_peer_memory_features_khr: unsafe {
                         unsafe extern "system" fn get_device_group_peer_memory_features_khr(
@@ -11627,10 +11879,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     trim_command_pool_khr: unsafe {
                         unsafe extern "system" fn trim_command_pool_khr(
@@ -11692,10 +11947,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     enumerate_physical_device_groups_khr: unsafe {
                         unsafe extern "system" fn enumerate_physical_device_groups_khr(
@@ -11762,10 +12020,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_external_buffer_properties_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_external_buffer_properties_khr(
@@ -11838,10 +12099,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_memory_win32_handle_khr: unsafe {
                         unsafe extern "system" fn get_memory_win32_handle_khr(
@@ -11929,10 +12193,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_memory_fd_khr: unsafe {
                         unsafe extern "system" fn get_memory_fd_khr(
@@ -12021,10 +12288,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_external_semaphore_properties_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_external_semaphore_properties_khr(
@@ -12099,10 +12369,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     import_semaphore_win32_handle_khr: unsafe {
                         unsafe extern "system" fn import_semaphore_win32_handle_khr(
@@ -12186,10 +12459,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     import_semaphore_fd_khr: unsafe {
                         unsafe extern "system" fn import_semaphore_fd_khr(
@@ -12269,10 +12545,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_push_descriptor_set_khr: unsafe {
                         unsafe extern "system" fn cmd_push_descriptor_set_khr(
@@ -12389,10 +12668,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_descriptor_update_template_khr: unsafe {
                         unsafe extern "system" fn create_descriptor_update_template_khr(
@@ -12534,10 +12816,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_render_pass2_khr: unsafe {
                         unsafe extern "system" fn create_render_pass2_khr(
@@ -12659,10 +12944,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_swapchain_status_khr: unsafe {
                         unsafe extern "system" fn get_swapchain_status_khr(
@@ -12725,10 +13013,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_external_fence_properties_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_external_fence_properties_khr(
@@ -12801,10 +13092,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     import_fence_win32_handle_khr: unsafe {
                         unsafe extern "system" fn import_fence_win32_handle_khr(
@@ -12889,10 +13183,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     import_fence_fd_khr: unsafe {
                         unsafe extern "system" fn import_fence_fd_khr(
@@ -12969,10 +13266,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     enumerate_physical_device_queue_family_performance_query_counters_khr: unsafe {
                         unsafe extern "system" fn enumerate_physical_device_queue_family_performance_query_counters_khr(
@@ -13051,10 +13351,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     acquire_profiling_lock_khr: unsafe {
                         unsafe extern "system" fn acquire_profiling_lock_khr(
@@ -13144,10 +13447,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_surface_capabilities2_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_surface_capabilities2_khr(
@@ -13246,10 +13552,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_display_properties2_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_display_properties2_khr(
@@ -13403,10 +13712,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_image_memory_requirements2_khr: unsafe {
                         unsafe extern "system" fn get_image_memory_requirements2_khr(
@@ -13546,10 +13858,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_acceleration_structure_khr: unsafe {
                         unsafe extern "system" fn create_acceleration_structure_khr(
@@ -13949,10 +14264,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_trace_rays_khr: unsafe {
                         unsafe extern "system" fn cmd_trace_rays_khr(
@@ -14163,10 +14481,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_sampler_ycbcr_conversion_khr: unsafe {
                         unsafe extern "system" fn create_sampler_ycbcr_conversion_khr(
@@ -14253,10 +14574,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     bind_buffer_memory2_khr: unsafe {
                         unsafe extern "system" fn bind_buffer_memory2_khr(
@@ -14346,10 +14670,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_descriptor_set_layout_support_khr: unsafe {
                         unsafe extern "system" fn get_descriptor_set_layout_support_khr(
@@ -14414,10 +14741,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_draw_indirect_count_khr: unsafe {
                         unsafe extern "system" fn cmd_draw_indirect_count_khr(
@@ -14591,10 +14921,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_semaphore_counter_value_khr: unsafe {
                         unsafe extern "system" fn get_semaphore_counter_value_khr(
@@ -14705,10 +15038,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_fragment_shading_rates_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_fragment_shading_rates_khr(
@@ -14766,10 +15102,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_fragment_shading_rate_khr: unsafe {
                         unsafe extern "system" fn cmd_set_fragment_shading_rate_khr(
@@ -14836,10 +15175,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_rendering_attachment_locations_khr: unsafe {
                         unsafe extern "system" fn cmd_set_rendering_attachment_locations_khr(
@@ -14954,10 +15296,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     wait_for_present_khr: unsafe {
                         unsafe extern "system" fn wait_for_present_khr(
@@ -15028,10 +15373,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_buffer_device_address_khr: unsafe {
                         unsafe extern "system" fn get_buffer_device_address_khr(
@@ -15138,10 +15486,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_deferred_operation_khr: unsafe {
                         unsafe extern "system" fn create_deferred_operation_khr(
@@ -15286,10 +15637,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_pipeline_executable_properties_khr: unsafe {
                         unsafe extern "system" fn get_pipeline_executable_properties_khr(
@@ -15399,10 +15753,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     map_memory2_khr: unsafe {
                         unsafe extern "system" fn map_memory2_khr(
@@ -15509,10 +15866,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_video_encode_quality_level_properties_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_video_encode_quality_level_properties_khr(
@@ -15573,10 +15933,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_encoded_video_session_parameters_khr: unsafe {
                         unsafe extern "system" fn get_encoded_video_session_parameters_khr(
@@ -15664,10 +16027,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_event2_khr: unsafe {
                         unsafe extern "system" fn cmd_set_event2_khr(
@@ -15895,10 +16261,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_copy_buffer2_khr: unsafe {
                         unsafe extern "system" fn cmd_copy_buffer2_khr(
@@ -16050,10 +16419,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_trace_rays_indirect2_khr: unsafe {
                         unsafe extern "system" fn cmd_trace_rays_indirect2_khr(
@@ -16126,10 +16498,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_device_buffer_memory_requirements_khr: unsafe {
                         unsafe extern "system" fn get_device_buffer_memory_requirements_khr(
@@ -16255,10 +16630,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_bind_index_buffer2_khr: unsafe {
                         unsafe extern "system" fn cmd_bind_index_buffer2_khr(
@@ -16396,10 +16774,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_cooperative_matrix_properties_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_cooperative_matrix_properties_khr(
@@ -16511,10 +16892,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_line_stipple_khr: unsafe {
                         unsafe extern "system" fn cmd_set_line_stipple_khr(
@@ -16578,10 +16962,13 @@ pub mod khr {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_calibrateable_time_domains_khr: unsafe {
                         unsafe extern "system" fn get_physical_device_calibrateable_time_domains_khr(
@@ -16637,10 +17024,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_calibrated_timestamps_khr: unsafe {
                         unsafe extern "system" fn get_calibrated_timestamps_khr(
@@ -16720,10 +17110,13 @@ pub mod khr {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_bind_descriptor_sets2_khr: unsafe {
                         unsafe extern "system" fn cmd_bind_descriptor_sets2_khr(
@@ -16908,10 +17301,13 @@ pub mod mvk {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_ios_surface_mvk: unsafe {
                         unsafe extern "system" fn create_ios_surface_mvk(
@@ -16974,10 +17370,13 @@ pub mod mvk {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_mac_os_surface_mvk: unsafe {
                         unsafe extern "system" fn create_mac_os_surface_mvk(
@@ -17044,10 +17443,13 @@ pub mod nn {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_vi_surface_nn: unsafe {
                         unsafe extern "system" fn create_vi_surface_nn(
@@ -17135,10 +17537,13 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_external_image_format_properties_nv: unsafe {
                         unsafe extern "system" fn get_physical_device_external_image_format_properties_nv(
@@ -17215,10 +17620,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_memory_win32_handle_nv: unsafe {
                         unsafe extern "system" fn get_memory_win32_handle_nv(
@@ -17290,10 +17698,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_viewport_w_scaling_nv: unsafe {
                         unsafe extern "system" fn cmd_set_viewport_w_scaling_nv(
@@ -17423,10 +17834,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_bind_shading_rate_image_nv: unsafe {
                         unsafe extern "system" fn cmd_bind_shading_rate_image_nv(
@@ -17545,10 +17959,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_acceleration_structure_nv: unsafe {
                         unsafe extern "system" fn create_acceleration_structure_nv(
@@ -17888,10 +18305,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_draw_mesh_tasks_nv: unsafe {
                         unsafe extern "system" fn cmd_draw_mesh_tasks_nv(
@@ -18017,10 +18437,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_exclusive_scissor_enable_nv: unsafe {
                         unsafe extern "system" fn cmd_set_exclusive_scissor_enable_nv(
@@ -18107,10 +18530,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_checkpoint_nv: unsafe {
                         unsafe extern "system" fn cmd_set_checkpoint_nv(
@@ -18200,10 +18626,13 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_cooperative_matrix_properties_nv: unsafe {
                         unsafe extern "system" fn get_physical_device_cooperative_matrix_properties_nv(
@@ -18268,10 +18697,13 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_supported_framebuffer_mixed_samples_combinations_nv: unsafe {
                         unsafe extern "system" fn get_physical_device_supported_framebuffer_mixed_samples_combinations_nv(
@@ -18338,10 +18770,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_generated_commands_memory_requirements_nv: unsafe {
                         unsafe extern "system" fn get_generated_commands_memory_requirements_nv(
@@ -18540,10 +18975,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_cuda_module_nv: unsafe {
                         unsafe extern "system" fn create_cuda_module_nv(
@@ -18714,10 +19152,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_set_fragment_shading_rate_enum_nv: unsafe {
                         unsafe extern "system" fn cmd_set_fragment_shading_rate_enum_nv(
@@ -18790,10 +19231,13 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     acquire_winrt_display_nv: unsafe {
                         unsafe extern "system" fn acquire_winrt_display_nv(
@@ -18871,10 +19315,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_memory_remote_address_nv: unsafe {
                         unsafe extern "system" fn get_memory_remote_address_nv(
@@ -18948,10 +19395,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_copy_memory_indirect_nv: unsafe {
                         unsafe extern "system" fn cmd_copy_memory_indirect_nv(
@@ -19041,10 +19491,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     cmd_decompress_memory_nv: unsafe {
                         unsafe extern "system" fn cmd_decompress_memory_nv(
@@ -19132,10 +19585,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_pipeline_indirect_memory_requirements_nv: unsafe {
                         unsafe extern "system" fn get_pipeline_indirect_memory_requirements_nv(
@@ -19249,10 +19705,13 @@ pub mod nv {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_physical_device_optical_flow_image_formats_nv: unsafe {
                         unsafe extern "system" fn get_physical_device_optical_flow_image_formats_nv(
@@ -19314,10 +19773,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_optical_flow_session_nv: unsafe {
                         unsafe extern "system" fn create_optical_flow_session_nv(
@@ -19464,10 +19926,13 @@ pub mod nv {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     set_latency_sleep_mode_nv: unsafe {
                         unsafe extern "system" fn set_latency_sleep_mode_nv(
@@ -19650,10 +20115,13 @@ pub mod nvx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_cu_module_nvx: unsafe {
                         unsafe extern "system" fn create_cu_module_nvx(
@@ -19792,10 +20260,13 @@ pub mod nvx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_image_view_handle_nvx: unsafe {
                         unsafe extern "system" fn get_image_view_handle_nvx(
@@ -19938,10 +20409,13 @@ pub mod qcom {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_framebuffer_tile_properties_qcom: unsafe {
                         unsafe extern "system" fn get_framebuffer_tile_properties_qcom(
@@ -20080,10 +20554,13 @@ pub mod qnx {
         unsafe impl Send for InstanceFn {}
         unsafe impl Sync for InstanceFn {}
         impl InstanceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     create_screen_surface_qnx: unsafe {
                         unsafe extern "system" fn create_screen_surface_qnx(
@@ -20168,10 +20645,13 @@ pub mod qnx {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_screen_buffer_properties_qnx: unsafe {
                         unsafe extern "system" fn get_screen_buffer_properties_qnx(
@@ -20259,10 +20739,13 @@ pub mod valve {
         unsafe impl Send for DeviceFn {}
         unsafe impl Sync for DeviceFn {}
         impl DeviceFn {
-            pub fn load<F>(mut _f: F) -> Self
+            pub fn load<F>(mut f: F) -> Self
             where
                 F: FnMut(&CStr) -> *const c_void,
             {
+                Self::load_erased(&mut f)
+            }
+            fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                 Self {
                     get_descriptor_set_layout_host_mapping_info_valve: unsafe {
                         unsafe extern "system" fn get_descriptor_set_layout_host_mapping_info_valve(

--- a/ash/src/tables.rs
+++ b/ash/src/tables.rs
@@ -9,10 +9,13 @@ pub struct StaticFn {
 unsafe impl Send for StaticFn {}
 unsafe impl Sync for StaticFn {}
 impl StaticFn {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             get_instance_proc_addr: unsafe {
                 unsafe extern "system" fn get_instance_proc_addr(
@@ -45,10 +48,13 @@ pub struct EntryFnV1_0 {
 unsafe impl Send for EntryFnV1_0 {}
 unsafe impl Sync for EntryFnV1_0 {}
 impl EntryFnV1_0 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             create_instance: unsafe {
                 unsafe extern "system" fn create_instance(
@@ -130,10 +136,13 @@ pub struct InstanceFnV1_0 {
 unsafe impl Send for InstanceFnV1_0 {}
 unsafe impl Sync for InstanceFnV1_0 {}
 impl InstanceFnV1_0 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             destroy_instance: unsafe {
                 unsafe extern "system" fn destroy_instance(
@@ -519,10 +528,13 @@ pub struct DeviceFnV1_0 {
 unsafe impl Send for DeviceFnV1_0 {}
 unsafe impl Sync for DeviceFnV1_0 {}
 impl DeviceFnV1_0 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             destroy_device: unsafe {
                 unsafe extern "system" fn destroy_device(
@@ -2685,10 +2697,13 @@ pub struct EntryFnV1_1 {
 unsafe impl Send for EntryFnV1_1 {}
 unsafe impl Sync for EntryFnV1_1 {}
 impl EntryFnV1_1 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             enumerate_instance_version: unsafe {
                 unsafe extern "system" fn enumerate_instance_version(
@@ -2732,10 +2747,13 @@ pub struct InstanceFnV1_1 {
 unsafe impl Send for InstanceFnV1_1 {}
 unsafe impl Sync for InstanceFnV1_1 {}
 impl InstanceFnV1_1 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             enumerate_physical_device_groups: unsafe {
                 unsafe extern "system" fn enumerate_physical_device_groups(
@@ -2986,10 +3004,13 @@ pub struct DeviceFnV1_1 {
 unsafe impl Send for DeviceFnV1_1 {}
 unsafe impl Sync for DeviceFnV1_1 {}
 impl DeviceFnV1_1 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             bind_buffer_memory2: unsafe {
                 unsafe extern "system" fn bind_buffer_memory2(
@@ -3324,10 +3345,13 @@ pub struct DeviceFnV1_2 {
 unsafe impl Send for DeviceFnV1_2 {}
 unsafe impl Sync for DeviceFnV1_2 {}
 impl DeviceFnV1_2 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             cmd_draw_indirect_count: unsafe {
                 unsafe extern "system" fn cmd_draw_indirect_count(
@@ -3579,10 +3603,13 @@ pub struct InstanceFnV1_3 {
 unsafe impl Send for InstanceFnV1_3 {}
 unsafe impl Sync for InstanceFnV1_3 {}
 impl InstanceFnV1_3 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             get_physical_device_tool_properties: unsafe {
                 unsafe extern "system" fn get_physical_device_tool_properties(
@@ -3650,10 +3677,13 @@ pub struct DeviceFnV1_3 {
 unsafe impl Send for DeviceFnV1_3 {}
 unsafe impl Sync for DeviceFnV1_3 {}
 impl DeviceFnV1_3 {
-    pub fn load<F>(mut _f: F) -> Self
+    pub fn load<F>(mut f: F) -> Self
     where
         F: FnMut(&CStr) -> *const c_void,
     {
+        Self::load_erased(&mut f)
+    }
+    fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
         Self {
             create_private_data_slot: unsafe {
                 unsafe extern "system" fn create_private_data_slot(

--- a/ash/src/tables.rs
+++ b/ash/src/tables.rs
@@ -9,10 +9,7 @@ pub struct StaticFn {
 unsafe impl Send for StaticFn {}
 unsafe impl Sync for StaticFn {}
 impl StaticFn {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -48,10 +45,7 @@ pub struct EntryFnV1_0 {
 unsafe impl Send for EntryFnV1_0 {}
 unsafe impl Sync for EntryFnV1_0 {}
 impl EntryFnV1_0 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -136,10 +130,7 @@ pub struct InstanceFnV1_0 {
 unsafe impl Send for InstanceFnV1_0 {}
 unsafe impl Sync for InstanceFnV1_0 {}
 impl InstanceFnV1_0 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -528,10 +519,7 @@ pub struct DeviceFnV1_0 {
 unsafe impl Send for DeviceFnV1_0 {}
 unsafe impl Sync for DeviceFnV1_0 {}
 impl DeviceFnV1_0 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2697,10 +2685,7 @@ pub struct EntryFnV1_1 {
 unsafe impl Send for EntryFnV1_1 {}
 unsafe impl Sync for EntryFnV1_1 {}
 impl EntryFnV1_1 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -2747,10 +2732,7 @@ pub struct InstanceFnV1_1 {
 unsafe impl Send for InstanceFnV1_1 {}
 unsafe impl Sync for InstanceFnV1_1 {}
 impl InstanceFnV1_1 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3004,10 +2986,7 @@ pub struct DeviceFnV1_1 {
 unsafe impl Send for DeviceFnV1_1 {}
 unsafe impl Sync for DeviceFnV1_1 {}
 impl DeviceFnV1_1 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3345,10 +3324,7 @@ pub struct DeviceFnV1_2 {
 unsafe impl Send for DeviceFnV1_2 {}
 unsafe impl Sync for DeviceFnV1_2 {}
 impl DeviceFnV1_2 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3603,10 +3579,7 @@ pub struct InstanceFnV1_3 {
 unsafe impl Send for InstanceFnV1_3 {}
 unsafe impl Sync for InstanceFnV1_3 {}
 impl InstanceFnV1_3 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
@@ -3677,10 +3650,7 @@ pub struct DeviceFnV1_3 {
 unsafe impl Send for DeviceFnV1_3 {}
 unsafe impl Sync for DeviceFnV1_3 {}
 impl DeviceFnV1_3 {
-    pub fn load<F>(mut f: F) -> Self
-    where
-        F: FnMut(&CStr) -> *const c_void,
-    {
+    pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
         Self::load_erased(&mut f)
     }
     fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1109,9 +1109,7 @@ fn generate_function_pointers<'a>(
     let loader = commands.is_empty().not().then(|| {
         quote! {
             impl #ident {
-                pub fn load<F>(mut f: F) -> Self
-                    where F: FnMut(&CStr) -> *const c_void
-                {
+                pub fn load<F: FnMut(&CStr) -> *const c_void>(mut f: F) -> Self {
                     Self::load_erased(&mut f)
                 }
 

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1109,9 +1109,13 @@ fn generate_function_pointers<'a>(
     let loader = commands.is_empty().not().then(|| {
         quote! {
             impl #ident {
-                pub fn load<F>(mut _f: F) -> Self
+                pub fn load<F>(mut f: F) -> Self
                     where F: FnMut(&CStr) -> *const c_void
                 {
+                    Self::load_erased(&mut f)
+                }
+
+                fn load_erased(_f: &mut dyn FnMut(&CStr) -> *const c_void) -> Self {
                     Self {
                         #(#loaders,)*
                     }


### PR DESCRIPTION
Seems to save about 5MiB (out of 77MiB total pre-change) in the debug build of ash-window's winit example. No obvious impact on compile time or release build size, probably because these only have one callsite each anyway in normal use. Still, seems like an easy win, might have more impact to folks who use `*Fn` directly, and it's nice to know we're not emitting a bunch of unnecessary IR.

No changelog entry as this is not a publicly-visible change.