### PR TITLE
extensions/khr/calibrated_device: Use `self.handle` instead of requiring `vk::Device` argument

### DIFF
--- a/ash/src/extensions/khr/calibrated_timestamps.rs
+++ b/ash/src/extensions/khr/calibrated_timestamps.rs
@@ -12,13 +12,12 @@ impl crate::khr::calibrated_timestamps::Device {
     #[inline]
     pub unsafe fn get_calibrated_timestamps(
         &self,
-        device: vk::Device,
         info: &[vk::CalibratedTimestampInfoKHR<'_>],
     ) -> VkResult<(Vec<u64>, u64)> {
         let mut timestamps = Vec::with_capacity(info.len());
         let mut max_deviation = mem::MaybeUninit::uninit();
         let max_deviation = (self.fp.get_calibrated_timestamps_khr)(
-            device,
+            self.handle,
             info.len() as u32,
             info.as_ptr(),
             timestamps.as_mut_ptr(),


### PR DESCRIPTION
When introducing this new `VK_KHR_calibrated_timestamps` extension based on `VK_EXT_calibrated_timestamps` in #890 in parallel to finalizing and merging the `Instance`/`Device` separation in #734, I seem to have missed an opportunity to use the newly available `self.handle` for this extension from `struct Device`, instead leaving an unnecessary `device: vk::Device` argument in place.
