### PR TITLE
ash: Document `vk::Result` mapping whenever it is transformed on return

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1051,9 +1051,11 @@ impl Device {
         .assume_init_on_success(event)
     }
 
-    /// Returns [`true`] if the event was set, and [`false`] if the event was reset, otherwise it will
-    /// return the error code.
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetEventStatus.html>
+    ///
+    /// # Returns
+    /// Returns [`true`] if the event is _signaled_ ([`vk::Result::EVENT_SET`]), [`false`] if the
+    /// event is _unsignaled_ ([`vk::Result::EVENT_RESET`]), or [`Err`] on failure.
     #[inline]
     pub unsafe fn get_event_status(&self, event: vk::Event) -> VkResult<bool> {
         let err_code = (self.device_fn_1_0.get_event_status)(self.handle(), event);
@@ -2443,6 +2445,10 @@ impl Device {
     }
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetFenceStatus.html>
+    ///
+    /// # Returns
+    /// Returns [`true`] if the fence is _signaled_ ([`vk::Result::SUCCESS`]), [`false`] if the
+    /// fence is _unsignaled_ ([`vk::Result::NOT_READY`]), or [`Err`] on failure.
     #[inline]
     pub unsafe fn get_fence_status(&self, fence: vk::Fence) -> VkResult<bool> {
         let err_code = (self.device_fn_1_0.get_fence_status)(self.handle(), fence);

--- a/ash/src/extensions/khr/device_group.rs
+++ b/ash/src/extensions/khr/device_group.rs
@@ -94,8 +94,6 @@ impl crate::khr::device_group::Device {
         .assume_init_on_success(modes)
     }
 
-    /// On success, returns the next image's index and whether the swapchain is suboptimal for the surface.
-    ///
     /// Requires [`VK_KHR_swapchain`] to be enabled.
     ///
     /// Also available as [`khr::swapchain::Device::acquire_next_image2()`] since [Vulkan 1.1].
@@ -104,6 +102,11 @@ impl crate::khr::device_group::Device {
     ///
     /// [Vulkan 1.1]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_VERSION_1_1.html
     /// [`VK_KHR_swapchain`]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_swapchain.html
+    ///
+    /// # Returns
+    /// Returns the next image's index, and [`false`] if the swapchain is optimal for the surface
+    /// ([`vk::Result::SUCCESS`]), [`true`] if the swapchain is _suboptimal_ for the surface
+    /// ([`vk::Result::SUBOPTIMAL_KHR`]), or [`Err`] on failure.
     #[inline]
     pub unsafe fn acquire_next_image2(
         &self,

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -47,9 +47,12 @@ impl crate::khr::swapchain::Device {
         })
     }
 
-    /// On success, returns the next image's index and whether the swapchain is suboptimal for the surface.
-    ///
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkAcquireNextImageKHR.html>
+    ///
+    /// # Returns
+    /// Returns the next image's index, and [`false`] if the swapchain is optimal for the surface
+    /// ([`vk::Result::SUCCESS`]), [`true`] if the swapchain is _suboptimal_ for the surface
+    /// ([`vk::Result::SUBOPTIMAL_KHR`]), or [`Err`] on failure.
     #[inline]
     pub unsafe fn acquire_next_image(
         &self,
@@ -74,9 +77,12 @@ impl crate::khr::swapchain::Device {
         }
     }
 
-    /// On success, returns whether the swapchain is suboptimal for the surface.
-    ///
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkQueuePresentKHR.html>
+    ///
+    /// # Returns
+    /// Returns [`false`] if the swapchain is optimal for the surface ([`vk::Result::SUCCESS`]),
+    /// [`true`] if the swapchain is _suboptimal_ for the surface ([`vk::Result::SUBOPTIMAL_KHR`]),
+    /// or [`Err`] on failure.
     #[inline]
     pub unsafe fn queue_present(
         &self,
@@ -135,8 +141,6 @@ impl crate::khr::swapchain::Device {
         .assume_init_on_success(modes)
     }
 
-    /// On success, returns the next image's index and whether the swapchain is suboptimal for the surface.
-    ///
     /// Only available since [Vulkan 1.1].
     ///
     /// Also available as [`khr::device_group::Device::acquire_next_image2()`]
@@ -146,6 +150,11 @@ impl crate::khr::swapchain::Device {
     ///
     /// [Vulkan 1.1]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_VERSION_1_1.html
     /// [`VK_KHR_swapchain`]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_swapchain.html
+    ///
+    /// # Returns
+    /// Returns the next image's index, and [`false`] if the swapchain is optimal for the surface
+    /// ([`vk::Result::SUCCESS`]), [`true`] if the swapchain is _suboptimal_ for the surface
+    /// ([`vk::Result::SUBOPTIMAL_KHR`]), or [`Err`] on failure.
     #[inline]
     pub unsafe fn acquire_next_image2(
         &self,


### PR DESCRIPTION
Fixes #928

In case one or more `VkResult` values returned by the underlying Vulkan function are mapped to a different return value inside `ash` for user convenience (i.e. whether a `swapchain` is suboptimal, or whether a `fence` or `event` was signaled), document explicitly what error codes from the upstream documentation result in what output values.

Note that "user convenience" here relates specifically to "success" scenarios that shouldn't be accidentally bubbled up via for example the `?` (`Try`) operator, but handled more clearly by providing a `bool` instead of forcing the user to match it out of `Err(vk::Result::*)`.

Documenting what `VkResult`s result in these `bool` return values should make it easier for the user to relate to the upstream documentation, as the naming of the Vulkan function never clearly reflects the expected output (i.e. `get_*status()` could have been named `is_*_signaled()` which is a more typical Rust convention), or whether `true` means "optimal" or "suboptimal" for the `Swapchain` interfaces.
