### PR TITLE
Make bindings resilient to OOM errors

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1547,7 +1547,10 @@ impl Device {
         &self,
         allocate_info: &vk::DescriptorSetAllocateInfo<'_>,
     ) -> VkResult<Vec<vk::DescriptorSet>> {
-        let mut desc_set = Vec::with_capacity(allocate_info.descriptor_set_count as usize);
+        let mut desc_set = Vec::new();
+        desc_set
+            .try_reserve(allocate_info.descriptor_set_count as usize)
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         (self.device_fn_1_0.allocate_descriptor_sets)(
             self.handle(),
             allocate_info,
@@ -2153,7 +2156,10 @@ impl Device {
         create_infos: &[vk::GraphicsPipelineCreateInfo<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+        let mut pipelines = Vec::new();
+        pipelines
+            .try_reserve(create_infos.len())
+            .map_err(|_| (Vec::new(), vk::Result::ERROR_OUT_OF_HOST_MEMORY))?;
         let err_code = (self.device_fn_1_0.create_graphics_pipelines)(
             self.handle(),
             pipeline_cache,
@@ -2181,7 +2187,10 @@ impl Device {
         create_infos: &[vk::ComputePipelineCreateInfo<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+        let mut pipelines = Vec::new();
+        pipelines
+            .try_reserve(create_infos.len())
+            .map_err(|_| (Vec::new(), vk::Result::ERROR_OUT_OF_HOST_MEMORY))?;
         let err_code = (self.device_fn_1_0.create_compute_pipelines)(
             self.handle(),
             pipeline_cache,
@@ -2542,7 +2551,10 @@ impl Device {
         &self,
         allocate_info: &vk::CommandBufferAllocateInfo<'_>,
     ) -> VkResult<Vec<vk::CommandBuffer>> {
-        let mut buffers = Vec::with_capacity(allocate_info.command_buffer_count as usize);
+        let mut buffers = Vec::new();
+        buffers
+            .try_reserve(allocate_info.command_buffer_count as usize)
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         (self.device_fn_1_0.allocate_command_buffers)(
             self.handle(),
             allocate_info,

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -19,7 +19,10 @@ impl crate::amdx::shader_enqueue::Device {
         create_infos: &[vk::ExecutionGraphPipelineCreateInfoAMDX<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+        let mut pipelines = Vec::new();
+        pipelines
+            .try_reserve(create_infos.len())
+            .map_err(|_| (Vec::new(), vk::Result::ERROR_OUT_OF_HOST_MEMORY))?;
         let err_code = (self.fp.create_execution_graph_pipelines_amdx)(
             self.handle,
             pipeline_cache,

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -14,7 +14,10 @@ impl crate::ext::calibrated_timestamps::Device {
         &self,
         info: &[vk::CalibratedTimestampInfoEXT<'_>],
     ) -> VkResult<(Vec<u64>, u64)> {
-        let mut timestamps = Vec::with_capacity(info.len());
+        let mut timestamps = Vec::new();
+        timestamps
+            .try_reserve(info.len())
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         let mut max_deviation = mem::MaybeUninit::uninit();
         let max_deviation = (self.fp.get_calibrated_timestamps_ext)(
             self.handle,

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -23,7 +23,10 @@ impl crate::ext::shader_object::Device {
         create_infos: &[vk::ShaderCreateInfoEXT<'_>],
         allocator: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::ShaderEXT>, (Vec<vk::ShaderEXT>, vk::Result)> {
-        let mut shaders = Vec::with_capacity(create_infos.len());
+        let mut shaders = Vec::new();
+        shaders
+            .try_reserve(create_infos.len())
+            .map_err(|_| (Vec::new(), vk::Result::ERROR_OUT_OF_HOST_MEMORY))?;
         let err_code = (self.fp.create_shaders_ext)(
             self.handle,
             create_infos.len() as u32,

--- a/ash/src/extensions/khr/calibrated_timestamps.rs
+++ b/ash/src/extensions/khr/calibrated_timestamps.rs
@@ -14,7 +14,10 @@ impl crate::khr::calibrated_timestamps::Device {
         &self,
         info: &[vk::CalibratedTimestampInfoKHR<'_>],
     ) -> VkResult<(Vec<u64>, u64)> {
-        let mut timestamps = Vec::with_capacity(info.len());
+        let mut timestamps = Vec::new();
+        timestamps
+            .try_reserve(info.len())
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         let mut max_deviation = mem::MaybeUninit::uninit();
         let max_deviation = (self.fp.get_calibrated_timestamps_khr)(
             self.handle,

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -13,7 +13,10 @@ impl crate::khr::display_swapchain::Device {
         create_infos: &[vk::SwapchainCreateInfoKHR<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> VkResult<Vec<vk::SwapchainKHR>> {
-        let mut swapchains = Vec::with_capacity(create_infos.len());
+        let mut swapchains = Vec::new();
+        swapchains
+            .try_reserve(create_infos.len())
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         (self.fp.create_shared_swapchains_khr)(
             self.handle,
             create_infos.len() as u32,

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -44,7 +44,10 @@ impl crate::khr::ray_tracing_pipeline::Device {
         create_infos: &[vk::RayTracingPipelineCreateInfoKHR<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+        let mut pipelines = Vec::new();
+        pipelines
+            .try_reserve(create_infos.len())
+            .map_err(|_| (Vec::new(), vk::Result::ERROR_OUT_OF_HOST_MEMORY))?;
         let err_code = (self.fp.create_ray_tracing_pipelines_khr)(
             self.handle,
             deferred_operation,
@@ -70,7 +73,9 @@ impl crate::khr::ray_tracing_pipeline::Device {
         group_count: u32,
         data_size: usize,
     ) -> VkResult<Vec<u8>> {
-        let mut data = Vec::<u8>::with_capacity(data_size);
+        let mut data = Vec::<u8>::new();
+        data.try_reserve(data_size)
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         (self.fp.get_ray_tracing_shader_group_handles_khr)(
             self.handle,
             pipeline,
@@ -91,7 +96,9 @@ impl crate::khr::ray_tracing_pipeline::Device {
         group_count: u32,
         data_size: usize,
     ) -> VkResult<Vec<u8>> {
-        let mut data = Vec::<u8>::with_capacity(data_size);
+        let mut data = Vec::<u8>::new();
+        data.try_reserve(data_size)
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
         (self
             .fp
             .get_ray_tracing_capture_replay_shader_group_handles_khr)(

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -157,7 +157,10 @@ impl crate::nv::ray_tracing::Device {
         create_infos: &[vk::RayTracingPipelineCreateInfoNV<'_>],
         allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+        let mut pipelines = Vec::new();
+        pipelines
+            .try_reserve(create_infos.len())
+            .map_err(|_| (Vec::new(), vk::Result::ERROR_OUT_OF_HOST_MEMORY))?;
         let err_code = (self.fp.create_ray_tracing_pipelines_nv)(
             self.handle,
             pipeline_cache,


### PR DESCRIPTION
This PR proposes a relatively simple but maybe controversial change.

In the functions that return a `Vec`, instead of using `Vec::with_capacity` and similar, we use `Vec::new()` followed with `Vec::try_reserve`. If `try_reserve` fails, we return `VK_ERROR_OUT_OF_HOST_MEMORY`.

Note that there's no shorter way on stable Rust to do this. Notably, `try_with_capacity` is unstable.

If I'm not mistaken, the bindings now never panic in case of OOM.

I personally don't have a need for this change, but I thought that this was a neat thing to add.
