### PR TITLE
Add InstanceExtension and DeviceExtension traits

### DIFF
--- a/ash-examples/src/lib.rs
+++ b/ash-examples/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
 use ash::{
     ext::debug_utils,
     khr::{surface, swapchain},
+    prelude::*,
     vk, Device, Entry, Instance,
 };
 use winit::{

--- a/ash-window/examples/winit.rs
+++ b/ash-window/examples/winit.rs
@@ -5,6 +5,7 @@
 //!
 //! On instance extensions platform specific extensions need to be enabled.
 
+use ash::prelude::*;
 use ash::vk;
 use std::error::Error;
 use winit::{

--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -48,20 +48,25 @@ pub mod amd {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = AMD_DRAW_INDIRECT_COUNT_NAME;
+            const SPEC_VERSION: u32 = AMD_DRAW_INDIRECT_COUNT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_DRAW_INDIRECT_COUNT_NAME);
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -177,20 +182,24 @@ pub mod amd {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = AMD_SHADER_INFO_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_INFO_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -275,20 +284,24 @@ pub mod amd {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = AMD_BUFFER_MARKER_NAME;
+            const SPEC_VERSION: u32 = AMD_BUFFER_MARKER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -368,20 +381,24 @@ pub mod amd {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = AMD_DISPLAY_NATIVE_HDR_NAME;
+            const SPEC_VERSION: u32 = AMD_DISPLAY_NATIVE_HDR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -461,20 +478,24 @@ pub mod amdx {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = AMDX_SHADER_ENQUEUE_NAME;
+            const SPEC_VERSION: u32 = AMDX_SHADER_ENQUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -668,20 +689,24 @@ pub mod android {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = ANDROID_NATIVE_BUFFER_NAME;
+            const SPEC_VERSION: u32 = ANDROID_NATIVE_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -808,20 +833,24 @@ pub mod android {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_NAME;
+            const SPEC_VERSION: u32 = ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -954,20 +983,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_DEBUG_REPORT_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_REPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -1079,20 +1112,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DEBUG_MARKER_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_MARKER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(EXT_DEBUG_UTILS_NAME);
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -1224,20 +1262,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_TRANSFORM_FEEDBACK_NAME;
+            const SPEC_VERSION: u32 = EXT_TRANSFORM_FEEDBACK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -1460,20 +1502,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_CONDITIONAL_RENDERING_NAME;
+            const SPEC_VERSION: u32 = EXT_CONDITIONAL_RENDERING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -1549,20 +1595,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_DIRECT_MODE_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = EXT_DIRECT_MODE_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -1611,20 +1661,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_ACQUIRE_XLIB_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -1700,20 +1754,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_DISPLAY_SURFACE_COUNTER_NAME;
+            const SPEC_VERSION: u32 = EXT_DISPLAY_SURFACE_COUNTER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -1769,20 +1827,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DISPLAY_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_DISPLAY_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -1903,20 +1965,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DISCARD_RECTANGLES_NAME;
+            const SPEC_VERSION: u32 = EXT_DISCARD_RECTANGLES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2037,20 +2103,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_HDR_METADATA_NAME;
+            const SPEC_VERSION: u32 = EXT_HDR_METADATA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2117,20 +2187,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_DEBUG_UTILS_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_UTILS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -2222,20 +2296,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DEBUG_UTILS_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_UTILS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2450,20 +2528,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_SAMPLE_LOCATIONS_NAME;
+            const SPEC_VERSION: u32 = EXT_SAMPLE_LOCATIONS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -2511,20 +2593,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_SAMPLE_LOCATIONS_NAME;
+            const SPEC_VERSION: u32 = EXT_SAMPLE_LOCATIONS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2593,20 +2679,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_DRM_FORMAT_MODIFIER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2662,20 +2752,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_VALIDATION_CACHE_NAME;
+            const SPEC_VERSION: u32 = EXT_VALIDATION_CACHE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2827,20 +2921,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_EXTERNAL_MEMORY_HOST_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTERNAL_MEMORY_HOST_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -2898,20 +2996,25 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_CALIBRATED_TIMESTAMPS_NAME;
+            const SPEC_VERSION: u32 = EXT_CALIBRATED_TIMESTAMPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_CALIBRATED_TIMESTAMPS_NAME);
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -2959,20 +3062,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_CALIBRATED_TIMESTAMPS_NAME;
+            const SPEC_VERSION: u32 = EXT_CALIBRATED_TIMESTAMPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_CALIBRATED_TIMESTAMPS_NAME);
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -3052,20 +3160,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_METAL_SURFACE_NAME;
+            const SPEC_VERSION: u32 = EXT_METAL_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -3168,20 +3280,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_BUFFER_DEVICE_ADDRESS_NAME;
+            const SPEC_VERSION: u32 = EXT_BUFFER_DEVICE_ADDRESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -3234,20 +3350,25 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_TOOLING_INFO_NAME;
+            const SPEC_VERSION: u32 = EXT_TOOLING_INFO_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -3342,20 +3463,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_FULL_SCREEN_EXCLUSIVE_NAME;
+            const SPEC_VERSION: u32 = EXT_FULL_SCREEN_EXCLUSIVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -3404,20 +3529,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_FULL_SCREEN_EXCLUSIVE_NAME;
+            const SPEC_VERSION: u32 = EXT_FULL_SCREEN_EXCLUSIVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -3515,20 +3644,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_HEADLESS_SURFACE_NAME;
+            const SPEC_VERSION: u32 = EXT_HEADLESS_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -3583,20 +3716,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_LINE_RASTERIZATION_NAME;
+            const SPEC_VERSION: u32 = EXT_LINE_RASTERIZATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_LINE_RASTERIZATION_NAME);
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -3658,20 +3796,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_HOST_QUERY_RESET_NAME;
+            const SPEC_VERSION: u32 = EXT_HOST_QUERY_RESET_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 2, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -3730,20 +3873,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_EXTENDED_DYNAMIC_STATE_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTENDED_DYNAMIC_STATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4025,20 +4173,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_HOST_IMAGE_COPY_NAME;
+            const SPEC_VERSION: u32 = EXT_HOST_IMAGE_COPY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4198,20 +4350,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_SWAPCHAIN_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = EXT_SWAPCHAIN_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4280,20 +4436,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DEPTH_BIAS_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_DEPTH_BIAS_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4353,20 +4513,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_ACQUIRE_DRM_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = EXT_ACQUIRE_DRM_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -4454,20 +4618,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_PRIVATE_DATA_NAME;
+            const SPEC_VERSION: u32 = EXT_PRIVATE_DATA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4589,20 +4758,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_METAL_OBJECTS_NAME;
+            const SPEC_VERSION: u32 = EXT_METAL_OBJECTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4655,20 +4828,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DESCRIPTOR_BUFFER_NAME;
+            const SPEC_VERSION: u32 = EXT_DESCRIPTOR_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -4961,20 +5138,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_MESH_SHADER_NAME;
+            const SPEC_VERSION: u32 = EXT_MESH_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5101,20 +5282,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_IMAGE_COMPRESSION_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_COMPRESSION_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5186,20 +5371,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_DEVICE_FAULT_NAME;
+            const SPEC_VERSION: u32 = EXT_DEVICE_FAULT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5261,20 +5450,24 @@ pub mod ext {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = EXT_DIRECTFB_SURFACE_NAME;
+            const SPEC_VERSION: u32 = EXT_DIRECTFB_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -5352,20 +5545,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_VERTEX_INPUT_DYNAMIC_STATE_NAME;
+            const SPEC_VERSION: u32 = EXT_VERTEX_INPUT_DYNAMIC_STATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5453,20 +5650,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_PIPELINE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5543,20 +5744,25 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_EXTENDED_DYNAMIC_STATE2_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTENDED_DYNAMIC_STATE2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5687,20 +5893,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_COLOR_WRITE_ENABLE_NAME;
+            const SPEC_VERSION: u32 = EXT_COLOR_WRITE_ENABLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5778,20 +5988,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_MULTI_DRAW_NAME;
+            const SPEC_VERSION: u32 = EXT_MULTI_DRAW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -5885,20 +6099,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_OPACITY_MICROMAP_NAME;
+            const SPEC_VERSION: u32 = EXT_OPACITY_MICROMAP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -6233,20 +6451,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_NAME;
+            const SPEC_VERSION: u32 = EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -6348,20 +6570,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_EXTENDED_DYNAMIC_STATE3_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTENDED_DYNAMIC_STATE3_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -7057,20 +7283,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_SHADER_MODULE_IDENTIFIER_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_MODULE_IDENTIFIER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -7172,20 +7402,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_SHADER_OBJECT_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_OBJECT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -8351,20 +8585,24 @@ pub mod ext {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_NAME;
+            const SPEC_VERSION: u32 = EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -8422,20 +8660,24 @@ pub mod fuchsia {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = FUCHSIA_IMAGEPIPE_SURFACE_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_IMAGEPIPE_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -8491,20 +8733,24 @@ pub mod fuchsia {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = FUCHSIA_EXTERNAL_MEMORY_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_EXTERNAL_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -8583,20 +8829,24 @@ pub mod fuchsia {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = FUCHSIA_EXTERNAL_SEMAPHORE_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_EXTERNAL_SEMAPHORE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -8674,20 +8924,24 @@ pub mod fuchsia {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = FUCHSIA_BUFFER_COLLECTION_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_BUFFER_COLLECTION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -8837,20 +9091,24 @@ pub mod ggp {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = GGP_STREAM_DESCRIPTOR_SURFACE_NAME;
+            const SPEC_VERSION: u32 = GGP_STREAM_DESCRIPTOR_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -8917,20 +9175,24 @@ pub mod google {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = GOOGLE_DISPLAY_TIMING_NAME;
+            const SPEC_VERSION: u32 = GOOGLE_DISPLAY_TIMING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -9043,20 +9305,24 @@ pub mod huawei {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = HUAWEI_SUBPASS_SHADING_NAME;
+            const SPEC_VERSION: u32 = HUAWEI_SUBPASS_SHADING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -9131,20 +9397,24 @@ pub mod huawei {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = HUAWEI_INVOCATION_MASK_NAME;
+            const SPEC_VERSION: u32 = HUAWEI_INVOCATION_MASK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -9198,20 +9468,24 @@ pub mod huawei {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = HUAWEI_CLUSTER_CULLING_SHADER_NAME;
+            const SPEC_VERSION: u32 = HUAWEI_CLUSTER_CULLING_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -9326,20 +9600,24 @@ pub mod intel {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = INTEL_PERFORMANCE_QUERY_NAME;
+            const SPEC_VERSION: u32 = INTEL_PERFORMANCE_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -9566,20 +9844,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -9722,20 +10004,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_SWAPCHAIN_NAME;
+            const SPEC_VERSION: u32 = KHR_SWAPCHAIN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -9784,20 +10070,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_SWAPCHAIN_NAME;
+            const SPEC_VERSION: u32 = KHR_SWAPCHAIN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -9995,20 +10285,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = KHR_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10201,20 +10495,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DISPLAY_SWAPCHAIN_NAME;
+            const SPEC_VERSION: u32 = KHR_DISPLAY_SWAPCHAIN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -10270,20 +10568,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_XLIB_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_XLIB_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10362,20 +10664,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_XCB_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_XCB_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10453,20 +10759,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_WAYLAND_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_WAYLAND_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10544,20 +10854,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_ANDROID_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_ANDROID_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10612,20 +10926,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_WIN32_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_WIN32_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10710,20 +11028,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_VIDEO_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -10795,20 +11117,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_VIDEO_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -11057,20 +11383,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_VIDEO_DECODE_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_DECODE_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -11143,20 +11473,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DYNAMIC_RENDERING_NAME;
+            const SPEC_VERSION: u32 = KHR_DYNAMIC_RENDERING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -11235,20 +11570,25 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -11438,20 +11778,25 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_DEVICE_GROUP_NAME;
+            const SPEC_VERSION: u32 = KHR_DEVICE_GROUP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -11500,20 +11845,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DEVICE_GROUP_NAME;
+            const SPEC_VERSION: u32 = KHR_DEVICE_GROUP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -11687,20 +12037,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -11753,20 +12108,25 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_DEVICE_GROUP_CREATION_NAME;
+            const SPEC_VERSION: u32 = KHR_DEVICE_GROUP_CREATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -11823,20 +12183,25 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -11900,20 +12265,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_WIN32_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -11992,20 +12361,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_FD_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_FD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12085,20 +12458,25 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -12164,20 +12542,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_WIN32_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12252,20 +12634,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_FD_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_FD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12335,20 +12721,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_PUSH_DESCRIPTOR_NAME;
+            const SPEC_VERSION: u32 = KHR_PUSH_DESCRIPTOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12454,20 +12844,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DESCRIPTOR_UPDATE_TEMPLATE_NAME;
+            const SPEC_VERSION: u32 = KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12601,20 +12996,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_CREATE_RENDERPASS2_NAME;
+            const SPEC_VERSION: u32 = KHR_CREATE_RENDERPASS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 2, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12730,20 +13130,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_SHARED_PRESENTABLE_IMAGE_NAME;
+            const SPEC_VERSION: u32 = KHR_SHARED_PRESENTABLE_IMAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12796,20 +13200,25 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -12873,20 +13282,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_WIN32_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -12962,20 +13375,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_FD_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_FD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -13041,20 +13458,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_PERFORMANCE_QUERY_NAME;
+            const SPEC_VERSION: u32 = KHR_PERFORMANCE_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -13126,20 +13547,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_PERFORMANCE_QUERY_NAME;
+            const SPEC_VERSION: u32 = KHR_PERFORMANCE_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -13219,20 +13644,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_GET_SURFACE_CAPABILITIES2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_SURFACE_CAPABILITIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -13319,20 +13748,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_GET_DISPLAY_PROPERTIES2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_DISPLAY_PROPERTIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -13480,20 +13913,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_GET_MEMORY_REQUIREMENTS2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_MEMORY_REQUIREMENTS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -13601,20 +14039,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_ACCELERATION_STRUCTURE_NAME;
+            const SPEC_VERSION: u32 = KHR_ACCELERATION_STRUCTURE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14021,20 +14463,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_RAY_TRACING_PIPELINE_NAME;
+            const SPEC_VERSION: u32 = KHR_RAY_TRACING_PIPELINE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14244,20 +14690,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_SAMPLER_YCBCR_CONVERSION_NAME;
+            const SPEC_VERSION: u32 = KHR_SAMPLER_YCBCR_CONVERSION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14335,20 +14786,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_BIND_MEMORY2_NAME;
+            const SPEC_VERSION: u32 = KHR_BIND_MEMORY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14430,20 +14886,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_MAINTENANCE3_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE3_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 1, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14498,20 +14959,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DRAW_INDIRECT_COUNT_NAME;
+            const SPEC_VERSION: u32 = KHR_DRAW_INDIRECT_COUNT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 2, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14675,20 +15141,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_TIMELINE_SEMAPHORE_NAME;
+            const SPEC_VERSION: u32 = KHR_TIMELINE_SEMAPHORE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 2, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14791,20 +15262,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_FRAGMENT_SHADING_RATE_NAME;
+            const SPEC_VERSION: u32 = KHR_FRAGMENT_SHADING_RATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -14854,20 +15329,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_FRAGMENT_SHADING_RATE_NAME;
+            const SPEC_VERSION: u32 = KHR_FRAGMENT_SHADING_RATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -14922,20 +15401,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DYNAMIC_RENDERING_LOCAL_READ_NAME;
+            const SPEC_VERSION: u32 = KHR_DYNAMIC_RENDERING_LOCAL_READ_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15044,20 +15527,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_PRESENT_WAIT_NAME;
+            const SPEC_VERSION: u32 = KHR_PRESENT_WAIT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15116,20 +15603,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_BUFFER_DEVICE_ADDRESS_NAME;
+            const SPEC_VERSION: u32 = KHR_BUFFER_DEVICE_ADDRESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 2, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15225,20 +15717,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_DEFERRED_HOST_OPERATIONS_NAME;
+            const SPEC_VERSION: u32 = KHR_DEFERRED_HOST_OPERATIONS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15376,20 +15872,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_PIPELINE_EXECUTABLE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = KHR_PIPELINE_EXECUTABLE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15492,20 +15992,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_MAP_MEMORY2_NAME;
+            const SPEC_VERSION: u32 = KHR_MAP_MEMORY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15603,20 +16107,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_VIDEO_ENCODE_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -15668,20 +16176,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_VIDEO_ENCODE_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15754,20 +16266,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_SYNCHRONIZATION2_NAME;
+            const SPEC_VERSION: u32 = KHR_SYNCHRONIZATION2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -15988,20 +16505,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_COPY_COMMANDS2_NAME;
+            const SPEC_VERSION: u32 = KHR_COPY_COMMANDS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -16149,20 +16671,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_RAY_TRACING_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = KHR_RAY_TRACING_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -16223,20 +16749,25 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_MAINTENANCE4_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE4_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(make_api_version(0, 1, 3, 0));
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -16353,20 +16884,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_MAINTENANCE5_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE5_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -16497,20 +17032,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_COOPERATIVE_MATRIX_NAME;
+            const SPEC_VERSION: u32 = KHR_COOPERATIVE_MATRIX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -16614,20 +17153,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_LINE_RASTERIZATION_NAME;
+            const SPEC_VERSION: u32 = KHR_LINE_RASTERIZATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -16681,20 +17224,24 @@ pub mod khr {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = KHR_CALIBRATED_TIMESTAMPS_NAME;
+            const SPEC_VERSION: u32 = KHR_CALIBRATED_TIMESTAMPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -16742,20 +17289,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_CALIBRATED_TIMESTAMPS_NAME;
+            const SPEC_VERSION: u32 = KHR_CALIBRATED_TIMESTAMPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -16819,20 +17370,24 @@ pub mod khr {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = KHR_MAINTENANCE6_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE6_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -17015,20 +17570,24 @@ pub mod mvk {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = MVK_IOS_SURFACE_NAME;
+            const SPEC_VERSION: u32 = MVK_IOS_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -17082,20 +17641,24 @@ pub mod mvk {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = MVK_MACOS_SURFACE_NAME;
+            const SPEC_VERSION: u32 = MVK_MACOS_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -17153,20 +17716,24 @@ pub mod nn {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = NN_VI_SURFACE_NAME;
+            const SPEC_VERSION: u32 = NN_VI_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -17244,20 +17811,24 @@ pub mod nv {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -17326,20 +17897,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_WIN32_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -17402,20 +17977,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_CLIP_SPACE_W_SCALING_NAME;
+            const SPEC_VERSION: u32 = NV_CLIP_SPACE_W_SCALING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -17534,20 +18113,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_SHADING_RATE_IMAGE_NAME;
+            const SPEC_VERSION: u32 = NV_SHADING_RATE_IMAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -17646,20 +18229,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_RAY_TRACING_NAME;
+            const SPEC_VERSION: u32 = NV_RAY_TRACING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18001,20 +18588,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_MESH_SHADER_NAME;
+            const SPEC_VERSION: u32 = NV_MESH_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18132,20 +18723,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_SCISSOR_EXCLUSIVE_NAME;
+            const SPEC_VERSION: u32 = NV_SCISSOR_EXCLUSIVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18223,20 +18818,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18317,20 +18916,24 @@ pub mod nv {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = NV_COOPERATIVE_MATRIX_NAME;
+            const SPEC_VERSION: u32 = NV_COOPERATIVE_MATRIX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -18386,20 +18989,24 @@ pub mod nv {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = NV_COVERAGE_REDUCTION_MODE_NAME;
+            const SPEC_VERSION: u32 = NV_COVERAGE_REDUCTION_MODE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -18452,20 +19059,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_DEVICE_GENERATED_COMMANDS_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_GENERATED_COMMANDS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18656,20 +19267,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_CUDA_KERNEL_LAUNCH_NAME;
+            const SPEC_VERSION: u32 = NV_CUDA_KERNEL_LAUNCH_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18836,20 +19451,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_FRAGMENT_SHADING_RATE_ENUMS_NAME;
+            const SPEC_VERSION: u32 = NV_FRAGMENT_SHADING_RATE_ENUMS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -18912,20 +19531,24 @@ pub mod nv {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = NV_ACQUIRE_WINRT_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = NV_ACQUIRE_WINRT_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -18995,20 +19618,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_RDMA_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_RDMA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19072,20 +19699,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_COPY_MEMORY_INDIRECT_NAME;
+            const SPEC_VERSION: u32 = NV_COPY_MEMORY_INDIRECT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19166,20 +19797,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_MEMORY_DECOMPRESSION_NAME;
+            const SPEC_VERSION: u32 = NV_MEMORY_DECOMPRESSION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19256,20 +19891,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_DEVICE_GENERATED_COMMANDS_COMPUTE_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_GENERATED_COMMANDS_COMPUTE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19376,20 +20015,24 @@ pub mod nv {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = NV_OPTICAL_FLOW_NAME;
+            const SPEC_VERSION: u32 = NV_OPTICAL_FLOW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -19440,20 +20083,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_OPTICAL_FLOW_NAME;
+            const SPEC_VERSION: u32 = NV_OPTICAL_FLOW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19590,20 +20237,24 @@ pub mod nv {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NV_LOW_LATENCY2_NAME;
+            const SPEC_VERSION: u32 = NV_LOW_LATENCY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19777,20 +20428,24 @@ pub mod nvx {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NVX_BINARY_IMPORT_NAME;
+            const SPEC_VERSION: u32 = NVX_BINARY_IMPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -19923,20 +20578,24 @@ pub mod nvx {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = NVX_IMAGE_VIEW_HANDLE_NAME;
+            const SPEC_VERSION: u32 = NVX_IMAGE_VIEW_HANDLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -20069,20 +20728,24 @@ pub mod qcom {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = QCOM_TILE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = QCOM_TILE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -20212,20 +20875,24 @@ pub mod qnx {
             pub(crate) fp: InstanceFn,
             pub(crate) handle: crate::vk::Instance,
         }
-        impl Instance {
-            pub fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
+        impl InstanceExtension for Instance {
+            const NAME: &'static CStr = QNX_SCREEN_SURFACE_NAME;
+            const SPEC_VERSION: u32 = QNX_SCREEN_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self {
                 let handle = instance.handle();
                 let fp = InstanceFn::load(|name| unsafe {
                     core::mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = InstanceFn;
             #[inline]
-            pub fn fp(&self) -> &InstanceFn {
+            fn fp(&self) -> &InstanceFn {
                 &self.fp
             }
             #[inline]
-            pub fn instance(&self) -> crate::vk::Instance {
+            fn instance(&self) -> crate::vk::Instance {
                 self.handle
             }
         }
@@ -20303,20 +20970,24 @@ pub mod qnx {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = QNX_EXTERNAL_MEMORY_SCREEN_BUFFER_NAME;
+            const SPEC_VERSION: u32 = QNX_EXTERNAL_MEMORY_SCREEN_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }
@@ -20393,20 +21064,24 @@ pub mod valve {
             pub(crate) fp: DeviceFn,
             pub(crate) handle: crate::vk::Device,
         }
-        impl Device {
-            pub fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
+        impl DeviceExtension for Device {
+            const NAME: &'static CStr = VALVE_DESCRIPTOR_SET_HOST_MAPPING_NAME;
+            const SPEC_VERSION: u32 = VALVE_DESCRIPTOR_SET_HOST_MAPPING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            fn new(instance: &crate::Instance, device: &crate::Device) -> Self {
                 let handle = device.handle();
                 let fp = DeviceFn::load(|name| unsafe {
                     core::mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
                 });
                 Self { handle, fp }
             }
+            type Fp = DeviceFn;
             #[inline]
-            pub fn fp(&self) -> &DeviceFn {
+            fn fp(&self) -> &DeviceFn {
                 &self.fp
             }
             #[inline]
-            pub fn device(&self) -> crate::vk::Device {
+            fn device(&self) -> crate::vk::Device {
                 self.handle
             }
         }

--- a/ash/src/prelude.rs
+++ b/ash/src/prelude.rs
@@ -5,6 +5,7 @@ use core::ptr;
 
 use crate::vk;
 pub type VkResult<T> = Result<T, vk::Result>;
+pub use vk::{DeviceExtension, InstanceExtension};
 
 impl vk::Result {
     #[inline]

--- a/ash/src/vk/prelude.rs
+++ b/ash/src/vk/prelude.rs
@@ -107,3 +107,30 @@ pub(crate) fn write_c_str_slice_with_nul(
         .copy_from_slice(bytes);
     Ok(())
 }
+
+pub enum PromotionStatus {
+    None,
+    PromotedToCore(u32),
+    PromotedToExtension(&'static std::ffi::CStr),
+}
+pub trait InstanceExtension: Send + Sync + 'static {
+    fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self;
+    const NAME: &'static std::ffi::CStr;
+    const SPEC_VERSION: u32;
+
+    type Fp;
+    fn fp(&self) -> &Self::Fp;
+    fn instance(&self) -> vk::Instance;
+    const PROMOTION_STATUS: PromotionStatus;
+}
+
+pub trait DeviceExtension: Send + Sync + Sized + 'static {
+    fn new(instance: &crate::Instance, device: &crate::Device) -> Self;
+    const NAME: &'static std::ffi::CStr;
+    const SPEC_VERSION: u32;
+
+    type Fp;
+    fn fp(&self) -> &Self::Fp;
+    fn device(&self) -> vk::Device;
+    const PROMOTION_STATUS: PromotionStatus;
+}


### PR DESCRIPTION
Create new marker traits `InstanceExtension` and `DeviceExtension` as defined below:

```rs
pub enum PromotionStatus {
    None,
    PromotedToCore(u32),
    PromotedToExtension(&'static std::ffi::CStr),
}
pub trait InstanceExtension: Send + Sync + 'static {
    fn new(entry: &crate::Entry, instance: &crate::Instance) -> Self;
    const NAME: &'static std::ffi::CStr;
    const SPEC_VERSION: u32;

    type Fp;
    fn fp(&self) -> &Self::Fp;
    fn instance(&self) -> vk::Instance;
    const PROMOTION_STATUS: PromotionStatus;
}

pub trait DeviceExtension: Send + Sync + Sized + 'static {
    fn new(instance: &crate::Instance, device: &crate::Device) -> Self;
    const NAME: &'static std::ffi::CStr;
    const SPEC_VERSION: u32;

    type Fp;
    fn fp(&self) -> &Self::Fp;
    fn device(&self) -> vk::Device;
    const PROMOTION_STATUS: PromotionStatus;
}
```
These traits are automatically implemented for all extension fp structs.

Traits like these make it easier to manage extensions in higher level abstractions. Marker traits like these are not unprecedented: we already have `TaggedStructure` and `Extends*` traits, and the changes proposed in this PR are similar in spirit.
