### PR TITLE
Upgrade vk-parse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,3 @@ members = [
     "generator-rewrite",
 ]
 
-[patch.crates-io]
-# https://github.com/krolli/vk-parse/pull/32
-# https://togithub.com/KhronosGroup/Vulkan-Docs/pull/2366
-vk-parse = { git = "https://github.com/MarijnS95/vk-parse", rev = "97848b1" }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.7"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.4"
-vk-parse = { version = "0.12", features = ["vkxml-convert"] }
+vk-parse = { version = "0.13", features = ["vkxml-convert"] }
 vkxml = "0.3"
 
 [dependencies.syn]


### PR DESCRIPTION
`vk-parse` has released v0.13 so we can now use the published version.

See also: https://github.com/krolli/vk-parse/pull/32