### PR TITLE
TEMP: Take a git reference on `vk-parse` for the upcoming `vk.xml` `<enums type="constants">` attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ members = [
     "generator",
     "generator-rewrite",
 ]
+
+[patch.crates-io]
+# https://github.com/krolli/vk-parse/pull/32
+# https://togithub.com/KhronosGroup/Vulkan-Docs/pull/2366
+vk-parse = { git = "https://github.com/MarijnS95/vk-parse", rev = "97848b1" }


### PR DESCRIPTION
Without a `vk-parse` change, adding `type="constants"` to `<enums>` in `vk.xml` will cause all our constants to be lost.  Use the patched crate until it's merged and released upstream, to unblock the proposed `vk.xml` change.

https://github.com/krolli/vk-parse/pull/32
https://github.com/KhronosGroup/Vulkan-Docs/pull/2366
