### PR TITLE
Release `ash 0.38.0` and `ash-window 0.13.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A very lightweight wrapper around Vulkan
 - [x] Additional type safety
 - [x] Device local function pointer loading
 - [x] No validation, everything is **unsafe**
+- [x] Lifetime-safety on structs created with the builder pattern
 - [x] Generated from `vk.xml`
 - [x] Support for Vulkan `1.1`, `1.2`, `1.3`
 - [x] `no_std` support
@@ -146,11 +147,11 @@ Custom loaders can be implemented.
 
 ### Extension loading
 
-Additionally, every Vulkan extension has to be loaded explicitly. You can find all extensions under [`ash::extensions`](https://github.com/ash-rs/ash/tree/master/ash/src/extensions).
+Additionally, every Vulkan extension has to be loaded explicitly. You can find all extensions directly under `ash::*` in a module with their prefix (e.g. `khr` or `ext`).
 
 ```rust
-use ash::extensions::khr::Swapchain;
-let swapchain_loader = Swapchain::new(&instance, &device);
+use ash::khr;
+let swapchain_loader = khr::swapchain::Device::new(&instance, &device);
 let swapchain = swapchain_loader.create_swapchain(&swapchain_create_info).unwrap();
 ```
 
@@ -165,13 +166,13 @@ device.fp_v1_0().destroy_device(...);
 ### Support for extension names
 
 ```rust
-use ash::extensions::{Swapchain, XlibSurface, Surface, DebugReport};
+use ash::{ext, khr};
 #[cfg(all(unix, not(target_os = "android")))]
 fn extension_names() -> Vec<*const i8> {
     vec![
-        Surface::NAME.as_ptr(),
-        XlibSurface::NAME.as_ptr(),
-        DebugReport::NAME.as_ptr()
+        khr::surface::NAME.as_ptr(),
+        khr::xlib_surface::NAME.as_ptr(),
+        ext::debug_utils::NAME.as_ptr(),
     ]
 }
 ```
@@ -236,7 +237,7 @@ Displays a triangle with vertex colors.
 cargo run -p ash-examples --bin triangle
 ```
 
-![screenshot](http://i.imgur.com/PQZcL6w.jpg)
+![screenshot](https://i.imgur.com/PQZcL6w.jpg)
 
 ### [Texture](https://github.com/ash-rs/ash/blob/master/ash-examples/src/bin/texture.rs)
 
@@ -246,7 +247,7 @@ Displays a texture on a quad.
 cargo run -p ash-examples --bin texture
 ```
 
-![texture](http://i.imgur.com/trow00H.png)
+![texture](https://i.imgur.com/trow00H.png)
 
 ## Useful resources
 
@@ -270,7 +271,7 @@ cargo run -p ash-examples --bin texture
 ## A thanks to
 
 - [Api with no secrets](https://software.intel.com/en-us/articles/api-without-secrets-introduction-to-vulkan-part-1)
-- [Vulkan tutorial](http://jhenriques.net/development.html)
+- [Vulkan tutorial](https://jhenriques.net/development.html)
 - [Vulkan examples](https://github.com/SaschaWillems/Vulkan)
 - [Vulkan tutorial](https://vulkan-tutorial.com/)
 - [Vulkano](https://github.com/vulkano-rs/vulkano)

--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ash-window"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     "msiglreith <m.siglreith@gmail.com>",
     "Marijn Suijten <marijn@traverseresearch.nl>",
@@ -19,7 +19,7 @@ edition = "2021"
 rust-version = "1.69.0"
 
 [dependencies]
-ash = { path = "../ash", version = "0.37", default-features = false, features = ["std"] }
+ash = { path = "../ash", version = "0.38", default-features = false, features = ["std"] }
 raw-window-handle = "0.6"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
@@ -27,7 +27,7 @@ raw-window-metal = "0.4"
 
 [dev-dependencies]
 winit = { version = "0.29", features = ["rwh_06"] }
-ash = { path = "../ash", version = "0.37", default-features = false, features = ["linked"] }
+ash = { path = "../ash", version = "0.38", default-features = false, features = ["linked"] }
 
 [[example]]
 name = "winit"

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased] - ReleaseDate
+## [0.13.0] - 2024-03-31
 
 - Bumped MSRV from 1.59 to 1.69 for `winit 0.28` and `raw-window-handle 0.5.1`, and `CStr::from_bytes_until_nul`. (#709, #716, #746)
 - Bumped `raw-window-handle` to `0.6.0` (#799)
+- Bumped `ash` version to [`0.38`](https://github.com/ash-rs/ash/releases/tag/0.38.0) (#TODO)
 
 ## [0.12.0] - 2022-09-23
 
@@ -86,7 +87,8 @@
 ## Version 0.1.0
 Initial release for `raw-window-handle = "0.3"` with Windows, Linux, Android, MacOS/iOS support.
 
-[Unreleased]: https://github.com/ash-rs/ash/compare/ash-window-0.12.0...HEAD
+[Unreleased]: https://github.com/ash-rs/ash/compare/ash-window-0.13.0...HEAD
+[0.12.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.13.0
 [0.12.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.12.0
 [0.11.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.11.0
 [0.10.0]: https://github.com/ash-rs/ash/releases/tag/ash-window-0.10.0

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ash"
-version = "0.37.0+1.3.281"
+version = "0.38.0+1.3.281"
 authors = [
     "Maik Klein <maikklein@googlemail.com>",
     "Benjamin Saunders <ben.e.saunders@gmail.com>",

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -64,7 +64,12 @@ impl Entry {
 
         #[cfg(all(
             unix,
-            not(any(target_os = "macos", target_os = "ios", target_os = "android", target_os = "fuchsia"))
+            not(any(
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "android",
+                target_os = "fuchsia"
+            ))
         ))]
         const LIB_PATH: &str = "libvulkan.so.1";
 


### PR DESCRIPTION
This is a head-start with a "little" migration guide explaining all the breaking changes we've done over the past two (!!) years, to be posted in the GitHub release (and I'm not sure if it should reside in the `keepachangelog` file).  Please let me know if there's anything breaking or otherwise important that deserves a mention.
