### PR TITLE
Work around `unused_qualifications` lint for Rust 1.80 prelude extension

### DIFF
--- a/ash-examples/src/bin/texture.rs
+++ b/ash-examples/src/bin/texture.rs
@@ -5,6 +5,7 @@ use std::error::Error;
 use std::ffi;
 use std::io::Cursor;
 use std::mem;
+use std::mem::{size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
 use std::os::raw::c_void;
 
 use ash::util::*;
@@ -98,7 +99,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .collect();
         let index_buffer_data = [0u32, 1, 2, 2, 3, 0];
         let index_buffer_info = vk::BufferCreateInfo {
-            size: mem::size_of_val(&index_buffer_data) as u64,
+            size: size_of_val(&index_buffer_data) as u64,
             usage: vk::BufferUsageFlags::INDEX_BUFFER,
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
@@ -131,7 +132,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap();
         let mut index_slice = Align::new(
             index_ptr,
-            mem::align_of::<u32>() as u64,
+            align_of::<u32>() as u64,
             index_buffer_memory_req.size,
         );
         index_slice.copy_from_slice(&index_buffer_data);
@@ -159,7 +160,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             },
         ];
         let vertex_input_buffer_info = vk::BufferCreateInfo {
-            size: mem::size_of_val(&vertices) as u64,
+            size: size_of_val(&vertices) as u64,
             usage: vk::BufferUsageFlags::VERTEX_BUFFER,
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
@@ -199,7 +200,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap();
         let mut slice = Align::new(
             vert_ptr,
-            mem::align_of::<Vertex>() as u64,
+            align_of::<Vertex>() as u64,
             vertex_input_buffer_memory_req.size,
         );
         slice.copy_from_slice(&vertices);
@@ -215,7 +216,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             _pad: 0.0,
         };
         let uniform_color_buffer_info = vk::BufferCreateInfo {
-            size: mem::size_of_val(&uniform_color_buffer_data) as u64,
+            size: size_of_val(&uniform_color_buffer_data) as u64,
             usage: vk::BufferUsageFlags::UNIFORM_BUFFER,
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
@@ -254,7 +255,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap();
         let mut uniform_aligned_slice = Align::new(
             uniform_ptr,
-            mem::align_of::<Vector3>() as u64,
+            align_of::<Vector3>() as u64,
             uniform_color_buffer_memory_req.size,
         );
         uniform_aligned_slice.copy_from_slice(&[uniform_color_buffer_data]);
@@ -270,7 +271,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let image_extent = vk::Extent2D { width, height };
         let image_data = image.into_raw();
         let image_buffer_info = vk::BufferCreateInfo {
-            size: (mem::size_of::<u8>() * image_data.len()) as u64,
+            size: (size_of::<u8>() * image_data.len()) as u64,
             usage: vk::BufferUsageFlags::TRANSFER_SRC,
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
@@ -304,7 +305,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap();
         let mut image_slice = Align::new(
             image_ptr,
-            mem::align_of::<u8>() as u64,
+            align_of::<u8>() as u64,
             image_buffer_memory_req.size,
         );
         image_slice.copy_from_slice(&image_data);
@@ -510,7 +511,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let uniform_color_buffer_descriptor = vk::DescriptorBufferInfo {
             buffer: uniform_color_buffer,
             offset: 0,
-            range: mem::size_of_val(&uniform_color_buffer_data) as u64,
+            range: size_of_val(&uniform_color_buffer_data) as u64,
         };
 
         let tex_descriptor = vk::DescriptorImageInfo {
@@ -584,7 +585,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ];
         let vertex_input_binding_descriptions = [vk::VertexInputBindingDescription {
             binding: 0,
-            stride: mem::size_of::<Vertex>() as u32,
+            stride: size_of::<Vertex>() as u32,
             input_rate: vk::VertexInputRate::VERTEX,
         }];
         let vertex_input_attribute_descriptions = [

--- a/ash-examples/src/bin/triangle.rs
+++ b/ash-examples/src/bin/triangle.rs
@@ -5,6 +5,7 @@ use std::error::Error;
 use std::ffi;
 use std::io::Cursor;
 use std::mem;
+use std::mem::{size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
 
 use ash::util::*;
 use ash::vk;
@@ -89,7 +90,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let index_buffer_data = [0u32, 1, 2];
         let index_buffer_info = vk::BufferCreateInfo::default()
-            .size(mem::size_of_val(&index_buffer_data) as u64)
+            .size(size_of_val(&index_buffer_data) as u64)
             .usage(vk::BufferUsageFlags::INDEX_BUFFER)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
 
@@ -122,7 +123,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap();
         let mut index_slice = Align::new(
             index_ptr,
-            mem::align_of::<u32>() as u64,
+            align_of::<u32>() as u64,
             index_buffer_memory_req.size,
         );
         index_slice.copy_from_slice(&index_buffer_data);
@@ -132,7 +133,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap();
 
         let vertex_input_buffer_info = vk::BufferCreateInfo {
-            size: 3 * mem::size_of::<Vertex>() as u64,
+            size: 3 * size_of::<Vertex>() as u64,
             usage: vk::BufferUsageFlags::VERTEX_BUFFER,
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
@@ -192,7 +193,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let mut vert_align = Align::new(
             vert_ptr,
-            mem::align_of::<Vertex>() as u64,
+            align_of::<Vertex>() as u64,
             vertex_input_buffer_memory_req.size,
         );
         vert_align.copy_from_slice(&vertices);
@@ -247,7 +248,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ];
         let vertex_input_binding_descriptions = [vk::VertexInputBindingDescription {
             binding: 0,
-            stride: mem::size_of::<Vertex>() as u32,
+            stride: size_of::<Vertex>() as u32,
             input_rate: vk::VertexInputRate::VERTEX,
         }];
         let vertex_input_attribute_descriptions = [

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -5,6 +5,7 @@ use crate::RawPtr;
 use alloc::vec::Vec;
 use core::ffi;
 use core::mem;
+use core::mem::{size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
 use core::ptr;
 
 /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDevice.html>
@@ -2065,7 +2066,7 @@ impl Device {
         data: &mut [T],
         flags: vk::QueryResultFlags,
     ) -> VkResult<()> {
-        let data_size = mem::size_of_val(data);
+        let data_size = size_of_val(data);
         (self.device_fn_1_0.get_query_pool_results)(
             self.handle(),
             query_pool,
@@ -2073,7 +2074,7 @@ impl Device {
             data.len() as u32,
             data_size,
             data.as_mut_ptr().cast(),
-            mem::size_of::<T>() as _,
+            size_of::<T>() as _,
             flags,
         )
         .result()

--- a/ash/src/extensions/amd/shader_info.rs
+++ b/ash/src/extensions/amd/shader_info.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use crate::vk;
 use alloc::vec::Vec;
 use core::mem;
+use core::mem::size_of_val; // TODO: Remove when bumping MSRV to 1.80
 
 impl crate::amd::shader_info::Device {
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetShaderInfoAMD.html> with [`vk::ShaderInfoTypeAMD::STATISTICS`]
@@ -14,7 +15,7 @@ impl crate::amd::shader_info::Device {
         shader_stage: vk::ShaderStageFlags,
     ) -> VkResult<vk::ShaderStatisticsInfoAMD> {
         let mut info = mem::MaybeUninit::<vk::ShaderStatisticsInfoAMD>::uninit();
-        let mut size = mem::size_of_val(&info);
+        let mut size = size_of_val(&info);
         (self.fp.get_shader_info_amd)(
             self.handle,
             pipeline,
@@ -24,7 +25,7 @@ impl crate::amd::shader_info::Device {
             info.as_mut_ptr().cast(),
         )
         .result()?;
-        assert_eq!(size, mem::size_of_val(&info));
+        assert_eq!(size, size_of_val(&info));
         Ok(info.assume_init())
     }
 

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -5,6 +5,7 @@ use crate::vk;
 use crate::RawPtr;
 use alloc::vec::Vec;
 use core::mem;
+use core::mem::size_of_val; // TODO: Remove when bumping MSRV to 1.80
 
 impl crate::nv::ray_tracing::Device {
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateAccelerationStructureNV.html>
@@ -203,7 +204,7 @@ impl crate::nv::ray_tracing::Device {
         (self.fp.get_acceleration_structure_handle_nv)(
             self.handle,
             accel_struct,
-            mem::size_of_val(&handle),
+            size_of_val(&handle),
             handle.as_mut_ptr().cast(),
         )
         .assume_init_on_success(handle)

--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -2,7 +2,7 @@ use crate::vk;
 use core::ffi::c_void;
 use core::iter::Iterator;
 use core::marker::PhantomData;
-use core::mem::size_of;
+use core::mem::size_of; // TODO: Remove when bumping MSRV to 1.80
 use core::slice;
 #[cfg(feature = "std")]
 use std::io;


### PR DESCRIPTION
`size_of(_val)()` was added to the prelude in Rust 1.80, causing `unused_qualifications` warnings whenever we import `mem` in scope and call it with `mem::` prefix.

The easiest workaround is to remove the prefix and explicitly import the function(s) in scope, which was already done in a few places.  We annotate the import with a `TODO` to remove it once bumping our MSRV on or past 1.80.
