### PR TITLE
generator: Print `vk-parse` errors when they're encountered

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -3067,7 +3067,11 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let vk_xml = vk_headers_dir.join("registry/vk.xml");
     use std::fs::File;
     use std::io::Write;
-    let (spec2, _errors) = vk_parse::parse_file(&vk_xml).expect("Invalid xml file");
+    let (spec2, errors) = vk_parse::parse_file(&vk_xml).expect("Invalid xml file");
+    assert!(
+        errors.is_empty(),
+        "vk_parse encountered one or more errors while parsing: {errors:?}"
+    );
     let extensions: Vec<&vk_parse::Extension> = spec2
         .0
         .iter()


### PR DESCRIPTION
Some upstream `vk.xml` changes are causing failures on missing registry children later on in our generator code.  These are complicated to debug, unless we print the errors that `vk-parse` already reports.  In this debug case it was clarifying that some new and unknown elements upstream are the reason for high-level registry elements to not be parsable.
