### PR TITLE
Add ExtensionMeta traits

### DIFF
--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -10,6 +10,16 @@ pub mod amd {
             crate::vk::AMD_RASTERIZATION_ORDER_NAME as NAME,
             crate::vk::AMD_RASTERIZATION_ORDER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_RASTERIZATION_ORDER_NAME;
+            const SPEC_VERSION: u32 = AMD_RASTERIZATION_ORDER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_trinary_minmax"]
     pub mod shader_trinary_minmax {
@@ -18,6 +28,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_TRINARY_MINMAX_NAME as NAME,
             crate::vk::AMD_SHADER_TRINARY_MINMAX_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_TRINARY_MINMAX_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_TRINARY_MINMAX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_explicit_vertex_parameter"]
     pub mod shader_explicit_vertex_parameter {
@@ -26,6 +46,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_NAME as NAME,
             crate::vk::AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_gcn_shader"]
     pub mod gcn_shader {
@@ -34,6 +64,16 @@ pub mod amd {
             crate::vk::AMD_GCN_SHADER_NAME as NAME,
             crate::vk::AMD_GCN_SHADER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_GCN_SHADER_NAME;
+            const SPEC_VERSION: u32 = AMD_GCN_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_draw_indirect_count"]
     pub mod draw_indirect_count {
@@ -131,6 +171,19 @@ pub mod amd {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_DRAW_INDIRECT_COUNT_NAME;
+            const SPEC_VERSION: u32 = AMD_DRAW_INDIRECT_COUNT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_DRAW_INDIRECT_COUNT_NAME);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_negative_viewport_height"]
     pub mod negative_viewport_height {
@@ -139,6 +192,16 @@ pub mod amd {
             crate::vk::AMD_NEGATIVE_VIEWPORT_HEIGHT_NAME as NAME,
             crate::vk::AMD_NEGATIVE_VIEWPORT_HEIGHT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_NEGATIVE_VIEWPORT_HEIGHT_NAME;
+            const SPEC_VERSION: u32 = AMD_NEGATIVE_VIEWPORT_HEIGHT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_gpu_shader_half_float"]
     pub mod gpu_shader_half_float {
@@ -147,6 +210,16 @@ pub mod amd {
             crate::vk::AMD_GPU_SHADER_HALF_FLOAT_NAME as NAME,
             crate::vk::AMD_GPU_SHADER_HALF_FLOAT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_GPU_SHADER_HALF_FLOAT_NAME;
+            const SPEC_VERSION: u32 = AMD_GPU_SHADER_HALF_FLOAT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_ballot"]
     pub mod shader_ballot {
@@ -155,6 +228,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_BALLOT_NAME as NAME,
             crate::vk::AMD_SHADER_BALLOT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_BALLOT_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_BALLOT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_texture_gather_bias_lod"]
     pub mod texture_gather_bias_lod {
@@ -163,6 +246,16 @@ pub mod amd {
             crate::vk::AMD_TEXTURE_GATHER_BIAS_LOD_NAME as NAME,
             crate::vk::AMD_TEXTURE_GATHER_BIAS_LOD_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_TEXTURE_GATHER_BIAS_LOD_NAME;
+            const SPEC_VERSION: u32 = AMD_TEXTURE_GATHER_BIAS_LOD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_info"]
     pub mod shader_info {
@@ -229,6 +322,18 @@ pub mod amd {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_INFO_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_INFO_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_image_load_store_lod"]
     pub mod shader_image_load_store_lod {
@@ -237,6 +342,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_IMAGE_LOAD_STORE_LOD_NAME as NAME,
             crate::vk::AMD_SHADER_IMAGE_LOAD_STORE_LOD_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_IMAGE_LOAD_STORE_LOD_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_IMAGE_LOAD_STORE_LOD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_gpu_shader_int16"]
     pub mod gpu_shader_int16 {
@@ -245,6 +360,16 @@ pub mod amd {
             crate::vk::AMD_GPU_SHADER_INT16_NAME as NAME,
             crate::vk::AMD_GPU_SHADER_INT16_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_GPU_SHADER_INT16_NAME;
+            const SPEC_VERSION: u32 = AMD_GPU_SHADER_INT16_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_mixed_attachment_samples"]
     pub mod mixed_attachment_samples {
@@ -253,6 +378,16 @@ pub mod amd {
             crate::vk::AMD_MIXED_ATTACHMENT_SAMPLES_NAME as NAME,
             crate::vk::AMD_MIXED_ATTACHMENT_SAMPLES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_MIXED_ATTACHMENT_SAMPLES_NAME;
+            const SPEC_VERSION: u32 = AMD_MIXED_ATTACHMENT_SAMPLES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_fragment_mask"]
     pub mod shader_fragment_mask {
@@ -261,6 +396,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_FRAGMENT_MASK_NAME as NAME,
             crate::vk::AMD_SHADER_FRAGMENT_MASK_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_FRAGMENT_MASK_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_FRAGMENT_MASK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_buffer_marker"]
     pub mod buffer_marker {
@@ -330,6 +475,18 @@ pub mod amd {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_BUFFER_MARKER_NAME;
+            const SPEC_VERSION: u32 = AMD_BUFFER_MARKER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_pipeline_compiler_control"]
     pub mod pipeline_compiler_control {
@@ -338,6 +495,16 @@ pub mod amd {
             crate::vk::AMD_PIPELINE_COMPILER_CONTROL_NAME as NAME,
             crate::vk::AMD_PIPELINE_COMPILER_CONTROL_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_PIPELINE_COMPILER_CONTROL_NAME;
+            const SPEC_VERSION: u32 = AMD_PIPELINE_COMPILER_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_core_properties"]
     pub mod shader_core_properties {
@@ -346,6 +513,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_CORE_PROPERTIES_NAME as NAME,
             crate::vk::AMD_SHADER_CORE_PROPERTIES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_CORE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_CORE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_memory_overallocation_behavior"]
     pub mod memory_overallocation_behavior {
@@ -354,6 +531,16 @@ pub mod amd {
             crate::vk::AMD_MEMORY_OVERALLOCATION_BEHAVIOR_NAME as NAME,
             crate::vk::AMD_MEMORY_OVERALLOCATION_BEHAVIOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_MEMORY_OVERALLOCATION_BEHAVIOR_NAME;
+            const SPEC_VERSION: u32 = AMD_MEMORY_OVERALLOCATION_BEHAVIOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_display_native_hdr"]
     pub mod display_native_hdr {
@@ -420,6 +607,18 @@ pub mod amd {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_DISPLAY_NATIVE_HDR_NAME;
+            const SPEC_VERSION: u32 = AMD_DISPLAY_NATIVE_HDR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_core_properties2"]
     pub mod shader_core_properties2 {
@@ -428,6 +627,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_CORE_PROPERTIES2_NAME as NAME,
             crate::vk::AMD_SHADER_CORE_PROPERTIES2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_CORE_PROPERTIES2_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_CORE_PROPERTIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_device_coherent_memory"]
     pub mod device_coherent_memory {
@@ -436,6 +645,16 @@ pub mod amd {
             crate::vk::AMD_DEVICE_COHERENT_MEMORY_NAME as NAME,
             crate::vk::AMD_DEVICE_COHERENT_MEMORY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_DEVICE_COHERENT_MEMORY_NAME;
+            const SPEC_VERSION: u32 = AMD_DEVICE_COHERENT_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_AMD_shader_early_and_late_fragment_tests"]
     pub mod shader_early_and_late_fragment_tests {
@@ -444,6 +663,16 @@ pub mod amd {
             crate::vk::AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_NAME as NAME,
             crate::vk::AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_NAME;
+            const SPEC_VERSION: u32 = AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged AMDX"]
@@ -651,6 +880,18 @@ pub mod amdx {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = AMDX_SHADER_ENQUEUE_NAME;
+            const SPEC_VERSION: u32 = AMDX_SHADER_ENQUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged ANDROID"]
@@ -794,6 +1035,18 @@ pub mod android {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ANDROID_NATIVE_BUFFER_NAME;
+            const SPEC_VERSION: u32 = ANDROID_NATIVE_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_ANDROID_external_memory_android_hardware_buffer"]
     pub mod external_memory_android_hardware_buffer {
@@ -886,6 +1139,18 @@ pub mod android {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_NAME;
+            const SPEC_VERSION: u32 = ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_ANDROID_external_format_resolve"]
     pub mod external_format_resolve {
@@ -894,6 +1159,16 @@ pub mod android {
             crate::vk::ANDROID_EXTERNAL_FORMAT_RESOLVE_NAME as NAME,
             crate::vk::ANDROID_EXTERNAL_FORMAT_RESOLVE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ANDROID_EXTERNAL_FORMAT_RESOLVE_NAME;
+            const SPEC_VERSION: u32 = ANDROID_EXTERNAL_FORMAT_RESOLVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged ARM"]
@@ -905,6 +1180,18 @@ pub mod arm {
             crate::vk::ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_NAME as NAME,
             crate::vk::ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_NAME;
+            const SPEC_VERSION: u32 = ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::PromotedToExtension(
+                EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_NAME,
+            );
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_ARM_shader_core_properties"]
     pub mod shader_core_properties {
@@ -913,6 +1200,16 @@ pub mod arm {
             crate::vk::ARM_SHADER_CORE_PROPERTIES_NAME as NAME,
             crate::vk::ARM_SHADER_CORE_PROPERTIES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ARM_SHADER_CORE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = ARM_SHADER_CORE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_ARM_scheduling_controls"]
     pub mod scheduling_controls {
@@ -921,6 +1218,16 @@ pub mod arm {
             crate::vk::ARM_SCHEDULING_CONTROLS_NAME as NAME,
             crate::vk::ARM_SCHEDULING_CONTROLS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ARM_SCHEDULING_CONTROLS_NAME;
+            const SPEC_VERSION: u32 = ARM_SCHEDULING_CONTROLS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_ARM_render_pass_striped"]
     pub mod render_pass_striped {
@@ -929,6 +1236,16 @@ pub mod arm {
             crate::vk::ARM_RENDER_PASS_STRIPED_NAME as NAME,
             crate::vk::ARM_RENDER_PASS_STRIPED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ARM_RENDER_PASS_STRIPED_NAME;
+            const SPEC_VERSION: u32 = ARM_RENDER_PASS_STRIPED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_ARM_shader_core_builtins"]
     pub mod shader_core_builtins {
@@ -937,6 +1254,16 @@ pub mod arm {
             crate::vk::ARM_SHADER_CORE_BUILTINS_NAME as NAME,
             crate::vk::ARM_SHADER_CORE_BUILTINS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = ARM_SHADER_CORE_BUILTINS_NAME;
+            const SPEC_VERSION: u32 = ARM_SHADER_CORE_BUILTINS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged EXT"]
@@ -1057,6 +1384,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEBUG_REPORT_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_REPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_depth_range_unrestricted"]
     pub mod depth_range_unrestricted {
@@ -1065,6 +1404,16 @@ pub mod ext {
             crate::vk::EXT_DEPTH_RANGE_UNRESTRICTED_NAME as NAME,
             crate::vk::EXT_DEPTH_RANGE_UNRESTRICTED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEPTH_RANGE_UNRESTRICTED_NAME;
+            const SPEC_VERSION: u32 = EXT_DEPTH_RANGE_UNRESTRICTED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_debug_marker"]
     pub mod debug_marker {
@@ -1209,6 +1558,19 @@ pub mod ext {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEBUG_MARKER_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_MARKER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(EXT_DEBUG_UTILS_NAME);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_EXT_transform_feedback"]
@@ -1398,6 +1760,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_TRANSFORM_FEEDBACK_NAME;
+            const SPEC_VERSION: u32 = EXT_TRANSFORM_FEEDBACK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_validation_flags"]
     pub mod validation_flags {
@@ -1406,6 +1780,16 @@ pub mod ext {
             crate::vk::EXT_VALIDATION_FLAGS_NAME as NAME,
             crate::vk::EXT_VALIDATION_FLAGS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_VALIDATION_FLAGS_NAME;
+            const SPEC_VERSION: u32 = EXT_VALIDATION_FLAGS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_subgroup_ballot"]
     pub mod shader_subgroup_ballot {
@@ -1414,6 +1798,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_SUBGROUP_BALLOT_NAME as NAME,
             crate::vk::EXT_SHADER_SUBGROUP_BALLOT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_SUBGROUP_BALLOT_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_SUBGROUP_BALLOT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_subgroup_vote"]
     pub mod shader_subgroup_vote {
@@ -1422,6 +1816,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_SUBGROUP_VOTE_NAME as NAME,
             crate::vk::EXT_SHADER_SUBGROUP_VOTE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_SUBGROUP_VOTE_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_SUBGROUP_VOTE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_texture_compression_astc_hdr"]
     pub mod texture_compression_astc_hdr {
@@ -1430,6 +1834,17 @@ pub mod ext {
             crate::vk::EXT_TEXTURE_COMPRESSION_ASTC_HDR_NAME as NAME,
             crate::vk::EXT_TEXTURE_COMPRESSION_ASTC_HDR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_TEXTURE_COMPRESSION_ASTC_HDR_NAME;
+            const SPEC_VERSION: u32 = EXT_TEXTURE_COMPRESSION_ASTC_HDR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_astc_decode_mode"]
     pub mod astc_decode_mode {
@@ -1438,6 +1853,16 @@ pub mod ext {
             crate::vk::EXT_ASTC_DECODE_MODE_NAME as NAME,
             crate::vk::EXT_ASTC_DECODE_MODE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_ASTC_DECODE_MODE_NAME;
+            const SPEC_VERSION: u32 = EXT_ASTC_DECODE_MODE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pipeline_robustness"]
     pub mod pipeline_robustness {
@@ -1446,6 +1871,16 @@ pub mod ext {
             crate::vk::EXT_PIPELINE_ROBUSTNESS_NAME as NAME,
             crate::vk::EXT_PIPELINE_ROBUSTNESS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PIPELINE_ROBUSTNESS_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_ROBUSTNESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_conditional_rendering"]
     pub mod conditional_rendering {
@@ -1535,6 +1970,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_CONDITIONAL_RENDERING_NAME;
+            const SPEC_VERSION: u32 = EXT_CONDITIONAL_RENDERING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_direct_mode_display"]
     pub mod direct_mode_display {
@@ -1595,6 +2042,18 @@ pub mod ext {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DIRECT_MODE_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = EXT_DIRECT_MODE_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -1686,6 +2145,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_ACQUIRE_XLIB_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_display_surface_counter"]
     pub mod display_surface_counter {
@@ -1753,6 +2224,18 @@ pub mod ext {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DISPLAY_SURFACE_COUNTER_NAME;
+            const SPEC_VERSION: u32 = EXT_DISPLAY_SURFACE_COUNTER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -1889,6 +2372,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DISPLAY_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_DISPLAY_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_discard_rectangles"]
     pub mod discard_rectangles {
@@ -1999,6 +2494,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DISCARD_RECTANGLES_NAME;
+            const SPEC_VERSION: u32 = EXT_DISCARD_RECTANGLES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_conservative_rasterization"]
     pub mod conservative_rasterization {
@@ -2007,6 +2514,16 @@ pub mod ext {
             crate::vk::EXT_CONSERVATIVE_RASTERIZATION_NAME as NAME,
             crate::vk::EXT_CONSERVATIVE_RASTERIZATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_CONSERVATIVE_RASTERIZATION_NAME;
+            const SPEC_VERSION: u32 = EXT_CONSERVATIVE_RASTERIZATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_depth_clip_enable"]
     pub mod depth_clip_enable {
@@ -2015,6 +2532,16 @@ pub mod ext {
             crate::vk::EXT_DEPTH_CLIP_ENABLE_NAME as NAME,
             crate::vk::EXT_DEPTH_CLIP_ENABLE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEPTH_CLIP_ENABLE_NAME;
+            const SPEC_VERSION: u32 = EXT_DEPTH_CLIP_ENABLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_swapchain_colorspace"]
     pub mod swapchain_colorspace {
@@ -2023,6 +2550,16 @@ pub mod ext {
             crate::vk::EXT_SWAPCHAIN_COLORSPACE_NAME as NAME,
             crate::vk::EXT_SWAPCHAIN_COLORSPACE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SWAPCHAIN_COLORSPACE_NAME;
+            const SPEC_VERSION: u32 = EXT_SWAPCHAIN_COLORSPACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_hdr_metadata"]
     pub mod hdr_metadata {
@@ -2087,6 +2624,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_HDR_METADATA_NAME;
+            const SPEC_VERSION: u32 = EXT_HDR_METADATA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_external_memory_dma_buf"]
     pub mod external_memory_dma_buf {
@@ -2095,6 +2644,16 @@ pub mod ext {
             crate::vk::EXT_EXTERNAL_MEMORY_DMA_BUF_NAME as NAME,
             crate::vk::EXT_EXTERNAL_MEMORY_DMA_BUF_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_EXTERNAL_MEMORY_DMA_BUF_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTERNAL_MEMORY_DMA_BUF_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_queue_family_foreign"]
     pub mod queue_family_foreign {
@@ -2103,6 +2662,16 @@ pub mod ext {
             crate::vk::EXT_QUEUE_FAMILY_FOREIGN_NAME as NAME,
             crate::vk::EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_QUEUE_FAMILY_FOREIGN_NAME;
+            const SPEC_VERSION: u32 = EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_debug_utils"]
     pub mod debug_utils {
@@ -2412,6 +2981,20 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEBUG_UTILS_NAME;
+            const SPEC_VERSION: u32 = EXT_DEBUG_UTILS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_sampler_filter_minmax"]
     pub mod sampler_filter_minmax {
@@ -2420,6 +3003,17 @@ pub mod ext {
             crate::vk::EXT_SAMPLER_FILTER_MINMAX_NAME as NAME,
             crate::vk::EXT_SAMPLER_FILTER_MINMAX_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SAMPLER_FILTER_MINMAX_NAME;
+            const SPEC_VERSION: u32 = EXT_SAMPLER_FILTER_MINMAX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_inline_uniform_block"]
     pub mod inline_uniform_block {
@@ -2428,6 +3022,17 @@ pub mod ext {
             crate::vk::EXT_INLINE_UNIFORM_BLOCK_NAME as NAME,
             crate::vk::EXT_INLINE_UNIFORM_BLOCK_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_INLINE_UNIFORM_BLOCK_NAME;
+            const SPEC_VERSION: u32 = EXT_INLINE_UNIFORM_BLOCK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_stencil_export"]
     pub mod shader_stencil_export {
@@ -2436,6 +3041,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_STENCIL_EXPORT_NAME as NAME,
             crate::vk::EXT_SHADER_STENCIL_EXPORT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_STENCIL_EXPORT_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_STENCIL_EXPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_sample_locations"]
     pub mod sample_locations {
@@ -2563,6 +3178,20 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SAMPLE_LOCATIONS_NAME;
+            const SPEC_VERSION: u32 = EXT_SAMPLE_LOCATIONS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_blend_operation_advanced"]
     pub mod blend_operation_advanced {
@@ -2571,6 +3200,16 @@ pub mod ext {
             crate::vk::EXT_BLEND_OPERATION_ADVANCED_NAME as NAME,
             crate::vk::EXT_BLEND_OPERATION_ADVANCED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_BLEND_OPERATION_ADVANCED_NAME;
+            const SPEC_VERSION: u32 = EXT_BLEND_OPERATION_ADVANCED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_post_depth_coverage"]
     pub mod post_depth_coverage {
@@ -2579,6 +3218,16 @@ pub mod ext {
             crate::vk::EXT_POST_DEPTH_COVERAGE_NAME as NAME,
             crate::vk::EXT_POST_DEPTH_COVERAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_POST_DEPTH_COVERAGE_NAME;
+            const SPEC_VERSION: u32 = EXT_POST_DEPTH_COVERAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_drm_format_modifier"]
     pub mod image_drm_format_modifier {
@@ -2647,6 +3296,18 @@ pub mod ext {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_DRM_FORMAT_MODIFIER_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_DRM_FORMAT_MODIFIER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_EXT_validation_cache"]
@@ -2781,6 +3442,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_VALIDATION_CACHE_NAME;
+            const SPEC_VERSION: u32 = EXT_VALIDATION_CACHE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_descriptor_indexing"]
     pub mod descriptor_indexing {
@@ -2789,6 +3462,17 @@ pub mod ext {
             crate::vk::EXT_DESCRIPTOR_INDEXING_NAME as NAME,
             crate::vk::EXT_DESCRIPTOR_INDEXING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DESCRIPTOR_INDEXING_NAME;
+            const SPEC_VERSION: u32 = EXT_DESCRIPTOR_INDEXING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_viewport_index_layer"]
     pub mod shader_viewport_index_layer {
@@ -2797,6 +3481,17 @@ pub mod ext {
             crate::vk::EXT_SHADER_VIEWPORT_INDEX_LAYER_NAME as NAME,
             crate::vk::EXT_SHADER_VIEWPORT_INDEX_LAYER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_VIEWPORT_INDEX_LAYER_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_VIEWPORT_INDEX_LAYER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_filter_cubic"]
     pub mod filter_cubic {
@@ -2805,6 +3500,16 @@ pub mod ext {
             crate::vk::EXT_FILTER_CUBIC_NAME as NAME,
             crate::vk::EXT_FILTER_CUBIC_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_FILTER_CUBIC_NAME;
+            const SPEC_VERSION: u32 = EXT_FILTER_CUBIC_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_global_priority"]
     pub mod global_priority {
@@ -2813,6 +3518,17 @@ pub mod ext {
             crate::vk::EXT_GLOBAL_PRIORITY_NAME as NAME,
             crate::vk::EXT_GLOBAL_PRIORITY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_GLOBAL_PRIORITY_NAME;
+            const SPEC_VERSION: u32 = EXT_GLOBAL_PRIORITY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_GLOBAL_PRIORITY_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_external_memory_host"]
     pub mod external_memory_host {
@@ -2883,6 +3599,18 @@ pub mod ext {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_EXTERNAL_MEMORY_HOST_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTERNAL_MEMORY_HOST_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_EXT_calibrated_timestamps"]
@@ -3014,6 +3742,21 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_CALIBRATED_TIMESTAMPS_NAME;
+            const SPEC_VERSION: u32 = EXT_CALIBRATED_TIMESTAMPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_CALIBRATED_TIMESTAMPS_NAME);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_vertex_attribute_divisor"]
     pub mod vertex_attribute_divisor {
@@ -3022,6 +3765,17 @@ pub mod ext {
             crate::vk::EXT_VERTEX_ATTRIBUTE_DIVISOR_NAME as NAME,
             crate::vk::EXT_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_VERTEX_ATTRIBUTE_DIVISOR_NAME;
+            const SPEC_VERSION: u32 = EXT_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_VERTEX_ATTRIBUTE_DIVISOR_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pipeline_creation_feedback"]
     pub mod pipeline_creation_feedback {
@@ -3030,6 +3784,17 @@ pub mod ext {
             crate::vk::EXT_PIPELINE_CREATION_FEEDBACK_NAME as NAME,
             crate::vk::EXT_PIPELINE_CREATION_FEEDBACK_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PIPELINE_CREATION_FEEDBACK_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_CREATION_FEEDBACK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pci_bus_info"]
     pub mod pci_bus_info {
@@ -3038,6 +3803,16 @@ pub mod ext {
             crate::vk::EXT_PCI_BUS_INFO_NAME as NAME,
             crate::vk::EXT_PCI_BUS_INFO_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PCI_BUS_INFO_NAME;
+            const SPEC_VERSION: u32 = EXT_PCI_BUS_INFO_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_metal_surface"]
     pub mod metal_surface {
@@ -3106,6 +3881,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_METAL_SURFACE_NAME;
+            const SPEC_VERSION: u32 = EXT_METAL_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_fragment_density_map"]
     pub mod fragment_density_map {
@@ -3114,6 +3901,16 @@ pub mod ext {
             crate::vk::EXT_FRAGMENT_DENSITY_MAP_NAME as NAME,
             crate::vk::EXT_FRAGMENT_DENSITY_MAP_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_FRAGMENT_DENSITY_MAP_NAME;
+            const SPEC_VERSION: u32 = EXT_FRAGMENT_DENSITY_MAP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_scalar_block_layout"]
     pub mod scalar_block_layout {
@@ -3122,6 +3919,17 @@ pub mod ext {
             crate::vk::EXT_SCALAR_BLOCK_LAYOUT_NAME as NAME,
             crate::vk::EXT_SCALAR_BLOCK_LAYOUT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SCALAR_BLOCK_LAYOUT_NAME;
+            const SPEC_VERSION: u32 = EXT_SCALAR_BLOCK_LAYOUT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_subgroup_size_control"]
     pub mod subgroup_size_control {
@@ -3130,6 +3938,17 @@ pub mod ext {
             crate::vk::EXT_SUBGROUP_SIZE_CONTROL_NAME as NAME,
             crate::vk::EXT_SUBGROUP_SIZE_CONTROL_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SUBGROUP_SIZE_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_SUBGROUP_SIZE_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_image_atomic_int64"]
     pub mod shader_image_atomic_int64 {
@@ -3138,6 +3957,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_IMAGE_ATOMIC_INT64_NAME as NAME,
             crate::vk::EXT_SHADER_IMAGE_ATOMIC_INT64_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_IMAGE_ATOMIC_INT64_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_IMAGE_ATOMIC_INT64_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_memory_budget"]
     pub mod memory_budget {
@@ -3146,6 +3975,16 @@ pub mod ext {
             crate::vk::EXT_MEMORY_BUDGET_NAME as NAME,
             crate::vk::EXT_MEMORY_BUDGET_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MEMORY_BUDGET_NAME;
+            const SPEC_VERSION: u32 = EXT_MEMORY_BUDGET_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_memory_priority"]
     pub mod memory_priority {
@@ -3154,6 +3993,16 @@ pub mod ext {
             crate::vk::EXT_MEMORY_PRIORITY_NAME as NAME,
             crate::vk::EXT_MEMORY_PRIORITY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MEMORY_PRIORITY_NAME;
+            const SPEC_VERSION: u32 = EXT_MEMORY_PRIORITY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_buffer_device_address"]
     pub mod buffer_device_address {
@@ -3219,6 +4068,18 @@ pub mod ext {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_BUFFER_DEVICE_ADDRESS_NAME;
+            const SPEC_VERSION: u32 = EXT_BUFFER_DEVICE_ADDRESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_EXT_tooling_info"]
@@ -3288,6 +4149,19 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_TOOLING_INFO_NAME;
+            const SPEC_VERSION: u32 = EXT_TOOLING_INFO_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_separate_stencil_usage"]
     pub mod separate_stencil_usage {
@@ -3296,6 +4170,17 @@ pub mod ext {
             crate::vk::EXT_SEPARATE_STENCIL_USAGE_NAME as NAME,
             crate::vk::EXT_SEPARATE_STENCIL_USAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SEPARATE_STENCIL_USAGE_NAME;
+            const SPEC_VERSION: u32 = EXT_SEPARATE_STENCIL_USAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_validation_features"]
     pub mod validation_features {
@@ -3304,6 +4189,16 @@ pub mod ext {
             crate::vk::EXT_VALIDATION_FEATURES_NAME as NAME,
             crate::vk::EXT_VALIDATION_FEATURES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_VALIDATION_FEATURES_NAME;
+            const SPEC_VERSION: u32 = EXT_VALIDATION_FEATURES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_fragment_shader_interlock"]
     pub mod fragment_shader_interlock {
@@ -3312,6 +4207,16 @@ pub mod ext {
             crate::vk::EXT_FRAGMENT_SHADER_INTERLOCK_NAME as NAME,
             crate::vk::EXT_FRAGMENT_SHADER_INTERLOCK_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_FRAGMENT_SHADER_INTERLOCK_NAME;
+            const SPEC_VERSION: u32 = EXT_FRAGMENT_SHADER_INTERLOCK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_ycbcr_image_arrays"]
     pub mod ycbcr_image_arrays {
@@ -3320,6 +4225,16 @@ pub mod ext {
             crate::vk::EXT_YCBCR_IMAGE_ARRAYS_NAME as NAME,
             crate::vk::EXT_YCBCR_IMAGE_ARRAYS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_YCBCR_IMAGE_ARRAYS_NAME;
+            const SPEC_VERSION: u32 = EXT_YCBCR_IMAGE_ARRAYS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_provoking_vertex"]
     pub mod provoking_vertex {
@@ -3328,6 +4243,16 @@ pub mod ext {
             crate::vk::EXT_PROVOKING_VERTEX_NAME as NAME,
             crate::vk::EXT_PROVOKING_VERTEX_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PROVOKING_VERTEX_NAME;
+            const SPEC_VERSION: u32 = EXT_PROVOKING_VERTEX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_full_screen_exclusive"]
     pub mod full_screen_exclusive {
@@ -3501,6 +4426,20 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_FULL_SCREEN_EXCLUSIVE_NAME;
+            const SPEC_VERSION: u32 = EXT_FULL_SCREEN_EXCLUSIVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_headless_surface"]
     pub mod headless_surface {
@@ -3567,6 +4506,18 @@ pub mod ext {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_HEADLESS_SURFACE_NAME;
+            const SPEC_VERSION: u32 = EXT_HEADLESS_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -3636,6 +4587,19 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_LINE_RASTERIZATION_NAME;
+            const SPEC_VERSION: u32 = EXT_LINE_RASTERIZATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_LINE_RASTERIZATION_NAME);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_atomic_float"]
     pub mod shader_atomic_float {
@@ -3644,6 +4608,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_ATOMIC_FLOAT_NAME as NAME,
             crate::vk::EXT_SHADER_ATOMIC_FLOAT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_ATOMIC_FLOAT_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_ATOMIC_FLOAT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_host_query_reset"]
     pub mod host_query_reset {
@@ -3708,6 +4682,19 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_HOST_QUERY_RESET_NAME;
+            const SPEC_VERSION: u32 = EXT_HOST_QUERY_RESET_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_index_type_uint8"]
     pub mod index_type_uint8 {
@@ -3716,6 +4703,17 @@ pub mod ext {
             crate::vk::EXT_INDEX_TYPE_UINT8_NAME as NAME,
             crate::vk::EXT_INDEX_TYPE_UINT8_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_INDEX_TYPE_UINT8_NAME;
+            const SPEC_VERSION: u32 = EXT_INDEX_TYPE_UINT8_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_INDEX_TYPE_UINT8_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_extended_dynamic_state"]
     pub mod extended_dynamic_state {
@@ -4011,6 +5009,19 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_EXTENDED_DYNAMIC_STATE_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTENDED_DYNAMIC_STATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_host_image_copy"]
     pub mod host_image_copy {
@@ -4160,6 +5171,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_HOST_IMAGE_COPY_NAME;
+            const SPEC_VERSION: u32 = EXT_HOST_IMAGE_COPY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_map_memory_placed"]
     pub mod map_memory_placed {
@@ -4168,6 +5191,16 @@ pub mod ext {
             crate::vk::EXT_MAP_MEMORY_PLACED_NAME as NAME,
             crate::vk::EXT_MAP_MEMORY_PLACED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MAP_MEMORY_PLACED_NAME;
+            const SPEC_VERSION: u32 = EXT_MAP_MEMORY_PLACED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_atomic_float2"]
     pub mod shader_atomic_float2 {
@@ -4176,6 +5209,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_ATOMIC_FLOAT2_NAME as NAME,
             crate::vk::EXT_SHADER_ATOMIC_FLOAT2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_ATOMIC_FLOAT2_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_ATOMIC_FLOAT2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_surface_maintenance1"]
     pub mod surface_maintenance1 {
@@ -4184,6 +5227,16 @@ pub mod ext {
             crate::vk::EXT_SURFACE_MAINTENANCE1_NAME as NAME,
             crate::vk::EXT_SURFACE_MAINTENANCE1_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SURFACE_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = EXT_SURFACE_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_swapchain_maintenance1"]
     pub mod swapchain_maintenance1 {
@@ -4250,6 +5303,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SWAPCHAIN_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = EXT_SWAPCHAIN_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_demote_to_helper_invocation"]
     pub mod shader_demote_to_helper_invocation {
@@ -4258,6 +5323,17 @@ pub mod ext {
             crate::vk::EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_NAME as NAME,
             crate::vk::EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_texel_buffer_alignment"]
     pub mod texel_buffer_alignment {
@@ -4266,6 +5342,17 @@ pub mod ext {
             crate::vk::EXT_TEXEL_BUFFER_ALIGNMENT_NAME as NAME,
             crate::vk::EXT_TEXEL_BUFFER_ALIGNMENT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_TEXEL_BUFFER_ALIGNMENT_NAME;
+            const SPEC_VERSION: u32 = EXT_TEXEL_BUFFER_ALIGNMENT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_depth_bias_control"]
     pub mod depth_bias_control {
@@ -4331,6 +5418,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEPTH_BIAS_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_DEPTH_BIAS_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_device_memory_report"]
     pub mod device_memory_report {
@@ -4339,6 +5438,16 @@ pub mod ext {
             crate::vk::EXT_DEVICE_MEMORY_REPORT_NAME as NAME,
             crate::vk::EXT_DEVICE_MEMORY_REPORT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEVICE_MEMORY_REPORT_NAME;
+            const SPEC_VERSION: u32 = EXT_DEVICE_MEMORY_REPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_acquire_drm_display"]
     pub mod acquire_drm_display {
@@ -4424,6 +5533,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_ACQUIRE_DRM_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = EXT_ACQUIRE_DRM_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_robustness2"]
     pub mod robustness2 {
@@ -4432,6 +5553,16 @@ pub mod ext {
             crate::vk::EXT_ROBUSTNESS2_NAME as NAME,
             crate::vk::EXT_ROBUSTNESS2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_ROBUSTNESS2_NAME;
+            const SPEC_VERSION: u32 = EXT_ROBUSTNESS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_custom_border_color"]
     pub mod custom_border_color {
@@ -4440,6 +5571,16 @@ pub mod ext {
             crate::vk::EXT_CUSTOM_BORDER_COLOR_NAME as NAME,
             crate::vk::EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_CUSTOM_BORDER_COLOR_NAME;
+            const SPEC_VERSION: u32 = EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_private_data"]
     pub mod private_data {
@@ -4567,6 +5708,19 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PRIVATE_DATA_NAME;
+            const SPEC_VERSION: u32 = EXT_PRIVATE_DATA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pipeline_creation_cache_control"]
     pub mod pipeline_creation_cache_control {
@@ -4575,6 +5729,17 @@ pub mod ext {
             crate::vk::EXT_PIPELINE_CREATION_CACHE_CONTROL_NAME as NAME,
             crate::vk::EXT_PIPELINE_CREATION_CACHE_CONTROL_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PIPELINE_CREATION_CACHE_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_CREATION_CACHE_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_metal_objects"]
     pub mod metal_objects {
@@ -4640,6 +5805,18 @@ pub mod ext {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_METAL_OBJECTS_NAME;
+            const SPEC_VERSION: u32 = EXT_METAL_OBJECTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_EXT_descriptor_buffer"]
@@ -4939,6 +6116,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DESCRIPTOR_BUFFER_NAME;
+            const SPEC_VERSION: u32 = EXT_DESCRIPTOR_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_graphics_pipeline_library"]
     pub mod graphics_pipeline_library {
@@ -4947,6 +6136,16 @@ pub mod ext {
             crate::vk::EXT_GRAPHICS_PIPELINE_LIBRARY_NAME as NAME,
             crate::vk::EXT_GRAPHICS_PIPELINE_LIBRARY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_GRAPHICS_PIPELINE_LIBRARY_NAME;
+            const SPEC_VERSION: u32 = EXT_GRAPHICS_PIPELINE_LIBRARY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_mesh_shader"]
     pub mod mesh_shader {
@@ -5063,6 +6262,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MESH_SHADER_NAME;
+            const SPEC_VERSION: u32 = EXT_MESH_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_ycbcr_2plane_444_formats"]
     pub mod ycbcr_2plane_444_formats {
@@ -5071,6 +6282,17 @@ pub mod ext {
             crate::vk::EXT_YCBCR_2PLANE_444_FORMATS_NAME as NAME,
             crate::vk::EXT_YCBCR_2PLANE_444_FORMATS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_YCBCR_2PLANE_444_FORMATS_NAME;
+            const SPEC_VERSION: u32 = EXT_YCBCR_2PLANE_444_FORMATS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_fragment_density_map2"]
     pub mod fragment_density_map2 {
@@ -5079,6 +6301,16 @@ pub mod ext {
             crate::vk::EXT_FRAGMENT_DENSITY_MAP2_NAME as NAME,
             crate::vk::EXT_FRAGMENT_DENSITY_MAP2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_FRAGMENT_DENSITY_MAP2_NAME;
+            const SPEC_VERSION: u32 = EXT_FRAGMENT_DENSITY_MAP2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_robustness"]
     pub mod image_robustness {
@@ -5087,6 +6319,17 @@ pub mod ext {
             crate::vk::EXT_IMAGE_ROBUSTNESS_NAME as NAME,
             crate::vk::EXT_IMAGE_ROBUSTNESS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_ROBUSTNESS_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_ROBUSTNESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_compression_control"]
     pub mod image_compression_control {
@@ -5156,6 +6399,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_COMPRESSION_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_COMPRESSION_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_attachment_feedback_loop_layout"]
     pub mod attachment_feedback_loop_layout {
@@ -5164,6 +6419,16 @@ pub mod ext {
             crate::vk::EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_NAME as NAME,
             crate::vk::EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_NAME;
+            const SPEC_VERSION: u32 = EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_4444_formats"]
     pub mod _4444_formats {
@@ -5172,6 +6437,17 @@ pub mod ext {
             crate::vk::EXT_4444_FORMATS_NAME as NAME,
             crate::vk::EXT_4444_FORMATS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_4444_FORMATS_NAME;
+            const SPEC_VERSION: u32 = EXT_4444_FORMATS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_device_fault"]
     pub mod device_fault {
@@ -5239,6 +6515,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEVICE_FAULT_NAME;
+            const SPEC_VERSION: u32 = EXT_DEVICE_FAULT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_rgba10x6_formats"]
     pub mod rgba10x6_formats {
@@ -5247,6 +6535,16 @@ pub mod ext {
             crate::vk::EXT_RGBA10X6_FORMATS_NAME as NAME,
             crate::vk::EXT_RGBA10X6_FORMATS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_RGBA10X6_FORMATS_NAME;
+            const SPEC_VERSION: u32 = EXT_RGBA10X6_FORMATS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_directfb_surface"]
     pub mod directfb_surface {
@@ -5338,6 +6636,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DIRECTFB_SURFACE_NAME;
+            const SPEC_VERSION: u32 = EXT_DIRECTFB_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_EXT_vertex_input_dynamic_state"]
     pub mod vertex_input_dynamic_state {
@@ -5407,6 +6717,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_VERTEX_INPUT_DYNAMIC_STATE_NAME;
+            const SPEC_VERSION: u32 = EXT_VERTEX_INPUT_DYNAMIC_STATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_physical_device_drm"]
     pub mod physical_device_drm {
@@ -5415,6 +6737,16 @@ pub mod ext {
             crate::vk::EXT_PHYSICAL_DEVICE_DRM_NAME as NAME,
             crate::vk::EXT_PHYSICAL_DEVICE_DRM_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PHYSICAL_DEVICE_DRM_NAME;
+            const SPEC_VERSION: u32 = EXT_PHYSICAL_DEVICE_DRM_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_device_address_binding_report"]
     pub mod device_address_binding_report {
@@ -5423,6 +6755,16 @@ pub mod ext {
             crate::vk::EXT_DEVICE_ADDRESS_BINDING_REPORT_NAME as NAME,
             crate::vk::EXT_DEVICE_ADDRESS_BINDING_REPORT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEVICE_ADDRESS_BINDING_REPORT_NAME;
+            const SPEC_VERSION: u32 = EXT_DEVICE_ADDRESS_BINDING_REPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_depth_clip_control"]
     pub mod depth_clip_control {
@@ -5431,6 +6773,16 @@ pub mod ext {
             crate::vk::EXT_DEPTH_CLIP_CONTROL_NAME as NAME,
             crate::vk::EXT_DEPTH_CLIP_CONTROL_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEPTH_CLIP_CONTROL_NAME;
+            const SPEC_VERSION: u32 = EXT_DEPTH_CLIP_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_primitive_topology_list_restart"]
     pub mod primitive_topology_list_restart {
@@ -5439,6 +6791,16 @@ pub mod ext {
             crate::vk::EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_NAME as NAME,
             crate::vk::EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_NAME;
+            const SPEC_VERSION: u32 = EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pipeline_properties"]
     pub mod pipeline_properties {
@@ -5513,6 +6875,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PIPELINE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_frame_boundary"]
     pub mod frame_boundary {
@@ -5521,6 +6895,16 @@ pub mod ext {
             crate::vk::EXT_FRAME_BOUNDARY_NAME as NAME,
             crate::vk::EXT_FRAME_BOUNDARY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_FRAME_BOUNDARY_NAME;
+            const SPEC_VERSION: u32 = EXT_FRAME_BOUNDARY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_multisampled_render_to_single_sampled"]
     pub mod multisampled_render_to_single_sampled {
@@ -5529,6 +6913,16 @@ pub mod ext {
             crate::vk::EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_NAME as NAME,
             crate::vk::EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_NAME;
+            const SPEC_VERSION: u32 = EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_extended_dynamic_state2"]
     pub mod extended_dynamic_state2 {
@@ -5673,6 +7067,19 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_EXTENDED_DYNAMIC_STATE2_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTENDED_DYNAMIC_STATE2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_color_write_enable"]
     pub mod color_write_enable {
@@ -5740,6 +7147,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_COLOR_WRITE_ENABLE_NAME;
+            const SPEC_VERSION: u32 = EXT_COLOR_WRITE_ENABLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_primitives_generated_query"]
     pub mod primitives_generated_query {
@@ -5748,6 +7167,16 @@ pub mod ext {
             crate::vk::EXT_PRIMITIVES_GENERATED_QUERY_NAME as NAME,
             crate::vk::EXT_PRIMITIVES_GENERATED_QUERY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PRIMITIVES_GENERATED_QUERY_NAME;
+            const SPEC_VERSION: u32 = EXT_PRIMITIVES_GENERATED_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_global_priority_query"]
     pub mod global_priority_query {
@@ -5756,6 +7185,17 @@ pub mod ext {
             crate::vk::EXT_GLOBAL_PRIORITY_QUERY_NAME as NAME,
             crate::vk::EXT_GLOBAL_PRIORITY_QUERY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_GLOBAL_PRIORITY_QUERY_NAME;
+            const SPEC_VERSION: u32 = EXT_GLOBAL_PRIORITY_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_GLOBAL_PRIORITY_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_view_min_lod"]
     pub mod image_view_min_lod {
@@ -5764,6 +7204,16 @@ pub mod ext {
             crate::vk::EXT_IMAGE_VIEW_MIN_LOD_NAME as NAME,
             crate::vk::EXT_IMAGE_VIEW_MIN_LOD_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_VIEW_MIN_LOD_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_VIEW_MIN_LOD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_multi_draw"]
     pub mod multi_draw {
@@ -5855,6 +7305,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MULTI_DRAW_NAME;
+            const SPEC_VERSION: u32 = EXT_MULTI_DRAW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_2d_view_of_3d"]
     pub mod image_2d_view_of_3d {
@@ -5863,6 +7325,16 @@ pub mod ext {
             crate::vk::EXT_IMAGE_2D_VIEW_OF_3D_NAME as NAME,
             crate::vk::EXT_IMAGE_2D_VIEW_OF_3D_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_2D_VIEW_OF_3D_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_2D_VIEW_OF_3D_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_tile_image"]
     pub mod shader_tile_image {
@@ -5871,6 +7343,16 @@ pub mod ext {
             crate::vk::EXT_SHADER_TILE_IMAGE_NAME as NAME,
             crate::vk::EXT_SHADER_TILE_IMAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_TILE_IMAGE_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_TILE_IMAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_opacity_micromap"]
     pub mod opacity_micromap {
@@ -6203,6 +7685,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_OPACITY_MICROMAP_NAME;
+            const SPEC_VERSION: u32 = EXT_OPACITY_MICROMAP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_load_store_op_none"]
     pub mod load_store_op_none {
@@ -6211,6 +7705,17 @@ pub mod ext {
             crate::vk::EXT_LOAD_STORE_OP_NONE_NAME as NAME,
             crate::vk::EXT_LOAD_STORE_OP_NONE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_LOAD_STORE_OP_NONE_NAME;
+            const SPEC_VERSION: u32 = EXT_LOAD_STORE_OP_NONE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_LOAD_STORE_OP_NONE_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_border_color_swizzle"]
     pub mod border_color_swizzle {
@@ -6219,6 +7724,16 @@ pub mod ext {
             crate::vk::EXT_BORDER_COLOR_SWIZZLE_NAME as NAME,
             crate::vk::EXT_BORDER_COLOR_SWIZZLE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_BORDER_COLOR_SWIZZLE_NAME;
+            const SPEC_VERSION: u32 = EXT_BORDER_COLOR_SWIZZLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pageable_device_local_memory"]
     pub mod pageable_device_local_memory {
@@ -6286,6 +7801,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_NAME;
+            const SPEC_VERSION: u32 = EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_sliced_view_of_3d"]
     pub mod image_sliced_view_of_3d {
@@ -6294,6 +7821,16 @@ pub mod ext {
             crate::vk::EXT_IMAGE_SLICED_VIEW_OF_3D_NAME as NAME,
             crate::vk::EXT_IMAGE_SLICED_VIEW_OF_3D_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_SLICED_VIEW_OF_3D_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_SLICED_VIEW_OF_3D_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_depth_clamp_zero_one"]
     pub mod depth_clamp_zero_one {
@@ -6302,6 +7839,16 @@ pub mod ext {
             crate::vk::EXT_DEPTH_CLAMP_ZERO_ONE_NAME as NAME,
             crate::vk::EXT_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DEPTH_CLAMP_ZERO_ONE_NAME;
+            const SPEC_VERSION: u32 = EXT_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_non_seamless_cube_map"]
     pub mod non_seamless_cube_map {
@@ -6310,6 +7857,16 @@ pub mod ext {
             crate::vk::EXT_NON_SEAMLESS_CUBE_MAP_NAME as NAME,
             crate::vk::EXT_NON_SEAMLESS_CUBE_MAP_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_NON_SEAMLESS_CUBE_MAP_NAME;
+            const SPEC_VERSION: u32 = EXT_NON_SEAMLESS_CUBE_MAP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_image_compression_control_swapchain"]
     pub mod image_compression_control_swapchain {
@@ -6318,6 +7875,16 @@ pub mod ext {
             crate::vk::EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_NAME as NAME,
             crate::vk::EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_NAME;
+            const SPEC_VERSION: u32 = EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_nested_command_buffer"]
     pub mod nested_command_buffer {
@@ -6326,6 +7893,16 @@ pub mod ext {
             crate::vk::EXT_NESTED_COMMAND_BUFFER_NAME as NAME,
             crate::vk::EXT_NESTED_COMMAND_BUFFER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_NESTED_COMMAND_BUFFER_NAME;
+            const SPEC_VERSION: u32 = EXT_NESTED_COMMAND_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_external_memory_acquire_unmodified"]
     pub mod external_memory_acquire_unmodified {
@@ -6334,6 +7911,16 @@ pub mod ext {
             crate::vk::EXT_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_NAME as NAME,
             crate::vk::EXT_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_extended_dynamic_state3"]
     pub mod extended_dynamic_state3 {
@@ -7035,6 +8622,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_EXTENDED_DYNAMIC_STATE3_NAME;
+            const SPEC_VERSION: u32 = EXT_EXTENDED_DYNAMIC_STATE3_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_subpass_merge_feedback"]
     pub mod subpass_merge_feedback {
@@ -7043,6 +8642,16 @@ pub mod ext {
             crate::vk::EXT_SUBPASS_MERGE_FEEDBACK_NAME as NAME,
             crate::vk::EXT_SUBPASS_MERGE_FEEDBACK_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SUBPASS_MERGE_FEEDBACK_NAME;
+            const SPEC_VERSION: u32 = EXT_SUBPASS_MERGE_FEEDBACK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_module_identifier"]
     pub mod shader_module_identifier {
@@ -7134,6 +8743,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_MODULE_IDENTIFIER_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_MODULE_IDENTIFIER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_rasterization_order_attachment_access"]
     pub mod rasterization_order_attachment_access {
@@ -7142,6 +8763,16 @@ pub mod ext {
             crate::vk::EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_NAME as NAME,
             crate::vk::EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_NAME;
+            const SPEC_VERSION: u32 = EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_legacy_dithering"]
     pub mod legacy_dithering {
@@ -7150,6 +8781,16 @@ pub mod ext {
             crate::vk::EXT_LEGACY_DITHERING_NAME as NAME,
             crate::vk::EXT_LEGACY_DITHERING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_LEGACY_DITHERING_NAME;
+            const SPEC_VERSION: u32 = EXT_LEGACY_DITHERING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pipeline_protected_access"]
     pub mod pipeline_protected_access {
@@ -7158,6 +8799,16 @@ pub mod ext {
             crate::vk::EXT_PIPELINE_PROTECTED_ACCESS_NAME as NAME,
             crate::vk::EXT_PIPELINE_PROTECTED_ACCESS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PIPELINE_PROTECTED_ACCESS_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_PROTECTED_ACCESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_shader_object"]
     pub mod shader_object {
@@ -8305,6 +9956,18 @@ pub mod ext {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_SHADER_OBJECT_NAME;
+            const SPEC_VERSION: u32 = EXT_SHADER_OBJECT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_mutable_descriptor_type"]
     pub mod mutable_descriptor_type {
@@ -8313,6 +9976,16 @@ pub mod ext {
             crate::vk::EXT_MUTABLE_DESCRIPTOR_TYPE_NAME as NAME,
             crate::vk::EXT_MUTABLE_DESCRIPTOR_TYPE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_MUTABLE_DESCRIPTOR_TYPE_NAME;
+            const SPEC_VERSION: u32 = EXT_MUTABLE_DESCRIPTOR_TYPE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_layer_settings"]
     pub mod layer_settings {
@@ -8321,6 +9994,16 @@ pub mod ext {
             crate::vk::EXT_LAYER_SETTINGS_NAME as NAME,
             crate::vk::EXT_LAYER_SETTINGS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_LAYER_SETTINGS_NAME;
+            const SPEC_VERSION: u32 = EXT_LAYER_SETTINGS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_pipeline_library_group_handles"]
     pub mod pipeline_library_group_handles {
@@ -8329,6 +10012,16 @@ pub mod ext {
             crate::vk::EXT_PIPELINE_LIBRARY_GROUP_HANDLES_NAME as NAME,
             crate::vk::EXT_PIPELINE_LIBRARY_GROUP_HANDLES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_PIPELINE_LIBRARY_GROUP_HANDLES_NAME;
+            const SPEC_VERSION: u32 = EXT_PIPELINE_LIBRARY_GROUP_HANDLES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_dynamic_rendering_unused_attachments"]
     pub mod dynamic_rendering_unused_attachments {
@@ -8337,6 +10030,16 @@ pub mod ext {
             crate::vk::EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_NAME as NAME,
             crate::vk::EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_NAME;
+            const SPEC_VERSION: u32 = EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_EXT_attachment_feedback_loop_dynamic_state"]
     pub mod attachment_feedback_loop_dynamic_state {
@@ -8404,6 +10107,18 @@ pub mod ext {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_NAME;
+            const SPEC_VERSION: u32 = EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
 }
@@ -8475,6 +10190,18 @@ pub mod fuchsia {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = FUCHSIA_IMAGEPIPE_SURFACE_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_IMAGEPIPE_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -8569,6 +10296,18 @@ pub mod fuchsia {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = FUCHSIA_EXTERNAL_MEMORY_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_EXTERNAL_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_FUCHSIA_external_semaphore"]
     pub mod external_semaphore {
@@ -8659,6 +10398,18 @@ pub mod fuchsia {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = FUCHSIA_EXTERNAL_SEMAPHORE_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_EXTERNAL_SEMAPHORE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_FUCHSIA_buffer_collection"]
@@ -8820,6 +10571,18 @@ pub mod fuchsia {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = FUCHSIA_BUFFER_COLLECTION_NAME;
+            const SPEC_VERSION: u32 = FUCHSIA_BUFFER_COLLECTION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged GGP"]
@@ -8892,6 +10655,18 @@ pub mod ggp {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GGP_STREAM_DESCRIPTOR_SURFACE_NAME;
+            const SPEC_VERSION: u32 = GGP_STREAM_DESCRIPTOR_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_GGP_frame_token"]
     pub mod frame_token {
@@ -8900,6 +10675,16 @@ pub mod ggp {
             crate::vk::GGP_FRAME_TOKEN_NAME as NAME,
             crate::vk::GGP_FRAME_TOKEN_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GGP_FRAME_TOKEN_NAME;
+            const SPEC_VERSION: u32 = GGP_FRAME_TOKEN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged GOOGLE"]
@@ -8994,6 +10779,18 @@ pub mod google {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GOOGLE_DISPLAY_TIMING_NAME;
+            const SPEC_VERSION: u32 = GOOGLE_DISPLAY_TIMING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_GOOGLE_hlsl_functionality1"]
     pub mod hlsl_functionality1 {
@@ -9002,6 +10799,16 @@ pub mod google {
             crate::vk::GOOGLE_HLSL_FUNCTIONALITY1_NAME as NAME,
             crate::vk::GOOGLE_HLSL_FUNCTIONALITY1_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GOOGLE_HLSL_FUNCTIONALITY1_NAME;
+            const SPEC_VERSION: u32 = GOOGLE_HLSL_FUNCTIONALITY1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_GOOGLE_decorate_string"]
     pub mod decorate_string {
@@ -9010,6 +10817,16 @@ pub mod google {
             crate::vk::GOOGLE_DECORATE_STRING_NAME as NAME,
             crate::vk::GOOGLE_DECORATE_STRING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GOOGLE_DECORATE_STRING_NAME;
+            const SPEC_VERSION: u32 = GOOGLE_DECORATE_STRING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_GOOGLE_user_type"]
     pub mod user_type {
@@ -9018,6 +10835,16 @@ pub mod google {
             crate::vk::GOOGLE_USER_TYPE_NAME as NAME,
             crate::vk::GOOGLE_USER_TYPE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GOOGLE_USER_TYPE_NAME;
+            const SPEC_VERSION: u32 = GOOGLE_USER_TYPE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_GOOGLE_surfaceless_query"]
     pub mod surfaceless_query {
@@ -9026,6 +10853,16 @@ pub mod google {
             crate::vk::GOOGLE_SURFACELESS_QUERY_NAME as NAME,
             crate::vk::GOOGLE_SURFACELESS_QUERY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = GOOGLE_SURFACELESS_QUERY_NAME;
+            const SPEC_VERSION: u32 = GOOGLE_SURFACELESS_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged HUAWEI"]
@@ -9117,6 +10954,18 @@ pub mod huawei {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = HUAWEI_SUBPASS_SHADING_NAME;
+            const SPEC_VERSION: u32 = HUAWEI_SUBPASS_SHADING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_HUAWEI_invocation_mask"]
     pub mod invocation_mask {
@@ -9183,6 +11032,18 @@ pub mod huawei {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = HUAWEI_INVOCATION_MASK_NAME;
+            const SPEC_VERSION: u32 = HUAWEI_INVOCATION_MASK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_HUAWEI_cluster_culling_shader"]
@@ -9274,6 +11135,18 @@ pub mod huawei {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = HUAWEI_CLUSTER_CULLING_SHADER_NAME;
+            const SPEC_VERSION: u32 = HUAWEI_CLUSTER_CULLING_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged IMG"]
@@ -9285,6 +11158,16 @@ pub mod img {
             crate::vk::IMG_FILTER_CUBIC_NAME as NAME,
             crate::vk::IMG_FILTER_CUBIC_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = IMG_FILTER_CUBIC_NAME;
+            const SPEC_VERSION: u32 = IMG_FILTER_CUBIC_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_IMG_format_pvrtc"]
     pub mod format_pvrtc {
@@ -9293,6 +11176,16 @@ pub mod img {
             crate::vk::IMG_FORMAT_PVRTC_NAME as NAME,
             crate::vk::IMG_FORMAT_PVRTC_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = IMG_FORMAT_PVRTC_NAME;
+            const SPEC_VERSION: u32 = IMG_FORMAT_PVRTC_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_IMG_relaxed_line_rasterization"]
     pub mod relaxed_line_rasterization {
@@ -9301,6 +11194,16 @@ pub mod img {
             crate::vk::IMG_RELAXED_LINE_RASTERIZATION_NAME as NAME,
             crate::vk::IMG_RELAXED_LINE_RASTERIZATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = IMG_RELAXED_LINE_RASTERIZATION_NAME;
+            const SPEC_VERSION: u32 = IMG_RELAXED_LINE_RASTERIZATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged INTEL"]
@@ -9312,6 +11215,16 @@ pub mod intel {
             crate::vk::INTEL_SHADER_INTEGER_FUNCTIONS2_NAME as NAME,
             crate::vk::INTEL_SHADER_INTEGER_FUNCTIONS2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = INTEL_SHADER_INTEGER_FUNCTIONS2_NAME;
+            const SPEC_VERSION: u32 = INTEL_SHADER_INTEGER_FUNCTIONS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_INTEL_performance_query"]
     pub mod performance_query {
@@ -9549,6 +11462,18 @@ pub mod intel {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = INTEL_PERFORMANCE_QUERY_NAME;
+            const SPEC_VERSION: u32 = INTEL_PERFORMANCE_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged KHR"]
@@ -9706,6 +11631,18 @@ pub mod khr {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -9981,6 +11918,20 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SWAPCHAIN_NAME;
+            const SPEC_VERSION: u32 = KHR_SWAPCHAIN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_display"]
     pub mod display {
@@ -10187,6 +12138,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = KHR_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_display_swapchain"]
     pub mod display_swapchain {
@@ -10255,6 +12218,18 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DISPLAY_SWAPCHAIN_NAME;
+            const SPEC_VERSION: u32 = KHR_DISPLAY_SWAPCHAIN_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_xlib_surface"]
@@ -10348,6 +12323,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_XLIB_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_XLIB_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_xcb_surface"]
     pub mod xcb_surface {
@@ -10437,6 +12424,18 @@ pub mod khr {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_XCB_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_XCB_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -10530,6 +12529,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_WAYLAND_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_WAYLAND_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_android_surface"]
     pub mod android_surface {
@@ -10596,6 +12607,18 @@ pub mod khr {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_ANDROID_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_ANDROID_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -10688,6 +12711,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_WIN32_SURFACE_NAME;
+            const SPEC_VERSION: u32 = KHR_WIN32_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_sampler_mirror_clamp_to_edge"]
     pub mod sampler_mirror_clamp_to_edge {
@@ -10696,6 +12731,17 @@ pub mod khr {
             crate::vk::KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_NAME as NAME,
             crate::vk::KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_NAME;
+            const SPEC_VERSION: u32 = KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_queue"]
     pub mod video_queue {
@@ -11043,6 +13089,20 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_video_decode_queue"]
     pub mod video_decode_queue {
@@ -11105,6 +13165,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_DECODE_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_DECODE_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_encode_h264"]
     pub mod video_encode_h264 {
@@ -11113,6 +13185,16 @@ pub mod khr {
             crate::vk::KHR_VIDEO_ENCODE_H264_NAME as NAME,
             crate::vk::KHR_VIDEO_ENCODE_H264_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_ENCODE_H264_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_ENCODE_H264_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_encode_h265"]
     pub mod video_encode_h265 {
@@ -11121,6 +13203,16 @@ pub mod khr {
             crate::vk::KHR_VIDEO_ENCODE_H265_NAME as NAME,
             crate::vk::KHR_VIDEO_ENCODE_H265_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_ENCODE_H265_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_ENCODE_H265_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_decode_h264"]
     pub mod video_decode_h264 {
@@ -11129,6 +13221,16 @@ pub mod khr {
             crate::vk::KHR_VIDEO_DECODE_H264_NAME as NAME,
             crate::vk::KHR_VIDEO_DECODE_H264_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_DECODE_H264_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_DECODE_H264_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_dynamic_rendering"]
     pub mod dynamic_rendering {
@@ -11213,6 +13315,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DYNAMIC_RENDERING_NAME;
+            const SPEC_VERSION: u32 = KHR_DYNAMIC_RENDERING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_multiview"]
     pub mod multiview {
@@ -11221,6 +13336,17 @@ pub mod khr {
             crate::vk::KHR_MULTIVIEW_NAME as NAME,
             crate::vk::KHR_MULTIVIEW_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MULTIVIEW_NAME;
+            const SPEC_VERSION: u32 = KHR_MULTIVIEW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_get_physical_device_properties2"]
     pub mod get_physical_device_properties2 {
@@ -11422,6 +13548,19 @@ pub mod khr {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -11665,6 +13804,21 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DEVICE_GROUP_NAME;
+            const SPEC_VERSION: u32 = KHR_DEVICE_GROUP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_shader_draw_parameters"]
     pub mod shader_draw_parameters {
@@ -11673,6 +13827,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_DRAW_PARAMETERS_NAME as NAME,
             crate::vk::KHR_SHADER_DRAW_PARAMETERS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_DRAW_PARAMETERS_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_DRAW_PARAMETERS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_maintenance1"]
     pub mod maintenance1 {
@@ -11738,6 +13903,19 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_device_group_creation"]
@@ -11809,6 +13987,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DEVICE_GROUP_CREATION_NAME;
+            const SPEC_VERSION: u32 = KHR_DEVICE_GROUP_CREATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_external_memory_capabilities"]
     pub mod external_memory_capabilities {
@@ -11878,6 +14069,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_external_memory"]
     pub mod external_memory {
@@ -11886,6 +14090,17 @@ pub mod khr {
             crate::vk::KHR_EXTERNAL_MEMORY_NAME as NAME,
             crate::vk::KHR_EXTERNAL_MEMORY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_memory_win32"]
     pub mod external_memory_win32 {
@@ -11978,6 +14193,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_WIN32_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_memory_fd"]
     pub mod external_memory_fd {
@@ -12063,6 +14290,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_MEMORY_FD_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_MEMORY_FD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_win32_keyed_mutex"]
     pub mod win32_keyed_mutex {
@@ -12071,6 +14310,16 @@ pub mod khr {
             crate::vk::KHR_WIN32_KEYED_MUTEX_NAME as NAME,
             crate::vk::KHR_WIN32_KEYED_MUTEX_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_WIN32_KEYED_MUTEX_NAME;
+            const SPEC_VERSION: u32 = KHR_WIN32_KEYED_MUTEX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_semaphore_capabilities"]
     pub mod external_semaphore_capabilities {
@@ -12142,6 +14391,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_external_semaphore"]
     pub mod external_semaphore {
@@ -12150,6 +14412,17 @@ pub mod khr {
             crate::vk::KHR_EXTERNAL_SEMAPHORE_NAME as NAME,
             crate::vk::KHR_EXTERNAL_SEMAPHORE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_semaphore_win32"]
     pub mod external_semaphore_win32 {
@@ -12238,6 +14511,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_WIN32_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_semaphore_fd"]
     pub mod external_semaphore_fd {
@@ -12320,6 +14605,18 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_SEMAPHORE_FD_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_SEMAPHORE_FD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_push_descriptor"]
@@ -12416,6 +14713,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PUSH_DESCRIPTOR_NAME;
+            const SPEC_VERSION: u32 = KHR_PUSH_DESCRIPTOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_float16_int8"]
     pub mod shader_float16_int8 {
@@ -12424,6 +14733,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_FLOAT16_INT8_NAME as NAME,
             crate::vk::KHR_SHADER_FLOAT16_INT8_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_FLOAT16_INT8_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_FLOAT16_INT8_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_16bit_storage"]
     pub mod _16bit_storage {
@@ -12432,6 +14752,17 @@ pub mod khr {
             crate::vk::KHR_16BIT_STORAGE_NAME as NAME,
             crate::vk::KHR_16BIT_STORAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_16BIT_STORAGE_NAME;
+            const SPEC_VERSION: u32 = KHR_16BIT_STORAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_incremental_present"]
     pub mod incremental_present {
@@ -12440,6 +14771,16 @@ pub mod khr {
             crate::vk::KHR_INCREMENTAL_PRESENT_NAME as NAME,
             crate::vk::KHR_INCREMENTAL_PRESENT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_INCREMENTAL_PRESENT_NAME;
+            const SPEC_VERSION: u32 = KHR_INCREMENTAL_PRESENT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_descriptor_update_template"]
     pub mod descriptor_update_template {
@@ -12579,6 +14920,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DESCRIPTOR_UPDATE_TEMPLATE_NAME;
+            const SPEC_VERSION: u32 = KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_imageless_framebuffer"]
     pub mod imageless_framebuffer {
@@ -12587,6 +14941,17 @@ pub mod khr {
             crate::vk::KHR_IMAGELESS_FRAMEBUFFER_NAME as NAME,
             crate::vk::KHR_IMAGELESS_FRAMEBUFFER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_IMAGELESS_FRAMEBUFFER_NAME;
+            const SPEC_VERSION: u32 = KHR_IMAGELESS_FRAMEBUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_create_renderpass2"]
     pub mod create_renderpass2 {
@@ -12716,6 +15081,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_CREATE_RENDERPASS2_NAME;
+            const SPEC_VERSION: u32 = KHR_CREATE_RENDERPASS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shared_presentable_image"]
     pub mod shared_presentable_image {
@@ -12781,6 +15159,18 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHARED_PRESENTABLE_IMAGE_NAME;
+            const SPEC_VERSION: u32 = KHR_SHARED_PRESENTABLE_IMAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_external_fence_capabilities"]
@@ -12851,6 +15241,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_external_fence"]
     pub mod external_fence {
@@ -12859,6 +15262,17 @@ pub mod khr {
             crate::vk::KHR_EXTERNAL_FENCE_NAME as NAME,
             crate::vk::KHR_EXTERNAL_FENCE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_fence_win32"]
     pub mod external_fence_win32 {
@@ -12948,6 +15362,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_WIN32_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_external_fence_fd"]
     pub mod external_fence_fd {
@@ -13026,6 +15452,18 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_EXTERNAL_FENCE_FD_NAME;
+            const SPEC_VERSION: u32 = KHR_EXTERNAL_FENCE_FD_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_performance_query"]
@@ -13197,6 +15635,20 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PERFORMANCE_QUERY_NAME;
+            const SPEC_VERSION: u32 = KHR_PERFORMANCE_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_maintenance2"]
     pub mod maintenance2 {
@@ -13205,6 +15657,17 @@ pub mod khr {
             crate::vk::KHR_MAINTENANCE2_NAME as NAME,
             crate::vk::KHR_MAINTENANCE2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAINTENANCE2_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_get_surface_capabilities2"]
     pub mod get_surface_capabilities2 {
@@ -13297,6 +15760,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_GET_SURFACE_CAPABILITIES2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_SURFACE_CAPABILITIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_variable_pointers"]
     pub mod variable_pointers {
@@ -13305,6 +15780,17 @@ pub mod khr {
             crate::vk::KHR_VARIABLE_POINTERS_NAME as NAME,
             crate::vk::KHR_VARIABLE_POINTERS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VARIABLE_POINTERS_NAME;
+            const SPEC_VERSION: u32 = KHR_VARIABLE_POINTERS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_get_display_properties2"]
     pub mod get_display_properties2 {
@@ -13442,6 +15928,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_GET_DISPLAY_PROPERTIES2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_DISPLAY_PROPERTIES2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_dedicated_allocation"]
     pub mod dedicated_allocation {
@@ -13450,6 +15948,17 @@ pub mod khr {
             crate::vk::KHR_DEDICATED_ALLOCATION_NAME as NAME,
             crate::vk::KHR_DEDICATED_ALLOCATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DEDICATED_ALLOCATION_NAME;
+            const SPEC_VERSION: u32 = KHR_DEDICATED_ALLOCATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_storage_buffer_storage_class"]
     pub mod storage_buffer_storage_class {
@@ -13458,6 +15967,17 @@ pub mod khr {
             crate::vk::KHR_STORAGE_BUFFER_STORAGE_CLASS_NAME as NAME,
             crate::vk::KHR_STORAGE_BUFFER_STORAGE_CLASS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_STORAGE_BUFFER_STORAGE_CLASS_NAME;
+            const SPEC_VERSION: u32 = KHR_STORAGE_BUFFER_STORAGE_CLASS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_relaxed_block_layout"]
     pub mod relaxed_block_layout {
@@ -13466,6 +15986,17 @@ pub mod khr {
             crate::vk::KHR_RELAXED_BLOCK_LAYOUT_NAME as NAME,
             crate::vk::KHR_RELAXED_BLOCK_LAYOUT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_RELAXED_BLOCK_LAYOUT_NAME;
+            const SPEC_VERSION: u32 = KHR_RELAXED_BLOCK_LAYOUT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_get_memory_requirements2"]
     pub mod get_memory_requirements2 {
@@ -13579,6 +16110,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_GET_MEMORY_REQUIREMENTS2_NAME;
+            const SPEC_VERSION: u32 = KHR_GET_MEMORY_REQUIREMENTS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_image_format_list"]
     pub mod image_format_list {
@@ -13587,6 +16131,17 @@ pub mod khr {
             crate::vk::KHR_IMAGE_FORMAT_LIST_NAME as NAME,
             crate::vk::KHR_IMAGE_FORMAT_LIST_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_IMAGE_FORMAT_LIST_NAME;
+            const SPEC_VERSION: u32 = KHR_IMAGE_FORMAT_LIST_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_acceleration_structure"]
     pub mod acceleration_structure {
@@ -14007,6 +16562,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_ACCELERATION_STRUCTURE_NAME;
+            const SPEC_VERSION: u32 = KHR_ACCELERATION_STRUCTURE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_ray_tracing_pipeline"]
     pub mod ray_tracing_pipeline {
@@ -14222,6 +16789,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_RAY_TRACING_PIPELINE_NAME;
+            const SPEC_VERSION: u32 = KHR_RAY_TRACING_PIPELINE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_ray_query"]
     pub mod ray_query {
@@ -14230,6 +16809,16 @@ pub mod khr {
             crate::vk::KHR_RAY_QUERY_NAME as NAME,
             crate::vk::KHR_RAY_QUERY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_RAY_QUERY_NAME;
+            const SPEC_VERSION: u32 = KHR_RAY_QUERY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_sampler_ycbcr_conversion"]
     pub mod sampler_ycbcr_conversion {
@@ -14321,6 +16910,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SAMPLER_YCBCR_CONVERSION_NAME;
+            const SPEC_VERSION: u32 = KHR_SAMPLER_YCBCR_CONVERSION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_bind_memory2"]
     pub mod bind_memory2 {
@@ -14408,6 +17010,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_BIND_MEMORY2_NAME;
+            const SPEC_VERSION: u32 = KHR_BIND_MEMORY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_portability_subset"]
     pub mod portability_subset {
@@ -14416,6 +17031,16 @@ pub mod khr {
             crate::vk::KHR_PORTABILITY_SUBSET_NAME as NAME,
             crate::vk::KHR_PORTABILITY_SUBSET_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PORTABILITY_SUBSET_NAME;
+            const SPEC_VERSION: u32 = KHR_PORTABILITY_SUBSET_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_maintenance3"]
     pub mod maintenance3 {
@@ -14483,6 +17108,19 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAINTENANCE3_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE3_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_1);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_draw_indirect_count"]
@@ -14581,6 +17219,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DRAW_INDIRECT_COUNT_NAME;
+            const SPEC_VERSION: u32 = KHR_DRAW_INDIRECT_COUNT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_subgroup_extended_types"]
     pub mod shader_subgroup_extended_types {
@@ -14589,6 +17240,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_SUBGROUP_EXTENDED_TYPES_NAME as NAME,
             crate::vk::KHR_SHADER_SUBGROUP_EXTENDED_TYPES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_SUBGROUP_EXTENDED_TYPES_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_SUBGROUP_EXTENDED_TYPES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_8bit_storage"]
     pub mod _8bit_storage {
@@ -14597,6 +17259,17 @@ pub mod khr {
             crate::vk::KHR_8BIT_STORAGE_NAME as NAME,
             crate::vk::KHR_8BIT_STORAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_8BIT_STORAGE_NAME;
+            const SPEC_VERSION: u32 = KHR_8BIT_STORAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_atomic_int64"]
     pub mod shader_atomic_int64 {
@@ -14605,6 +17278,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_ATOMIC_INT64_NAME as NAME,
             crate::vk::KHR_SHADER_ATOMIC_INT64_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_ATOMIC_INT64_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_ATOMIC_INT64_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_clock"]
     pub mod shader_clock {
@@ -14613,6 +17297,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_CLOCK_NAME as NAME,
             crate::vk::KHR_SHADER_CLOCK_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_CLOCK_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_CLOCK_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_decode_h265"]
     pub mod video_decode_h265 {
@@ -14621,6 +17315,16 @@ pub mod khr {
             crate::vk::KHR_VIDEO_DECODE_H265_NAME as NAME,
             crate::vk::KHR_VIDEO_DECODE_H265_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_DECODE_H265_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_DECODE_H265_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_global_priority"]
     pub mod global_priority {
@@ -14629,6 +17333,16 @@ pub mod khr {
             crate::vk::KHR_GLOBAL_PRIORITY_NAME as NAME,
             crate::vk::KHR_GLOBAL_PRIORITY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_GLOBAL_PRIORITY_NAME;
+            const SPEC_VERSION: u32 = KHR_GLOBAL_PRIORITY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_driver_properties"]
     pub mod driver_properties {
@@ -14637,6 +17351,17 @@ pub mod khr {
             crate::vk::KHR_DRIVER_PROPERTIES_NAME as NAME,
             crate::vk::KHR_DRIVER_PROPERTIES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DRIVER_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = KHR_DRIVER_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_float_controls"]
     pub mod shader_float_controls {
@@ -14645,6 +17370,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_FLOAT_CONTROLS_NAME as NAME,
             crate::vk::KHR_SHADER_FLOAT_CONTROLS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_FLOAT_CONTROLS_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_FLOAT_CONTROLS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_depth_stencil_resolve"]
     pub mod depth_stencil_resolve {
@@ -14653,6 +17389,17 @@ pub mod khr {
             crate::vk::KHR_DEPTH_STENCIL_RESOLVE_NAME as NAME,
             crate::vk::KHR_DEPTH_STENCIL_RESOLVE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DEPTH_STENCIL_RESOLVE_NAME;
+            const SPEC_VERSION: u32 = KHR_DEPTH_STENCIL_RESOLVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_swapchain_mutable_format"]
     pub mod swapchain_mutable_format {
@@ -14661,6 +17408,16 @@ pub mod khr {
             crate::vk::KHR_SWAPCHAIN_MUTABLE_FORMAT_NAME as NAME,
             crate::vk::KHR_SWAPCHAIN_MUTABLE_FORMAT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SWAPCHAIN_MUTABLE_FORMAT_NAME;
+            const SPEC_VERSION: u32 = KHR_SWAPCHAIN_MUTABLE_FORMAT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_timeline_semaphore"]
     pub mod timeline_semaphore {
@@ -14761,6 +17518,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_TIMELINE_SEMAPHORE_NAME;
+            const SPEC_VERSION: u32 = KHR_TIMELINE_SEMAPHORE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_vulkan_memory_model"]
     pub mod vulkan_memory_model {
@@ -14769,6 +17539,17 @@ pub mod khr {
             crate::vk::KHR_VULKAN_MEMORY_MODEL_NAME as NAME,
             crate::vk::KHR_VULKAN_MEMORY_MODEL_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VULKAN_MEMORY_MODEL_NAME;
+            const SPEC_VERSION: u32 = KHR_VULKAN_MEMORY_MODEL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_terminate_invocation"]
     pub mod shader_terminate_invocation {
@@ -14777,6 +17558,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_TERMINATE_INVOCATION_NAME as NAME,
             crate::vk::KHR_SHADER_TERMINATE_INVOCATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_TERMINATE_INVOCATION_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_TERMINATE_INVOCATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_fragment_shading_rate"]
     pub mod fragment_shading_rate {
@@ -14908,6 +17700,20 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_FRAGMENT_SHADING_RATE_NAME;
+            const SPEC_VERSION: u32 = KHR_FRAGMENT_SHADING_RATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_dynamic_rendering_local_read"]
     pub mod dynamic_rendering_local_read {
@@ -14998,6 +17804,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DYNAMIC_RENDERING_LOCAL_READ_NAME;
+            const SPEC_VERSION: u32 = KHR_DYNAMIC_RENDERING_LOCAL_READ_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_quad_control"]
     pub mod shader_quad_control {
@@ -15006,6 +17824,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_QUAD_CONTROL_NAME as NAME,
             crate::vk::KHR_SHADER_QUAD_CONTROL_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_QUAD_CONTROL_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_QUAD_CONTROL_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_spirv_1_4"]
     pub mod spirv_1_4 {
@@ -15014,6 +17842,17 @@ pub mod khr {
             crate::vk::KHR_SPIRV_1_4_NAME as NAME,
             crate::vk::KHR_SPIRV_1_4_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SPIRV_1_4_NAME;
+            const SPEC_VERSION: u32 = KHR_SPIRV_1_4_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_surface_protected_capabilities"]
     pub mod surface_protected_capabilities {
@@ -15022,6 +17861,16 @@ pub mod khr {
             crate::vk::KHR_SURFACE_PROTECTED_CAPABILITIES_NAME as NAME,
             crate::vk::KHR_SURFACE_PROTECTED_CAPABILITIES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SURFACE_PROTECTED_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = KHR_SURFACE_PROTECTED_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_separate_depth_stencil_layouts"]
     pub mod separate_depth_stencil_layouts {
@@ -15030,6 +17879,17 @@ pub mod khr {
             crate::vk::KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_NAME as NAME,
             crate::vk::KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_NAME;
+            const SPEC_VERSION: u32 = KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_present_wait"]
     pub mod present_wait {
@@ -15094,6 +17954,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PRESENT_WAIT_NAME;
+            const SPEC_VERSION: u32 = KHR_PRESENT_WAIT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_uniform_buffer_standard_layout"]
     pub mod uniform_buffer_standard_layout {
@@ -15102,6 +17974,17 @@ pub mod khr {
             crate::vk::KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_NAME as NAME,
             crate::vk::KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_NAME;
+            const SPEC_VERSION: u32 = KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_buffer_device_address"]
     pub mod buffer_device_address {
@@ -15210,6 +18093,19 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_BUFFER_DEVICE_ADDRESS_NAME;
+            const SPEC_VERSION: u32 = KHR_BUFFER_DEVICE_ADDRESS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_2);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_deferred_host_operations"]
@@ -15362,6 +18258,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_DEFERRED_HOST_OPERATIONS_NAME;
+            const SPEC_VERSION: u32 = KHR_DEFERRED_HOST_OPERATIONS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_pipeline_executable_properties"]
     pub mod pipeline_executable_properties {
@@ -15478,6 +18386,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PIPELINE_EXECUTABLE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = KHR_PIPELINE_EXECUTABLE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_map_memory2"]
     pub mod map_memory2 {
@@ -15557,6 +18477,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAP_MEMORY2_NAME;
+            const SPEC_VERSION: u32 = KHR_MAP_MEMORY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_integer_dot_product"]
     pub mod shader_integer_dot_product {
@@ -15565,6 +18497,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_INTEGER_DOT_PRODUCT_NAME as NAME,
             crate::vk::KHR_SHADER_INTEGER_DOT_PRODUCT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_INTEGER_DOT_PRODUCT_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_INTEGER_DOT_PRODUCT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_pipeline_library"]
     pub mod pipeline_library {
@@ -15573,6 +18516,16 @@ pub mod khr {
             crate::vk::KHR_PIPELINE_LIBRARY_NAME as NAME,
             crate::vk::KHR_PIPELINE_LIBRARY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PIPELINE_LIBRARY_NAME;
+            const SPEC_VERSION: u32 = KHR_PIPELINE_LIBRARY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_non_semantic_info"]
     pub mod shader_non_semantic_info {
@@ -15581,6 +18534,17 @@ pub mod khr {
             crate::vk::KHR_SHADER_NON_SEMANTIC_INFO_NAME as NAME,
             crate::vk::KHR_SHADER_NON_SEMANTIC_INFO_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_NON_SEMANTIC_INFO_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_NON_SEMANTIC_INFO_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_present_id"]
     pub mod present_id {
@@ -15589,6 +18553,16 @@ pub mod khr {
             crate::vk::KHR_PRESENT_ID_NAME as NAME,
             crate::vk::KHR_PRESENT_ID_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PRESENT_ID_NAME;
+            const SPEC_VERSION: u32 = KHR_PRESENT_ID_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_encode_queue"]
     pub mod video_encode_queue {
@@ -15738,6 +18712,20 @@ pub mod khr {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_ENCODE_QUEUE_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -15942,6 +18930,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SYNCHRONIZATION2_NAME;
+            const SPEC_VERSION: u32 = KHR_SYNCHRONIZATION2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_fragment_shader_barycentric"]
     pub mod fragment_shader_barycentric {
@@ -15950,6 +18951,16 @@ pub mod khr {
             crate::vk::KHR_FRAGMENT_SHADER_BARYCENTRIC_NAME as NAME,
             crate::vk::KHR_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_FRAGMENT_SHADER_BARYCENTRIC_NAME;
+            const SPEC_VERSION: u32 = KHR_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_subgroup_uniform_control_flow"]
     pub mod shader_subgroup_uniform_control_flow {
@@ -15958,6 +18969,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_NAME as NAME,
             crate::vk::KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_zero_initialize_workgroup_memory"]
     pub mod zero_initialize_workgroup_memory {
@@ -15966,6 +18987,17 @@ pub mod khr {
             crate::vk::KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_NAME as NAME,
             crate::vk::KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_NAME;
+            const SPEC_VERSION: u32 = KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_workgroup_memory_explicit_layout"]
     pub mod workgroup_memory_explicit_layout {
@@ -15974,6 +19006,16 @@ pub mod khr {
             crate::vk::KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_NAME as NAME,
             crate::vk::KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_NAME;
+            const SPEC_VERSION: u32 = KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_copy_commands2"]
     pub mod copy_commands2 {
@@ -16127,6 +19169,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_COPY_COMMANDS2_NAME;
+            const SPEC_VERSION: u32 = KHR_COPY_COMMANDS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_format_feature_flags2"]
     pub mod format_feature_flags2 {
@@ -16135,6 +19190,17 @@ pub mod khr {
             crate::vk::KHR_FORMAT_FEATURE_FLAGS2_NAME as NAME,
             crate::vk::KHR_FORMAT_FEATURE_FLAGS2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_FORMAT_FEATURE_FLAGS2_NAME;
+            const SPEC_VERSION: u32 = KHR_FORMAT_FEATURE_FLAGS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_ray_tracing_maintenance1"]
     pub mod ray_tracing_maintenance1 {
@@ -16201,6 +19267,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_RAY_TRACING_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = KHR_RAY_TRACING_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_portability_enumeration"]
     pub mod portability_enumeration {
@@ -16209,6 +19287,16 @@ pub mod khr {
             crate::vk::KHR_PORTABILITY_ENUMERATION_NAME as NAME,
             crate::vk::KHR_PORTABILITY_ENUMERATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_PORTABILITY_ENUMERATION_NAME;
+            const SPEC_VERSION: u32 = KHR_PORTABILITY_ENUMERATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_maintenance4"]
     pub mod maintenance4 {
@@ -16323,6 +19411,19 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAINTENANCE4_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE4_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToCore(API_VERSION_1_3);
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_subgroup_rotate"]
     pub mod shader_subgroup_rotate {
@@ -16331,6 +19432,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_SUBGROUP_ROTATE_NAME as NAME,
             crate::vk::KHR_SHADER_SUBGROUP_ROTATE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_SUBGROUP_ROTATE_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_SUBGROUP_ROTATE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_maximal_reconvergence"]
     pub mod shader_maximal_reconvergence {
@@ -16339,6 +19450,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_MAXIMAL_RECONVERGENCE_NAME as NAME,
             crate::vk::KHR_SHADER_MAXIMAL_RECONVERGENCE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_MAXIMAL_RECONVERGENCE_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_MAXIMAL_RECONVERGENCE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_maintenance5"]
     pub mod maintenance5 {
@@ -16475,6 +19596,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAINTENANCE5_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE5_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_ray_tracing_position_fetch"]
     pub mod ray_tracing_position_fetch {
@@ -16483,6 +19616,16 @@ pub mod khr {
             crate::vk::KHR_RAY_TRACING_POSITION_FETCH_NAME as NAME,
             crate::vk::KHR_RAY_TRACING_POSITION_FETCH_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_RAY_TRACING_POSITION_FETCH_NAME;
+            const SPEC_VERSION: u32 = KHR_RAY_TRACING_POSITION_FETCH_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_cooperative_matrix"]
     pub mod cooperative_matrix {
@@ -16552,6 +19695,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_COOPERATIVE_MATRIX_NAME;
+            const SPEC_VERSION: u32 = KHR_COOPERATIVE_MATRIX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_video_decode_av1"]
     pub mod video_decode_av1 {
@@ -16560,6 +19715,16 @@ pub mod khr {
             crate::vk::KHR_VIDEO_DECODE_AV1_NAME as NAME,
             crate::vk::KHR_VIDEO_DECODE_AV1_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_DECODE_AV1_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_DECODE_AV1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_video_maintenance1"]
     pub mod video_maintenance1 {
@@ -16568,6 +19733,16 @@ pub mod khr {
             crate::vk::KHR_VIDEO_MAINTENANCE1_NAME as NAME,
             crate::vk::KHR_VIDEO_MAINTENANCE1_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VIDEO_MAINTENANCE1_NAME;
+            const SPEC_VERSION: u32 = KHR_VIDEO_MAINTENANCE1_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_vertex_attribute_divisor"]
     pub mod vertex_attribute_divisor {
@@ -16576,6 +19751,16 @@ pub mod khr {
             crate::vk::KHR_VERTEX_ATTRIBUTE_DIVISOR_NAME as NAME,
             crate::vk::KHR_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_VERTEX_ATTRIBUTE_DIVISOR_NAME;
+            const SPEC_VERSION: u32 = KHR_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_load_store_op_none"]
     pub mod load_store_op_none {
@@ -16584,6 +19769,16 @@ pub mod khr {
             crate::vk::KHR_LOAD_STORE_OP_NONE_NAME as NAME,
             crate::vk::KHR_LOAD_STORE_OP_NONE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_LOAD_STORE_OP_NONE_NAME;
+            const SPEC_VERSION: u32 = KHR_LOAD_STORE_OP_NONE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_shader_float_controls2"]
     pub mod shader_float_controls2 {
@@ -16592,6 +19787,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_FLOAT_CONTROLS2_NAME as NAME,
             crate::vk::KHR_SHADER_FLOAT_CONTROLS2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_FLOAT_CONTROLS2_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_FLOAT_CONTROLS2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_index_type_uint8"]
     pub mod index_type_uint8 {
@@ -16600,6 +19805,16 @@ pub mod khr {
             crate::vk::KHR_INDEX_TYPE_UINT8_NAME as NAME,
             crate::vk::KHR_INDEX_TYPE_UINT8_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_INDEX_TYPE_UINT8_NAME;
+            const SPEC_VERSION: u32 = KHR_INDEX_TYPE_UINT8_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_line_rasterization"]
     pub mod line_rasterization {
@@ -16666,6 +19881,18 @@ pub mod khr {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_LINE_RASTERIZATION_NAME;
+            const SPEC_VERSION: u32 = KHR_LINE_RASTERIZATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_KHR_calibrated_timestamps"]
@@ -16797,6 +20024,20 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_CALIBRATED_TIMESTAMPS_NAME;
+            const SPEC_VERSION: u32 = KHR_CALIBRATED_TIMESTAMPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_KHR_shader_expect_assume"]
     pub mod shader_expect_assume {
@@ -16805,6 +20046,16 @@ pub mod khr {
             crate::vk::KHR_SHADER_EXPECT_ASSUME_NAME as NAME,
             crate::vk::KHR_SHADER_EXPECT_ASSUME_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_SHADER_EXPECT_ASSUME_NAME;
+            const SPEC_VERSION: u32 = KHR_SHADER_EXPECT_ASSUME_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_KHR_maintenance6"]
     pub mod maintenance6 {
@@ -16976,6 +20227,18 @@ pub mod khr {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = KHR_MAINTENANCE6_NAME;
+            const SPEC_VERSION: u32 = KHR_MAINTENANCE6_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged LUNARG"]
@@ -16987,6 +20250,16 @@ pub mod lunarg {
             crate::vk::LUNARG_DIRECT_DRIVER_LOADING_NAME as NAME,
             crate::vk::LUNARG_DIRECT_DRIVER_LOADING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = LUNARG_DIRECT_DRIVER_LOADING_NAME;
+            const SPEC_VERSION: u32 = LUNARG_DIRECT_DRIVER_LOADING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged MSFT"]
@@ -16998,6 +20271,16 @@ pub mod msft {
             crate::vk::MSFT_LAYERED_DRIVER_NAME as NAME,
             crate::vk::MSFT_LAYERED_DRIVER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = MSFT_LAYERED_DRIVER_NAME;
+            const SPEC_VERSION: u32 = MSFT_LAYERED_DRIVER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged MVK"]
@@ -17068,6 +20351,18 @@ pub mod mvk {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = MVK_IOS_SURFACE_NAME;
+            const SPEC_VERSION: u32 = MVK_IOS_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_MVK_macos_surface"]
     pub mod macos_surface {
@@ -17134,6 +20429,18 @@ pub mod mvk {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = MVK_MACOS_SURFACE_NAME;
+            const SPEC_VERSION: u32 = MVK_MACOS_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -17203,6 +20510,18 @@ pub mod nn {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NN_VI_SURFACE_NAME;
+            const SPEC_VERSION: u32 = NN_VI_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
 }
 #[doc = "Extensions tagged NV"]
@@ -17214,6 +20533,16 @@ pub mod nv {
             crate::vk::NV_GLSL_SHADER_NAME as NAME,
             crate::vk::NV_GLSL_SHADER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_GLSL_SHADER_NAME;
+            const SPEC_VERSION: u32 = NV_GLSL_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_dedicated_allocation"]
     pub mod dedicated_allocation {
@@ -17222,6 +20551,16 @@ pub mod nv {
             crate::vk::NV_DEDICATED_ALLOCATION_NAME as NAME,
             crate::vk::NV_DEDICATED_ALLOCATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DEDICATED_ALLOCATION_NAME;
+            const SPEC_VERSION: u32 = NV_DEDICATED_ALLOCATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_corner_sampled_image"]
     pub mod corner_sampled_image {
@@ -17230,6 +20569,16 @@ pub mod nv {
             crate::vk::NV_CORNER_SAMPLED_IMAGE_NAME as NAME,
             crate::vk::NV_CORNER_SAMPLED_IMAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_CORNER_SAMPLED_IMAGE_NAME;
+            const SPEC_VERSION: u32 = NV_CORNER_SAMPLED_IMAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_external_memory_capabilities"]
     pub mod external_memory_capabilities {
@@ -17304,6 +20653,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_CAPABILITIES_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_NV_external_memory"]
     pub mod external_memory {
@@ -17312,6 +20673,16 @@ pub mod nv {
             crate::vk::NV_EXTERNAL_MEMORY_NAME as NAME,
             crate::vk::NV_EXTERNAL_MEMORY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_external_memory_win32"]
     pub mod external_memory_win32 {
@@ -17380,6 +20751,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_WIN32_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_win32_keyed_mutex"]
     pub mod win32_keyed_mutex {
@@ -17388,6 +20771,17 @@ pub mod nv {
             crate::vk::NV_WIN32_KEYED_MUTEX_NAME as NAME,
             crate::vk::NV_WIN32_KEYED_MUTEX_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_WIN32_KEYED_MUTEX_NAME;
+            const SPEC_VERSION: u32 = NV_WIN32_KEYED_MUTEX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_WIN32_KEYED_MUTEX_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_clip_space_w_scaling"]
     pub mod clip_space_w_scaling {
@@ -17456,6 +20850,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_CLIP_SPACE_W_SCALING_NAME;
+            const SPEC_VERSION: u32 = NV_CLIP_SPACE_W_SCALING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_sample_mask_override_coverage"]
     pub mod sample_mask_override_coverage {
@@ -17464,6 +20870,16 @@ pub mod nv {
             crate::vk::NV_SAMPLE_MASK_OVERRIDE_COVERAGE_NAME as NAME,
             crate::vk::NV_SAMPLE_MASK_OVERRIDE_COVERAGE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SAMPLE_MASK_OVERRIDE_COVERAGE_NAME;
+            const SPEC_VERSION: u32 = NV_SAMPLE_MASK_OVERRIDE_COVERAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_geometry_shader_passthrough"]
     pub mod geometry_shader_passthrough {
@@ -17472,6 +20888,16 @@ pub mod nv {
             crate::vk::NV_GEOMETRY_SHADER_PASSTHROUGH_NAME as NAME,
             crate::vk::NV_GEOMETRY_SHADER_PASSTHROUGH_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_GEOMETRY_SHADER_PASSTHROUGH_NAME;
+            const SPEC_VERSION: u32 = NV_GEOMETRY_SHADER_PASSTHROUGH_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_viewport_array2"]
     pub mod viewport_array2 {
@@ -17480,6 +20906,16 @@ pub mod nv {
             crate::vk::NV_VIEWPORT_ARRAY2_NAME as NAME,
             crate::vk::NV_VIEWPORT_ARRAY2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_VIEWPORT_ARRAY2_NAME;
+            const SPEC_VERSION: u32 = NV_VIEWPORT_ARRAY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_viewport_swizzle"]
     pub mod viewport_swizzle {
@@ -17488,6 +20924,16 @@ pub mod nv {
             crate::vk::NV_VIEWPORT_SWIZZLE_NAME as NAME,
             crate::vk::NV_VIEWPORT_SWIZZLE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_VIEWPORT_SWIZZLE_NAME;
+            const SPEC_VERSION: u32 = NV_VIEWPORT_SWIZZLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_fragment_coverage_to_color"]
     pub mod fragment_coverage_to_color {
@@ -17496,6 +20942,16 @@ pub mod nv {
             crate::vk::NV_FRAGMENT_COVERAGE_TO_COLOR_NAME as NAME,
             crate::vk::NV_FRAGMENT_COVERAGE_TO_COLOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_FRAGMENT_COVERAGE_TO_COLOR_NAME;
+            const SPEC_VERSION: u32 = NV_FRAGMENT_COVERAGE_TO_COLOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_framebuffer_mixed_samples"]
     pub mod framebuffer_mixed_samples {
@@ -17504,6 +20960,16 @@ pub mod nv {
             crate::vk::NV_FRAMEBUFFER_MIXED_SAMPLES_NAME as NAME,
             crate::vk::NV_FRAMEBUFFER_MIXED_SAMPLES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_FRAMEBUFFER_MIXED_SAMPLES_NAME;
+            const SPEC_VERSION: u32 = NV_FRAMEBUFFER_MIXED_SAMPLES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_fill_rectangle"]
     pub mod fill_rectangle {
@@ -17512,6 +20978,16 @@ pub mod nv {
             crate::vk::NV_FILL_RECTANGLE_NAME as NAME,
             crate::vk::NV_FILL_RECTANGLE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_FILL_RECTANGLE_NAME;
+            const SPEC_VERSION: u32 = NV_FILL_RECTANGLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_shader_sm_builtins"]
     pub mod shader_sm_builtins {
@@ -17520,6 +20996,16 @@ pub mod nv {
             crate::vk::NV_SHADER_SM_BUILTINS_NAME as NAME,
             crate::vk::NV_SHADER_SM_BUILTINS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SHADER_SM_BUILTINS_NAME;
+            const SPEC_VERSION: u32 = NV_SHADER_SM_BUILTINS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_shading_rate_image"]
     pub mod shading_rate_image {
@@ -17631,6 +21117,18 @@ pub mod nv {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SHADING_RATE_IMAGE_NAME;
+            const SPEC_VERSION: u32 = NV_SHADING_RATE_IMAGE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_NV_ray_tracing"]
@@ -17963,6 +21461,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_RAY_TRACING_NAME;
+            const SPEC_VERSION: u32 = NV_RAY_TRACING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_representative_fragment_test"]
     pub mod representative_fragment_test {
@@ -17971,6 +21481,16 @@ pub mod nv {
             crate::vk::NV_REPRESENTATIVE_FRAGMENT_TEST_NAME as NAME,
             crate::vk::NV_REPRESENTATIVE_FRAGMENT_TEST_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_REPRESENTATIVE_FRAGMENT_TEST_NAME;
+            const SPEC_VERSION: u32 = NV_REPRESENTATIVE_FRAGMENT_TEST_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_shader_subgroup_partitioned"]
     pub mod shader_subgroup_partitioned {
@@ -17979,6 +21499,16 @@ pub mod nv {
             crate::vk::NV_SHADER_SUBGROUP_PARTITIONED_NAME as NAME,
             crate::vk::NV_SHADER_SUBGROUP_PARTITIONED_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SHADER_SUBGROUP_PARTITIONED_NAME;
+            const SPEC_VERSION: u32 = NV_SHADER_SUBGROUP_PARTITIONED_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_compute_shader_derivatives"]
     pub mod compute_shader_derivatives {
@@ -17987,6 +21517,16 @@ pub mod nv {
             crate::vk::NV_COMPUTE_SHADER_DERIVATIVES_NAME as NAME,
             crate::vk::NV_COMPUTE_SHADER_DERIVATIVES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_COMPUTE_SHADER_DERIVATIVES_NAME;
+            const SPEC_VERSION: u32 = NV_COMPUTE_SHADER_DERIVATIVES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_mesh_shader"]
     pub mod mesh_shader {
@@ -18102,6 +21642,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_MESH_SHADER_NAME;
+            const SPEC_VERSION: u32 = NV_MESH_SHADER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_fragment_shader_barycentric"]
     pub mod fragment_shader_barycentric {
@@ -18110,6 +21662,17 @@ pub mod nv {
             crate::vk::NV_FRAGMENT_SHADER_BARYCENTRIC_NAME as NAME,
             crate::vk::NV_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_FRAGMENT_SHADER_BARYCENTRIC_NAME;
+            const SPEC_VERSION: u32 = NV_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(KHR_FRAGMENT_SHADER_BARYCENTRIC_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_shader_image_footprint"]
     pub mod shader_image_footprint {
@@ -18118,6 +21681,16 @@ pub mod nv {
             crate::vk::NV_SHADER_IMAGE_FOOTPRINT_NAME as NAME,
             crate::vk::NV_SHADER_IMAGE_FOOTPRINT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SHADER_IMAGE_FOOTPRINT_NAME;
+            const SPEC_VERSION: u32 = NV_SHADER_IMAGE_FOOTPRINT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_scissor_exclusive"]
     pub mod scissor_exclusive {
@@ -18209,6 +21782,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SCISSOR_EXCLUSIVE_NAME;
+            const SPEC_VERSION: u32 = NV_SCISSOR_EXCLUSIVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_device_diagnostic_checkpoints"]
     pub mod device_diagnostic_checkpoints {
@@ -18295,6 +21880,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_dedicated_allocation_image_aliasing"]
     pub mod dedicated_allocation_image_aliasing {
@@ -18303,6 +21900,16 @@ pub mod nv {
             crate::vk::NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_NAME as NAME,
             crate::vk::NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_NAME;
+            const SPEC_VERSION: u32 = NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_cooperative_matrix"]
     pub mod cooperative_matrix {
@@ -18372,6 +21979,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_COOPERATIVE_MATRIX_NAME;
+            const SPEC_VERSION: u32 = NV_COOPERATIVE_MATRIX_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_NV_coverage_reduction_mode"]
     pub mod coverage_reduction_mode {
@@ -18436,6 +22055,18 @@ pub mod nv {
                         }
                     },
                 }
+            }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_COVERAGE_REDUCTION_MODE_NAME;
+            const SPEC_VERSION: u32 = NV_COVERAGE_REDUCTION_MODE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
             }
         }
     }
@@ -18618,6 +22249,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DEVICE_GENERATED_COMMANDS_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_GENERATED_COMMANDS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_inherited_viewport_scissor"]
     pub mod inherited_viewport_scissor {
@@ -18626,6 +22269,16 @@ pub mod nv {
             crate::vk::NV_INHERITED_VIEWPORT_SCISSOR_NAME as NAME,
             crate::vk::NV_INHERITED_VIEWPORT_SCISSOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_INHERITED_VIEWPORT_SCISSOR_NAME;
+            const SPEC_VERSION: u32 = NV_INHERITED_VIEWPORT_SCISSOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_present_barrier"]
     pub mod present_barrier {
@@ -18634,6 +22287,16 @@ pub mod nv {
             crate::vk::NV_PRESENT_BARRIER_NAME as NAME,
             crate::vk::NV_PRESENT_BARRIER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_PRESENT_BARRIER_NAME;
+            const SPEC_VERSION: u32 = NV_PRESENT_BARRIER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_device_diagnostics_config"]
     pub mod device_diagnostics_config {
@@ -18642,6 +22305,16 @@ pub mod nv {
             crate::vk::NV_DEVICE_DIAGNOSTICS_CONFIG_NAME as NAME,
             crate::vk::NV_DEVICE_DIAGNOSTICS_CONFIG_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DEVICE_DIAGNOSTICS_CONFIG_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_DIAGNOSTICS_CONFIG_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_cuda_kernel_launch"]
     pub mod cuda_kernel_launch {
@@ -18814,6 +22487,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_CUDA_KERNEL_LAUNCH_NAME;
+            const SPEC_VERSION: u32 = NV_CUDA_KERNEL_LAUNCH_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_low_latency"]
     pub mod low_latency {
@@ -18822,6 +22507,16 @@ pub mod nv {
             crate::vk::NV_LOW_LATENCY_NAME as NAME,
             crate::vk::NV_LOW_LATENCY_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_LOW_LATENCY_NAME;
+            const SPEC_VERSION: u32 = NV_LOW_LATENCY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_fragment_shading_rate_enums"]
     pub mod fragment_shading_rate_enums {
@@ -18890,6 +22585,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_FRAGMENT_SHADING_RATE_ENUMS_NAME;
+            const SPEC_VERSION: u32 = NV_FRAGMENT_SHADING_RATE_ENUMS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_ray_tracing_motion_blur"]
     pub mod ray_tracing_motion_blur {
@@ -18898,6 +22605,16 @@ pub mod nv {
             crate::vk::NV_RAY_TRACING_MOTION_BLUR_NAME as NAME,
             crate::vk::NV_RAY_TRACING_MOTION_BLUR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_RAY_TRACING_MOTION_BLUR_NAME;
+            const SPEC_VERSION: u32 = NV_RAY_TRACING_MOTION_BLUR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_acquire_winrt_display"]
     pub mod acquire_winrt_display {
@@ -18981,6 +22698,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_ACQUIRE_WINRT_DISPLAY_NAME;
+            const SPEC_VERSION: u32 = NV_ACQUIRE_WINRT_DISPLAY_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_NV_external_memory_rdma"]
     pub mod external_memory_rdma {
@@ -19050,6 +22779,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_EXTERNAL_MEMORY_RDMA_NAME;
+            const SPEC_VERSION: u32 = NV_EXTERNAL_MEMORY_RDMA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_displacement_micromap"]
     pub mod displacement_micromap {
@@ -19058,6 +22799,16 @@ pub mod nv {
             crate::vk::NV_DISPLACEMENT_MICROMAP_NAME as NAME,
             crate::vk::NV_DISPLACEMENT_MICROMAP_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DISPLACEMENT_MICROMAP_NAME;
+            const SPEC_VERSION: u32 = NV_DISPLACEMENT_MICROMAP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_copy_memory_indirect"]
     pub mod copy_memory_indirect {
@@ -19152,6 +22903,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_COPY_MEMORY_INDIRECT_NAME;
+            const SPEC_VERSION: u32 = NV_COPY_MEMORY_INDIRECT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_memory_decompression"]
     pub mod memory_decompression {
@@ -19241,6 +23004,18 @@ pub mod nv {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_MEMORY_DECOMPRESSION_NAME;
+            const SPEC_VERSION: u32 = NV_MEMORY_DECOMPRESSION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
     #[doc = "VK_NV_device_generated_commands_compute"]
@@ -19354,6 +23129,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DEVICE_GENERATED_COMMANDS_COMPUTE_NAME;
+            const SPEC_VERSION: u32 = NV_DEVICE_GENERATED_COMMANDS_COMPUTE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_linear_color_attachment"]
     pub mod linear_color_attachment {
@@ -19362,6 +23149,16 @@ pub mod nv {
             crate::vk::NV_LINEAR_COLOR_ATTACHMENT_NAME as NAME,
             crate::vk::NV_LINEAR_COLOR_ATTACHMENT_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_LINEAR_COLOR_ATTACHMENT_NAME;
+            const SPEC_VERSION: u32 = NV_LINEAR_COLOR_ATTACHMENT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_optical_flow"]
     pub mod optical_flow {
@@ -19560,6 +23357,20 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_OPTICAL_FLOW_NAME;
+            const SPEC_VERSION: u32 = NV_OPTICAL_FLOW_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_NV_ray_tracing_invocation_reorder"]
     pub mod ray_tracing_invocation_reorder {
@@ -19568,6 +23379,16 @@ pub mod nv {
             crate::vk::NV_RAY_TRACING_INVOCATION_REORDER_NAME as NAME,
             crate::vk::NV_RAY_TRACING_INVOCATION_REORDER_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_RAY_TRACING_INVOCATION_REORDER_NAME;
+            const SPEC_VERSION: u32 = NV_RAY_TRACING_INVOCATION_REORDER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_extended_sparse_address_space"]
     pub mod extended_sparse_address_space {
@@ -19576,6 +23397,16 @@ pub mod nv {
             crate::vk::NV_EXTENDED_SPARSE_ADDRESS_SPACE_NAME as NAME,
             crate::vk::NV_EXTENDED_SPARSE_ADDRESS_SPACE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_EXTENDED_SPARSE_ADDRESS_SPACE_NAME;
+            const SPEC_VERSION: u32 = NV_EXTENDED_SPARSE_ADDRESS_SPACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_low_latency2"]
     pub mod low_latency2 {
@@ -19720,6 +23551,18 @@ pub mod nv {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_LOW_LATENCY2_NAME;
+            const SPEC_VERSION: u32 = NV_LOW_LATENCY2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_per_stage_descriptor_set"]
     pub mod per_stage_descriptor_set {
@@ -19728,6 +23571,16 @@ pub mod nv {
             crate::vk::NV_PER_STAGE_DESCRIPTOR_SET_NAME as NAME,
             crate::vk::NV_PER_STAGE_DESCRIPTOR_SET_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_PER_STAGE_DESCRIPTOR_SET_NAME;
+            const SPEC_VERSION: u32 = NV_PER_STAGE_DESCRIPTOR_SET_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_descriptor_pool_overallocation"]
     pub mod descriptor_pool_overallocation {
@@ -19736,6 +23589,16 @@ pub mod nv {
             crate::vk::NV_DESCRIPTOR_POOL_OVERALLOCATION_NAME as NAME,
             crate::vk::NV_DESCRIPTOR_POOL_OVERALLOCATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_DESCRIPTOR_POOL_OVERALLOCATION_NAME;
+            const SPEC_VERSION: u32 = NV_DESCRIPTOR_POOL_OVERALLOCATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_raw_access_chains"]
     pub mod raw_access_chains {
@@ -19744,6 +23607,16 @@ pub mod nv {
             crate::vk::NV_RAW_ACCESS_CHAINS_NAME as NAME,
             crate::vk::NV_RAW_ACCESS_CHAINS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_RAW_ACCESS_CHAINS_NAME;
+            const SPEC_VERSION: u32 = NV_RAW_ACCESS_CHAINS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_shader_atomic_float16_vector"]
     pub mod shader_atomic_float16_vector {
@@ -19752,6 +23625,16 @@ pub mod nv {
             crate::vk::NV_SHADER_ATOMIC_FLOAT16_VECTOR_NAME as NAME,
             crate::vk::NV_SHADER_ATOMIC_FLOAT16_VECTOR_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_SHADER_ATOMIC_FLOAT16_VECTOR_NAME;
+            const SPEC_VERSION: u32 = NV_SHADER_ATOMIC_FLOAT16_VECTOR_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NV_ray_tracing_validation"]
     pub mod ray_tracing_validation {
@@ -19760,6 +23643,16 @@ pub mod nv {
             crate::vk::NV_RAY_TRACING_VALIDATION_NAME as NAME,
             crate::vk::NV_RAY_TRACING_VALIDATION_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NV_RAY_TRACING_VALIDATION_NAME;
+            const SPEC_VERSION: u32 = NV_RAY_TRACING_VALIDATION_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged NVX"]
@@ -19909,6 +23802,18 @@ pub mod nvx {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NVX_BINARY_IMPORT_NAME;
+            const SPEC_VERSION: u32 = NVX_BINARY_IMPORT_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NVX_image_view_handle"]
     pub mod image_view_handle {
@@ -19996,6 +23901,18 @@ pub mod nvx {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NVX_IMAGE_VIEW_HANDLE_NAME;
+            const SPEC_VERSION: u32 = NVX_IMAGE_VIEW_HANDLE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_NVX_multiview_per_view_attributes"]
     pub mod multiview_per_view_attributes {
@@ -20004,6 +23921,16 @@ pub mod nvx {
             crate::vk::NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_NAME as NAME,
             crate::vk::NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_NAME;
+            const SPEC_VERSION: u32 = NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged QCOM"]
@@ -20015,6 +23942,16 @@ pub mod qcom {
             crate::vk::QCOM_RENDER_PASS_SHADER_RESOLVE_NAME as NAME,
             crate::vk::QCOM_RENDER_PASS_SHADER_RESOLVE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_RENDER_PASS_SHADER_RESOLVE_NAME;
+            const SPEC_VERSION: u32 = QCOM_RENDER_PASS_SHADER_RESOLVE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_render_pass_transform"]
     pub mod render_pass_transform {
@@ -20023,6 +23960,16 @@ pub mod qcom {
             crate::vk::QCOM_RENDER_PASS_TRANSFORM_NAME as NAME,
             crate::vk::QCOM_RENDER_PASS_TRANSFORM_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_RENDER_PASS_TRANSFORM_NAME;
+            const SPEC_VERSION: u32 = QCOM_RENDER_PASS_TRANSFORM_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_render_pass_store_ops"]
     pub mod render_pass_store_ops {
@@ -20031,6 +23978,16 @@ pub mod qcom {
             crate::vk::QCOM_RENDER_PASS_STORE_OPS_NAME as NAME,
             crate::vk::QCOM_RENDER_PASS_STORE_OPS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_RENDER_PASS_STORE_OPS_NAME;
+            const SPEC_VERSION: u32 = QCOM_RENDER_PASS_STORE_OPS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_rotated_copy_commands"]
     pub mod rotated_copy_commands {
@@ -20039,6 +23996,16 @@ pub mod qcom {
             crate::vk::QCOM_ROTATED_COPY_COMMANDS_NAME as NAME,
             crate::vk::QCOM_ROTATED_COPY_COMMANDS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_ROTATED_COPY_COMMANDS_NAME;
+            const SPEC_VERSION: u32 = QCOM_ROTATED_COPY_COMMANDS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_fragment_density_map_offset"]
     pub mod fragment_density_map_offset {
@@ -20047,6 +24014,16 @@ pub mod qcom {
             crate::vk::QCOM_FRAGMENT_DENSITY_MAP_OFFSET_NAME as NAME,
             crate::vk::QCOM_FRAGMENT_DENSITY_MAP_OFFSET_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_FRAGMENT_DENSITY_MAP_OFFSET_NAME;
+            const SPEC_VERSION: u32 = QCOM_FRAGMENT_DENSITY_MAP_OFFSET_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_image_processing"]
     pub mod image_processing {
@@ -20055,6 +24032,16 @@ pub mod qcom {
             crate::vk::QCOM_IMAGE_PROCESSING_NAME as NAME,
             crate::vk::QCOM_IMAGE_PROCESSING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_IMAGE_PROCESSING_NAME;
+            const SPEC_VERSION: u32 = QCOM_IMAGE_PROCESSING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_tile_properties"]
     pub mod tile_properties {
@@ -20147,6 +24134,18 @@ pub mod qcom {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_TILE_PROPERTIES_NAME;
+            const SPEC_VERSION: u32 = QCOM_TILE_PROPERTIES_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_multiview_per_view_viewports"]
     pub mod multiview_per_view_viewports {
@@ -20155,6 +24154,16 @@ pub mod qcom {
             crate::vk::QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_NAME as NAME,
             crate::vk::QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_NAME;
+            const SPEC_VERSION: u32 = QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_multiview_per_view_render_areas"]
     pub mod multiview_per_view_render_areas {
@@ -20163,6 +24172,16 @@ pub mod qcom {
             crate::vk::QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_NAME as NAME,
             crate::vk::QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_NAME;
+            const SPEC_VERSION: u32 = QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_image_processing2"]
     pub mod image_processing2 {
@@ -20171,6 +24190,16 @@ pub mod qcom {
             crate::vk::QCOM_IMAGE_PROCESSING2_NAME as NAME,
             crate::vk::QCOM_IMAGE_PROCESSING2_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_IMAGE_PROCESSING2_NAME;
+            const SPEC_VERSION: u32 = QCOM_IMAGE_PROCESSING2_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_filter_cubic_weights"]
     pub mod filter_cubic_weights {
@@ -20179,6 +24208,16 @@ pub mod qcom {
             crate::vk::QCOM_FILTER_CUBIC_WEIGHTS_NAME as NAME,
             crate::vk::QCOM_FILTER_CUBIC_WEIGHTS_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_FILTER_CUBIC_WEIGHTS_NAME;
+            const SPEC_VERSION: u32 = QCOM_FILTER_CUBIC_WEIGHTS_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_ycbcr_degamma"]
     pub mod ycbcr_degamma {
@@ -20187,6 +24226,16 @@ pub mod qcom {
             crate::vk::QCOM_YCBCR_DEGAMMA_NAME as NAME,
             crate::vk::QCOM_YCBCR_DEGAMMA_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_YCBCR_DEGAMMA_NAME;
+            const SPEC_VERSION: u32 = QCOM_YCBCR_DEGAMMA_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_QCOM_filter_cubic_clamp"]
     pub mod filter_cubic_clamp {
@@ -20195,6 +24244,16 @@ pub mod qcom {
             crate::vk::QCOM_FILTER_CUBIC_CLAMP_NAME as NAME,
             crate::vk::QCOM_FILTER_CUBIC_CLAMP_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QCOM_FILTER_CUBIC_CLAMP_NAME;
+            const SPEC_VERSION: u32 = QCOM_FILTER_CUBIC_CLAMP_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged QNX"]
@@ -20289,6 +24348,18 @@ pub mod qnx {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QNX_SCREEN_SURFACE_NAME;
+            const SPEC_VERSION: u32 = QNX_SCREEN_SURFACE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = Instance;
+            fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Instance {
+                Instance::new(entry, instance)
+            }
+        }
     }
     #[doc = "VK_QNX_external_memory_screen_buffer"]
     pub mod external_memory_screen_buffer {
@@ -20357,6 +24428,18 @@ pub mod qnx {
                 }
             }
         }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = QNX_EXTERNAL_MEMORY_SCREEN_BUFFER_NAME;
+            const SPEC_VERSION: u32 = QNX_EXTERNAL_MEMORY_SCREEN_BUFFER_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged SEC"]
@@ -20368,6 +24451,16 @@ pub mod sec {
             crate::vk::SEC_AMIGO_PROFILING_NAME as NAME,
             crate::vk::SEC_AMIGO_PROFILING_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = SEC_AMIGO_PROFILING_NAME;
+            const SPEC_VERSION: u32 = SEC_AMIGO_PROFILING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
 }
 #[doc = "Extensions tagged VALVE"]
@@ -20379,6 +24472,17 @@ pub mod valve {
             crate::vk::VALVE_MUTABLE_DESCRIPTOR_TYPE_NAME as NAME,
             crate::vk::VALVE_MUTABLE_DESCRIPTOR_TYPE_SPEC_VERSION as SPEC_VERSION,
         };
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = VALVE_MUTABLE_DESCRIPTOR_TYPE_NAME;
+            const SPEC_VERSION: u32 = VALVE_MUTABLE_DESCRIPTOR_TYPE_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus =
+                PromotionStatus::PromotedToExtension(EXT_MUTABLE_DESCRIPTOR_TYPE_NAME);
+            type Device = ();
+            fn new_device(_instance: &crate::Instance, _device: &crate::Device) {}
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
+        }
     }
     #[doc = "VK_VALVE_descriptor_set_host_mapping"]
     pub mod descriptor_set_host_mapping {
@@ -20469,6 +24573,18 @@ pub mod valve {
                     },
                 }
             }
+        }
+        pub struct Meta;
+        impl ExtensionMeta for Meta {
+            const NAME: &'static CStr = VALVE_DESCRIPTOR_SET_HOST_MAPPING_NAME;
+            const SPEC_VERSION: u32 = VALVE_DESCRIPTOR_SET_HOST_MAPPING_SPEC_VERSION;
+            const PROMOTION_STATUS: PromotionStatus = PromotionStatus::None;
+            type Device = Device;
+            fn new_device(instance: &crate::Instance, device: &crate::Device) -> Device {
+                Device::new(instance, device)
+            }
+            type Instance = ();
+            fn new_instance(_entry: &crate::Entry, _instance: &crate::Instance) {}
         }
     }
 }

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -64,3 +64,20 @@ pub trait Handle: Sized {
         self.as_raw() == 0
     }
 }
+
+pub enum PromotionStatus {
+    None,
+    PromotedToCore(u32),
+    PromotedToExtension(&'static core::ffi::CStr),
+}
+
+pub trait ExtensionMeta {
+    const NAME: &'static core::ffi::CStr;
+    const SPEC_VERSION: u32;
+    const PROMOTION_STATUS: PromotionStatus;
+
+    type Device;
+    fn new_device(instance: &crate::Instance, device: &crate::Device) -> Self::Device;
+    type Instance;
+    fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Self::Instance;
+}


### PR DESCRIPTION
Supersedes #912

Create new marker traits `ExtensionMeta` as defined below:

 ```rs
pub enum PromotionStatus {
    None,
    PromotedToCore(u32),
    PromotedToExtension(&'static core::ffi::CStr),
}

pub trait ExtensionMeta {
    const NAME: &'static core::ffi::CStr;
    const SPEC_VERSION: u32;
    const PROMOTION_STATUS: PromotionStatus;

    type Device;
    fn new_device(instance: &crate::Instance, device: &crate::Device) -> Self::Device;
    type Instance;
    fn new_instance(entry: &crate::Entry, instance: &crate::Instance) -> Self::Instance;
}
```

Add marker struct `Meta` in all extension mod root. `ExtensionMeta` trait is automatically implemented for all `Meta` marker structs.

### Why is this useful?
Higher level abstractions may want to offer a way for users to enable extensions during application startup. Instead of asking for a `&'static CStr` extension name, we could instead ask for an `impl ExtensionMeta` which is significantly more idiomatic. This also gives us the promotion status of an extension, which allows the framework to behave differently depending on the core Vulkan version.

```rs
// During application startup
app.enable_extension<ash::khr::acceleration_structure::Meta>();
```

Unfortunately, we cannot implement traits for modules. That's why we need the extra `Meta` type that we added on module roots.