### PR TITLE
ash: Hide provisional extensions behind new `provisional` feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
         run: cargo test --workspace --all-targets
       - name: Test docs
         run: cargo test --workspace --doc
+      - name: Test all targets
+        run: cargo test --workspace --all-targets -F provisional
+      - name: Test docs
+        run: cargo test --workspace --doc -F provisional
 
   fmt:
     name: Rustfmt

--- a/ash-examples/Cargo.toml
+++ b/ash-examples/Cargo.toml
@@ -11,5 +11,6 @@ winit = { version = "0.29", features = ["rwh_06"] }
 # The examples require the validation layers, which means the SDK or
 # equivalent development packages should be present, so we can link
 # directly and benefit from the infallible `Entry` constructor.
-ash = { path = "../ash", default-features = false, features = ["linked", "debug", "std"] }
+# Provisional features are required to access VK_KHR_portability_subset for MoltenVK
+ash = { path = "../ash", default-features = false, features = ["linked", "debug", "std", "provisional"] }
 ash-window = { path = "../ash-window" }

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -37,6 +37,8 @@ loaded = ["libloading", "std"]
 debug = []
 # Whether the standard library should be required
 std = []
+# Enable provisional Vulkan extensions. May see *semver-breaking* code changes in non-breaking releases!
+provisional = []
 
 [package.metadata.release]
 no-dev-version = true

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "provisional")]
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_AMDX_shader_enqueue.html>
 
 use crate::vk;

--- a/ash/src/extensions/nv/cuda_kernel_launch.rs
+++ b/ash/src/extensions/nv/cuda_kernel_launch.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "provisional")]
 //! <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_NV_cuda_kernel_launch.html>
 
 use crate::read_into_uninitialized_vector;

--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -495,6 +495,7 @@ pub mod amd {
 #[doc = "Extensions tagged AMDX"]
 pub mod amdx {
     #[doc = "VK_AMDX_shader_enqueue"]
+    #[cfg(feature = "provisional")]
     pub mod shader_enqueue {
         use crate::vk::*;
         use core::ffi::*;
@@ -14792,6 +14793,7 @@ pub mod khr {
         }
     }
     #[doc = "VK_KHR_portability_subset"]
+    #[cfg(feature = "provisional")]
     pub mod portability_subset {
         pub use {
             crate::vk::KHR_PORTABILITY_SUBSET_NAME as NAME,
@@ -19181,6 +19183,7 @@ pub mod nv {
         };
     }
     #[doc = "VK_NV_cuda_kernel_launch"]
+    #[cfg(feature = "provisional")]
     pub mod cuda_kernel_launch {
         use crate::vk::*;
         use core::ffi::*;
@@ -19591,6 +19594,7 @@ pub mod nv {
         }
     }
     #[doc = "VK_NV_displacement_micromap"]
+    #[cfg(feature = "provisional")]
     pub mod displacement_micromap {
         pub use {
             crate::vk::NV_DISPLACEMENT_MICROMAP_NAME as NAME,

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -608,6 +608,7 @@ impl fmt::Debug for BufferUsageFlags {
                 BufferUsageFlags::CONDITIONAL_RENDERING_EXT.0,
                 "CONDITIONAL_RENDERING_EXT",
             ),
+            #[cfg(feature = "provisional")]
             (
                 BufferUsageFlags::EXECUTION_GRAPH_SCRATCH_AMDX.0,
                 "EXECUTION_GRAPH_SCRATCH_AMDX",
@@ -678,6 +679,7 @@ impl fmt::Debug for BufferUsageFlags2KHR {
             (BufferUsageFlags2KHR::INDEX_BUFFER.0, "INDEX_BUFFER"),
             (BufferUsageFlags2KHR::VERTEX_BUFFER.0, "VERTEX_BUFFER"),
             (BufferUsageFlags2KHR::INDIRECT_BUFFER.0, "INDIRECT_BUFFER"),
+            #[cfg(feature = "provisional")]
             (
                 BufferUsageFlags2KHR::EXECUTION_GRAPH_SCRATCH_AMDX.0,
                 "EXECUTION_GRAPH_SCRATCH_AMDX",
@@ -784,6 +786,7 @@ impl fmt::Debug for BuildAccelerationStructureFlagsKHR {
                 BuildAccelerationStructureFlagsKHR::ALLOW_OPACITY_MICROMAP_DATA_UPDATE_EXT.0,
                 "ALLOW_OPACITY_MICROMAP_DATA_UPDATE_EXT",
             ),
+            #[cfg(feature = "provisional")]
             (
                 BuildAccelerationStructureFlagsKHR::ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV.0,
                 "ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV",
@@ -1221,7 +1224,9 @@ impl fmt::Debug for DebugReportObjectTypeEXT {
             Self::CU_FUNCTION_NVX => Some("CU_FUNCTION_NVX"),
             Self::ACCELERATION_STRUCTURE_KHR => Some("ACCELERATION_STRUCTURE_KHR"),
             Self::ACCELERATION_STRUCTURE_NV => Some("ACCELERATION_STRUCTURE_NV"),
+            #[cfg(feature = "provisional")]
             Self::CUDA_MODULE_NV => Some("CUDA_MODULE_NV"),
+            #[cfg(feature = "provisional")]
             Self::CUDA_FUNCTION_NV => Some("CUDA_FUNCTION_NV"),
             Self::BUFFER_COLLECTION_FUCHSIA => Some("BUFFER_COLLECTION_FUCHSIA"),
             _ => None,
@@ -1626,6 +1631,7 @@ impl fmt::Debug for DiscardRectangleModeEXT {
         }
     }
 }
+#[cfg(feature = "provisional")]
 impl fmt::Debug for DisplacementMicromapFormatNV {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
@@ -3309,6 +3315,7 @@ impl fmt::Debug for MicromapTypeEXT {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             Self::OPACITY_MICROMAP => Some("OPACITY_MICROMAP"),
+            #[cfg(feature = "provisional")]
             Self::DISPLACEMENT_MICROMAP_NV => Some("DISPLACEMENT_MICROMAP_NV"),
             _ => None,
         };
@@ -3651,6 +3658,7 @@ impl fmt::Debug for PipelineBindPoint {
         let name = match *self {
             Self::GRAPHICS => Some("GRAPHICS"),
             Self::COMPUTE => Some("COMPUTE"),
+            #[cfg(feature = "provisional")]
             Self::EXECUTION_GRAPH_AMDX => Some("EXECUTION_GRAPH_AMDX"),
             Self::RAY_TRACING_KHR => Some("RAY_TRACING_KHR"),
             Self::SUBPASS_SHADING_HUAWEI => Some("SUBPASS_SHADING_HUAWEI"),
@@ -3808,6 +3816,7 @@ impl fmt::Debug for PipelineCreateFlags {
                 PipelineCreateFlags::RAY_TRACING_OPACITY_MICROMAP_EXT.0,
                 "RAY_TRACING_OPACITY_MICROMAP_EXT",
             ),
+            #[cfg(feature = "provisional")]
             (
                 PipelineCreateFlags::RAY_TRACING_DISPLACEMENT_MICROMAP_NV.0,
                 "RAY_TRACING_DISPLACEMENT_MICROMAP_NV",
@@ -5520,18 +5529,23 @@ impl fmt::Debug for StructureType {
             Self::ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID => {
                 Some("ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX => {
                 Some("PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX => {
                 Some("PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX")
             }
+            #[cfg(feature = "provisional")]
             Self::EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX => {
                 Some("EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX")
             }
+            #[cfg(feature = "provisional")]
             Self::EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX => {
                 Some("EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX")
             }
+            #[cfg(feature = "provisional")]
             Self::PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX => {
                 Some("PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX")
             }
@@ -5652,9 +5666,11 @@ impl fmt::Debug for StructureType {
             Self::SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT => {
                 Some("SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR => {
                 Some("PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR => {
                 Some("PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR")
             }
@@ -6081,12 +6097,17 @@ impl fmt::Debug for StructureType {
             Self::DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV => {
                 Some("DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV")
             }
+            #[cfg(feature = "provisional")]
             Self::CUDA_MODULE_CREATE_INFO_NV => Some("CUDA_MODULE_CREATE_INFO_NV"),
+            #[cfg(feature = "provisional")]
             Self::CUDA_FUNCTION_CREATE_INFO_NV => Some("CUDA_FUNCTION_CREATE_INFO_NV"),
+            #[cfg(feature = "provisional")]
             Self::CUDA_LAUNCH_INFO_NV => Some("CUDA_LAUNCH_INFO_NV"),
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV => {
                 Some("PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV => {
                 Some("PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV")
             }
@@ -6368,12 +6389,15 @@ impl fmt::Debug for StructureType {
             Self::ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT => {
                 Some("ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV => {
                 Some("PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV")
             }
+            #[cfg(feature = "provisional")]
             Self::PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV => {
                 Some("PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV")
             }
+            #[cfg(feature = "provisional")]
             Self::ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV => {
                 Some("ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV")
             }

--- a/ash/src/vk/constants.rs
+++ b/ash/src/vk/constants.rs
@@ -34,4 +34,5 @@ pub const MAX_GLOBAL_PRIORITY_SIZE_EXT: usize = MAX_GLOBAL_PRIORITY_SIZE_KHR;
 pub const MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT: usize = 32;
 pub const MAX_PIPELINE_BINARY_KEY_SIZE_KHR: usize = 32;
 pub const MAX_VIDEO_AV1_REFERENCES_PER_FRAME_KHR: usize = 7;
+#[cfg(feature = "provisional")]
 pub const SHADER_INDEX_UNUSED_AMDX: u32 = !0;

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -28304,6 +28304,7 @@ unsafe impl Extends<RayTracingPipelineCreateInfoKHR<'_>>
     for PipelineCreationFeedbackCreateInfo<'_>
 {
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<ExecutionGraphPipelineCreateInfoAMDX<'_>>
     for PipelineCreationFeedbackCreateInfo<'_>
 {
@@ -33023,6 +33024,7 @@ unsafe impl<'a> TaggedStructure<'a> for PipelineCompilerControlCreateInfoAMD<'a>
 }
 unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineCompilerControlCreateInfoAMD<'_> {}
 unsafe impl Extends<ComputePipelineCreateInfo<'_>> for PipelineCompilerControlCreateInfoAMD<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Extends<ExecutionGraphPipelineCreateInfoAMDX<'_>>
     for PipelineCompilerControlCreateInfoAMD<'_>
 {
@@ -33431,6 +33433,7 @@ impl ::core::default::Default for DeviceOrHostAddressConstKHR {
         unsafe { ::core::mem::zeroed() }
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[derive(Copy, Clone)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceOrHostAddressConstAMDX.html>"]
@@ -33438,6 +33441,7 @@ pub union DeviceOrHostAddressConstAMDX {
     pub device_address: DeviceAddress,
     pub host_address: *const c_void,
 }
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for DeviceOrHostAddressConstAMDX {
     #[inline]
     fn default() -> Self {
@@ -35425,6 +35429,7 @@ impl<'a> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -35450,8 +35455,11 @@ pub struct PhysicalDevicePortabilitySubsetFeaturesKHR<'a> {
     pub vertex_attribute_access_beyond_stride: Bool32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDevicePortabilitySubsetFeaturesKHR<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDevicePortabilitySubsetFeaturesKHR<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDevicePortabilitySubsetFeaturesKHR<'_> {
     #[inline]
     fn default() -> Self {
@@ -35477,15 +35485,19 @@ impl ::core::default::Default for PhysicalDevicePortabilitySubsetFeaturesKHR<'_>
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDevicePortabilitySubsetFeaturesKHR<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
     for PhysicalDevicePortabilitySubsetFeaturesKHR<'_>
 {
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePortabilitySubsetFeaturesKHR<'_> {}
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDevicePortabilitySubsetFeaturesKHR<'a> {
     #[inline]
     pub fn constant_alpha_color_blend_factors(
@@ -35576,6 +35588,7 @@ impl<'a> PhysicalDevicePortabilitySubsetFeaturesKHR<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -35587,8 +35600,11 @@ pub struct PhysicalDevicePortabilitySubsetPropertiesKHR<'a> {
     pub min_vertex_input_binding_stride_alignment: u32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDevicePortabilitySubsetPropertiesKHR<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDevicePortabilitySubsetPropertiesKHR<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDevicePortabilitySubsetPropertiesKHR<'_> {
     #[inline]
     fn default() -> Self {
@@ -35600,14 +35616,17 @@ impl ::core::default::Default for PhysicalDevicePortabilitySubsetPropertiesKHR<'
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDevicePortabilitySubsetPropertiesKHR<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceProperties2<'_>>
     for PhysicalDevicePortabilitySubsetPropertiesKHR<'_>
 {
 }
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDevicePortabilitySubsetPropertiesKHR<'a> {
     #[inline]
     pub fn min_vertex_input_binding_stride_alignment(
@@ -46970,7 +46989,7 @@ pub struct AccelerationStructureSRTMotionInstanceNV {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/AccelerationStructureMatrixMotionInstanceNV.html>"]
+#[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureMatrixMotionInstanceNV.html>"]
 pub struct AccelerationStructureMatrixMotionInstanceNV {
     pub transform_t0: TransformMatrixKHR,
     pub transform_t1: TransformMatrixKHR,
@@ -47632,14 +47651,17 @@ impl<'a> BufferCollectionConstraintsInfoFUCHSIA<'a> {
 handle_nondispatchable!(
     CudaModuleNV,
     CUDA_MODULE_NV,
-    doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCudaModuleNV.html>"
+    doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCudaModuleNV.html>",
+    cfg(feature = "provisional")
 );
 handle_nondispatchable!(
     CudaFunctionNV,
     CUDA_FUNCTION_NV,
     doc =
-        "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCudaFunctionNV.html>"
+        "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCudaFunctionNV.html>",
+    cfg(feature = "provisional")
 );
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -47652,8 +47674,11 @@ pub struct CudaModuleCreateInfoNV<'a> {
     pub p_data: *const c_void,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for CudaModuleCreateInfoNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for CudaModuleCreateInfoNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for CudaModuleCreateInfoNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -47666,9 +47691,11 @@ impl ::core::default::Default for CudaModuleCreateInfoNV<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for CudaModuleCreateInfoNV<'a> {
     const STRUCTURE_TYPE: StructureType = StructureType::CUDA_MODULE_CREATE_INFO_NV;
 }
+#[cfg(feature = "provisional")]
 impl<'a> CudaModuleCreateInfoNV<'a> {
     #[inline]
     pub fn data(mut self, data: &'a [u8]) -> Self {
@@ -47677,6 +47704,7 @@ impl<'a> CudaModuleCreateInfoNV<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -47689,8 +47717,11 @@ pub struct CudaFunctionCreateInfoNV<'a> {
     pub p_name: *const c_char,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for CudaFunctionCreateInfoNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for CudaFunctionCreateInfoNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for CudaFunctionCreateInfoNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -47703,9 +47734,11 @@ impl ::core::default::Default for CudaFunctionCreateInfoNV<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for CudaFunctionCreateInfoNV<'a> {
     const STRUCTURE_TYPE: StructureType = StructureType::CUDA_FUNCTION_CREATE_INFO_NV;
 }
+#[cfg(feature = "provisional")]
 impl<'a> CudaFunctionCreateInfoNV<'a> {
     #[inline]
     pub fn module(mut self, module: CudaModuleNV) -> Self {
@@ -47726,6 +47759,7 @@ impl<'a> CudaFunctionCreateInfoNV<'a> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -47748,8 +47782,11 @@ pub struct CudaLaunchInfoNV<'a> {
     pub p_extras: *const *const c_void,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for CudaLaunchInfoNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for CudaLaunchInfoNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for CudaLaunchInfoNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -47772,9 +47809,11 @@ impl ::core::default::Default for CudaLaunchInfoNV<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for CudaLaunchInfoNV<'a> {
     const STRUCTURE_TYPE: StructureType = StructureType::CUDA_LAUNCH_INFO_NV;
 }
+#[cfg(feature = "provisional")]
 impl<'a> CudaLaunchInfoNV<'a> {
     #[inline]
     pub fn function(mut self, function: CudaFunctionNV) -> Self {
@@ -50673,6 +50712,7 @@ impl<'a> AccelerationStructureTrianglesOpacityMicromapEXT<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -50684,8 +50724,11 @@ pub struct PhysicalDeviceDisplacementMicromapFeaturesNV<'a> {
     pub displacement_micromap: Bool32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDeviceDisplacementMicromapFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDeviceDisplacementMicromapFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDeviceDisplacementMicromapFeaturesNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -50697,15 +50740,19 @@ impl ::core::default::Default for PhysicalDeviceDisplacementMicromapFeaturesNV<'
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDeviceDisplacementMicromapFeaturesNV<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
     for PhysicalDeviceDisplacementMicromapFeaturesNV<'_>
 {
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDisplacementMicromapFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDeviceDisplacementMicromapFeaturesNV<'a> {
     #[inline]
     pub fn displacement_micromap(mut self, displacement_micromap: bool) -> Self {
@@ -50713,6 +50760,7 @@ impl<'a> PhysicalDeviceDisplacementMicromapFeaturesNV<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -50724,8 +50772,11 @@ pub struct PhysicalDeviceDisplacementMicromapPropertiesNV<'a> {
     pub max_displacement_micromap_subdivision_level: u32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDeviceDisplacementMicromapPropertiesNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDeviceDisplacementMicromapPropertiesNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDeviceDisplacementMicromapPropertiesNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -50737,14 +50788,17 @@ impl ::core::default::Default for PhysicalDeviceDisplacementMicromapPropertiesNV
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDeviceDisplacementMicromapPropertiesNV<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceProperties2<'_>>
     for PhysicalDeviceDisplacementMicromapPropertiesNV<'_>
 {
 }
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDeviceDisplacementMicromapPropertiesNV<'a> {
     #[inline]
     pub fn max_displacement_micromap_subdivision_level(
@@ -50756,6 +50810,7 @@ impl<'a> PhysicalDeviceDisplacementMicromapPropertiesNV<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[derive(Copy, Clone)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureTrianglesDisplacementMicromapNV.html>"]
@@ -50781,8 +50836,11 @@ pub struct AccelerationStructureTrianglesDisplacementMicromapNV<'a> {
     pub micromap: MicromapEXT,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {}
+#[cfg(feature = "provisional")]
 #[cfg(feature = "debug")]
 impl fmt::Debug for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -50823,6 +50881,7 @@ impl fmt::Debug for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {
             .finish()
     }
 }
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -50849,14 +50908,17 @@ impl ::core::default::Default for AccelerationStructureTrianglesDisplacementMicr
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for AccelerationStructureTrianglesDisplacementMicromapNV<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<AccelerationStructureGeometryTrianglesDataKHR<'_>>
     for AccelerationStructureTrianglesDisplacementMicromapNV<'_>
 {
 }
+#[cfg(feature = "provisional")]
 impl<'a> AccelerationStructureTrianglesDisplacementMicromapNV<'a> {
     #[inline]
     pub fn displacement_bias_and_scale_format(
@@ -55394,6 +55456,7 @@ impl<'a> PhysicalDeviceCooperativeMatrixPropertiesKHR<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -55409,8 +55472,11 @@ pub struct PhysicalDeviceShaderEnqueuePropertiesAMDX<'a> {
     pub execution_graph_dispatch_address_alignment: u32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_> {
     #[inline]
     fn default() -> Self {
@@ -55426,14 +55492,17 @@ impl ::core::default::Default for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_> 
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDeviceShaderEnqueuePropertiesAMDX<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceProperties2<'_>>
     for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_>
 {
 }
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDeviceShaderEnqueuePropertiesAMDX<'a> {
     #[inline]
     pub fn max_execution_graph_depth(mut self, max_execution_graph_depth: u32) -> Self {
@@ -55474,6 +55543,7 @@ impl<'a> PhysicalDeviceShaderEnqueuePropertiesAMDX<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -55485,8 +55555,11 @@ pub struct PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {
     pub shader_enqueue: Bool32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {
     #[inline]
     fn default() -> Self {
@@ -55498,12 +55571,16 @@ impl ::core::default::Default for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {}
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {
     #[inline]
     pub fn shader_enqueue(mut self, shader_enqueue: bool) -> Self {
@@ -55511,6 +55588,7 @@ impl<'a> PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -55528,8 +55606,11 @@ pub struct ExecutionGraphPipelineCreateInfoAMDX<'a> {
     pub base_pipeline_index: i32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for ExecutionGraphPipelineCreateInfoAMDX<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for ExecutionGraphPipelineCreateInfoAMDX<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for ExecutionGraphPipelineCreateInfoAMDX<'_> {
     #[inline]
     fn default() -> Self {
@@ -55547,9 +55628,11 @@ impl ::core::default::Default for ExecutionGraphPipelineCreateInfoAMDX<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for ExecutionGraphPipelineCreateInfoAMDX<'a> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX;
 }
+#[cfg(feature = "provisional")]
 impl<'a> ExecutionGraphPipelineCreateInfoAMDX<'a> {
     #[inline]
     pub fn flags(mut self, flags: PipelineCreateFlags) -> Self {
@@ -55583,6 +55666,7 @@ impl<'a> ExecutionGraphPipelineCreateInfoAMDX<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -55595,8 +55679,11 @@ pub struct PipelineShaderStageNodeCreateInfoAMDX<'a> {
     pub index: u32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PipelineShaderStageNodeCreateInfoAMDX<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PipelineShaderStageNodeCreateInfoAMDX<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PipelineShaderStageNodeCreateInfoAMDX<'_> {
     #[inline]
     fn default() -> Self {
@@ -55609,14 +55696,17 @@ impl ::core::default::Default for PipelineShaderStageNodeCreateInfoAMDX<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PipelineShaderStageNodeCreateInfoAMDX<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PipelineShaderStageCreateInfo<'_>>
     for PipelineShaderStageNodeCreateInfoAMDX<'_>
 {
 }
+#[cfg(feature = "provisional")]
 impl<'a> PipelineShaderStageNodeCreateInfoAMDX<'a> {
     #[inline]
     pub fn name(mut self, name: &'a CStr) -> Self {
@@ -55637,6 +55727,7 @@ impl<'a> PipelineShaderStageNodeCreateInfoAMDX<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -55648,8 +55739,11 @@ pub struct ExecutionGraphPipelineScratchSizeAMDX<'a> {
     pub size: DeviceSize,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for ExecutionGraphPipelineScratchSizeAMDX<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for ExecutionGraphPipelineScratchSizeAMDX<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for ExecutionGraphPipelineScratchSizeAMDX<'_> {
     #[inline]
     fn default() -> Self {
@@ -55661,9 +55755,11 @@ impl ::core::default::Default for ExecutionGraphPipelineScratchSizeAMDX<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for ExecutionGraphPipelineScratchSizeAMDX<'a> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX;
 }
+#[cfg(feature = "provisional")]
 impl<'a> ExecutionGraphPipelineScratchSizeAMDX<'a> {
     #[inline]
     pub fn size(mut self, size: DeviceSize) -> Self {
@@ -55671,6 +55767,7 @@ impl<'a> ExecutionGraphPipelineScratchSizeAMDX<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDispatchGraphInfoAMDX.html>"]
@@ -55681,6 +55778,7 @@ pub struct DispatchGraphInfoAMDX {
     pub payloads: DeviceOrHostAddressConstAMDX,
     pub payload_stride: u64,
 }
+#[cfg(feature = "provisional")]
 #[cfg(feature = "debug")]
 impl fmt::Debug for DispatchGraphInfoAMDX {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -55692,6 +55790,7 @@ impl fmt::Debug for DispatchGraphInfoAMDX {
             .finish()
     }
 }
+#[cfg(feature = "provisional")]
 impl DispatchGraphInfoAMDX {
     #[inline]
     pub fn node_index(mut self, node_index: u32) -> Self {
@@ -55714,6 +55813,7 @@ impl DispatchGraphInfoAMDX {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDispatchGraphCountInfoAMDX.html>"]
@@ -55723,6 +55823,7 @@ pub struct DispatchGraphCountInfoAMDX {
     pub infos: DeviceOrHostAddressConstAMDX,
     pub stride: u64,
 }
+#[cfg(feature = "provisional")]
 #[cfg(feature = "debug")]
 impl fmt::Debug for DispatchGraphCountInfoAMDX {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -55733,6 +55834,7 @@ impl fmt::Debug for DispatchGraphCountInfoAMDX {
             .finish()
     }
 }
+#[cfg(feature = "provisional")]
 impl DispatchGraphCountInfoAMDX {
     #[inline]
     pub fn count(mut self, count: u32) -> Self {
@@ -57331,6 +57433,7 @@ impl<'a> LatencySurfaceCapabilitiesNV<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -57342,8 +57445,11 @@ pub struct PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {
     pub cuda_kernel_launch_features: Bool32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -57355,12 +57461,16 @@ impl ::core::default::Default for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {}
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {
     #[inline]
     pub fn cuda_kernel_launch_features(mut self, cuda_kernel_launch_features: bool) -> Self {
@@ -57368,6 +57478,7 @@ impl<'a> PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {
         self
     }
 }
+#[cfg(feature = "provisional")]
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -57380,8 +57491,11 @@ pub struct PhysicalDeviceCudaKernelLaunchPropertiesNV<'a> {
     pub compute_capability_major: u32,
     pub _marker: PhantomData<&'a ()>,
 }
+#[cfg(feature = "provisional")]
 unsafe impl Send for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_> {}
+#[cfg(feature = "provisional")]
 unsafe impl Sync for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_> {}
+#[cfg(feature = "provisional")]
 impl ::core::default::Default for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_> {
     #[inline]
     fn default() -> Self {
@@ -57394,14 +57508,17 @@ impl ::core::default::Default for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_>
         }
     }
 }
+#[cfg(feature = "provisional")]
 unsafe impl<'a> TaggedStructure<'a> for PhysicalDeviceCudaKernelLaunchPropertiesNV<'a> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV;
 }
+#[cfg(feature = "provisional")]
 unsafe impl Extends<PhysicalDeviceProperties2<'_>>
     for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_>
 {
 }
+#[cfg(feature = "provisional")]
 impl<'a> PhysicalDeviceCudaKernelLaunchPropertiesNV<'a> {
     #[inline]
     pub fn compute_capability_minor(mut self, compute_capability_minor: u32) -> Self {

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -1,6 +1,6 @@
 use core::fmt;
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageLayout.html>"]
 pub struct ImageLayout(pub(crate) i32);
 impl ImageLayout {
@@ -12,8 +12,6 @@ impl ImageLayout {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ImageLayout {
     #[doc = "Implicit layout an image is when its contents are undefined due to various reasons (e.g. right after creation)"]
     pub const UNDEFINED: Self = Self(0);
     #[doc = "General layout when image can be used for any kind of access"]
@@ -33,8 +31,8 @@ impl ImageLayout {
     #[doc = "Initial layout used when the data is populated by the CPU"]
     pub const PREINITIALIZED: Self = Self(8);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAttachmentLoadOp.html>"]
 pub struct AttachmentLoadOp(pub(crate) i32);
 impl AttachmentLoadOp {
@@ -46,14 +44,12 @@ impl AttachmentLoadOp {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AttachmentLoadOp {
     pub const LOAD: Self = Self(0);
     pub const CLEAR: Self = Self(1);
     pub const DONT_CARE: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAttachmentStoreOp.html>"]
 pub struct AttachmentStoreOp(pub(crate) i32);
 impl AttachmentStoreOp {
@@ -65,13 +61,11 @@ impl AttachmentStoreOp {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AttachmentStoreOp {
     pub const STORE: Self = Self(0);
     pub const DONT_CARE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageType.html>"]
 pub struct ImageType(pub(crate) i32);
 impl ImageType {
@@ -83,14 +77,12 @@ impl ImageType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ImageType {
     pub const TYPE_1D: Self = Self(0);
     pub const TYPE_2D: Self = Self(1);
     pub const TYPE_3D: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageTiling.html>"]
 pub struct ImageTiling(pub(crate) i32);
 impl ImageTiling {
@@ -102,13 +94,11 @@ impl ImageTiling {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ImageTiling {
     pub const OPTIMAL: Self = Self(0);
     pub const LINEAR: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageViewType.html>"]
 pub struct ImageViewType(pub(crate) i32);
 impl ImageViewType {
@@ -120,8 +110,6 @@ impl ImageViewType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ImageViewType {
     pub const TYPE_1D: Self = Self(0);
     pub const TYPE_2D: Self = Self(1);
     pub const TYPE_3D: Self = Self(2);
@@ -130,8 +118,8 @@ impl ImageViewType {
     pub const TYPE_2D_ARRAY: Self = Self(5);
     pub const CUBE_ARRAY: Self = Self(6);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCommandBufferLevel.html>"]
 pub struct CommandBufferLevel(pub(crate) i32);
 impl CommandBufferLevel {
@@ -143,13 +131,11 @@ impl CommandBufferLevel {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CommandBufferLevel {
     pub const PRIMARY: Self = Self(0);
     pub const SECONDARY: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkComponentSwizzle.html>"]
 pub struct ComponentSwizzle(pub(crate) i32);
 impl ComponentSwizzle {
@@ -161,8 +147,6 @@ impl ComponentSwizzle {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ComponentSwizzle {
     pub const IDENTITY: Self = Self(0);
     pub const ZERO: Self = Self(1);
     pub const ONE: Self = Self(2);
@@ -171,8 +155,8 @@ impl ComponentSwizzle {
     pub const B: Self = Self(5);
     pub const A: Self = Self(6);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDescriptorType.html>"]
 pub struct DescriptorType(pub(crate) i32);
 impl DescriptorType {
@@ -184,8 +168,6 @@ impl DescriptorType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DescriptorType {
     pub const SAMPLER: Self = Self(0);
     pub const COMBINED_IMAGE_SAMPLER: Self = Self(1);
     pub const SAMPLED_IMAGE: Self = Self(2);
@@ -198,8 +180,8 @@ impl DescriptorType {
     pub const STORAGE_BUFFER_DYNAMIC: Self = Self(9);
     pub const INPUT_ATTACHMENT: Self = Self(10);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkQueryType.html>"]
 pub struct QueryType(pub(crate) i32);
 impl QueryType {
@@ -211,15 +193,13 @@ impl QueryType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl QueryType {
     pub const OCCLUSION: Self = Self(0);
     #[doc = "Optional"]
     pub const PIPELINE_STATISTICS: Self = Self(1);
     pub const TIMESTAMP: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBorderColor.html>"]
 pub struct BorderColor(pub(crate) i32);
 impl BorderColor {
@@ -231,8 +211,6 @@ impl BorderColor {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BorderColor {
     pub const FLOAT_TRANSPARENT_BLACK: Self = Self(0);
     pub const INT_TRANSPARENT_BLACK: Self = Self(1);
     pub const FLOAT_OPAQUE_BLACK: Self = Self(2);
@@ -240,8 +218,8 @@ impl BorderColor {
     pub const FLOAT_OPAQUE_WHITE: Self = Self(4);
     pub const INT_OPAQUE_WHITE: Self = Self(5);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineBindPoint.html>"]
 pub struct PipelineBindPoint(pub(crate) i32);
 impl PipelineBindPoint {
@@ -253,13 +231,11 @@ impl PipelineBindPoint {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PipelineBindPoint {
     pub const GRAPHICS: Self = Self(0);
     pub const COMPUTE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineCacheHeaderVersion.html>"]
 pub struct PipelineCacheHeaderVersion(pub(crate) i32);
 impl PipelineCacheHeaderVersion {
@@ -271,12 +247,10 @@ impl PipelineCacheHeaderVersion {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PipelineCacheHeaderVersion {
     pub const ONE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPrimitiveTopology.html>"]
 pub struct PrimitiveTopology(pub(crate) i32);
 impl PrimitiveTopology {
@@ -288,8 +262,6 @@ impl PrimitiveTopology {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PrimitiveTopology {
     pub const POINT_LIST: Self = Self(0);
     pub const LINE_LIST: Self = Self(1);
     pub const LINE_STRIP: Self = Self(2);
@@ -302,8 +274,8 @@ impl PrimitiveTopology {
     pub const TRIANGLE_STRIP_WITH_ADJACENCY: Self = Self(9);
     pub const PATCH_LIST: Self = Self(10);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSharingMode.html>"]
 pub struct SharingMode(pub(crate) i32);
 impl SharingMode {
@@ -315,13 +287,11 @@ impl SharingMode {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SharingMode {
     pub const EXCLUSIVE: Self = Self(0);
     pub const CONCURRENT: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkIndexType.html>"]
 pub struct IndexType(pub(crate) i32);
 impl IndexType {
@@ -333,13 +303,11 @@ impl IndexType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl IndexType {
     pub const UINT16: Self = Self(0);
     pub const UINT32: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFilter.html>"]
 pub struct Filter(pub(crate) i32);
 impl Filter {
@@ -351,13 +319,11 @@ impl Filter {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl Filter {
     pub const NEAREST: Self = Self(0);
     pub const LINEAR: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSamplerMipmapMode.html>"]
 pub struct SamplerMipmapMode(pub(crate) i32);
 impl SamplerMipmapMode {
@@ -369,15 +335,13 @@ impl SamplerMipmapMode {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SamplerMipmapMode {
     #[doc = "Choose nearest mip level"]
     pub const NEAREST: Self = Self(0);
     #[doc = "Linear filter between mip levels"]
     pub const LINEAR: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSamplerAddressMode.html>"]
 pub struct SamplerAddressMode(pub(crate) i32);
 impl SamplerAddressMode {
@@ -389,15 +353,13 @@ impl SamplerAddressMode {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SamplerAddressMode {
     pub const REPEAT: Self = Self(0);
     pub const MIRRORED_REPEAT: Self = Self(1);
     pub const CLAMP_TO_EDGE: Self = Self(2);
     pub const CLAMP_TO_BORDER: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCompareOp.html>"]
 pub struct CompareOp(pub(crate) i32);
 impl CompareOp {
@@ -409,8 +371,6 @@ impl CompareOp {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CompareOp {
     pub const NEVER: Self = Self(0);
     pub const LESS: Self = Self(1);
     pub const EQUAL: Self = Self(2);
@@ -420,8 +380,8 @@ impl CompareOp {
     pub const GREATER_OR_EQUAL: Self = Self(6);
     pub const ALWAYS: Self = Self(7);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPolygonMode.html>"]
 pub struct PolygonMode(pub(crate) i32);
 impl PolygonMode {
@@ -433,14 +393,12 @@ impl PolygonMode {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PolygonMode {
     pub const FILL: Self = Self(0);
     pub const LINE: Self = Self(1);
     pub const POINT: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFrontFace.html>"]
 pub struct FrontFace(pub(crate) i32);
 impl FrontFace {
@@ -452,13 +410,11 @@ impl FrontFace {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl FrontFace {
     pub const COUNTER_CLOCKWISE: Self = Self(0);
     pub const CLOCKWISE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBlendFactor.html>"]
 pub struct BlendFactor(pub(crate) i32);
 impl BlendFactor {
@@ -470,8 +426,6 @@ impl BlendFactor {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BlendFactor {
     pub const ZERO: Self = Self(0);
     pub const ONE: Self = Self(1);
     pub const SRC_COLOR: Self = Self(2);
@@ -492,8 +446,8 @@ impl BlendFactor {
     pub const SRC1_ALPHA: Self = Self(17);
     pub const ONE_MINUS_SRC1_ALPHA: Self = Self(18);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBlendOp.html>"]
 pub struct BlendOp(pub(crate) i32);
 impl BlendOp {
@@ -505,16 +459,14 @@ impl BlendOp {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BlendOp {
     pub const ADD: Self = Self(0);
     pub const SUBTRACT: Self = Self(1);
     pub const REVERSE_SUBTRACT: Self = Self(2);
     pub const MIN: Self = Self(3);
     pub const MAX: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkStencilOp.html>"]
 pub struct StencilOp(pub(crate) i32);
 impl StencilOp {
@@ -526,8 +478,6 @@ impl StencilOp {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl StencilOp {
     pub const KEEP: Self = Self(0);
     pub const ZERO: Self = Self(1);
     pub const REPLACE: Self = Self(2);
@@ -537,8 +487,8 @@ impl StencilOp {
     pub const INCREMENT_AND_WRAP: Self = Self(6);
     pub const DECREMENT_AND_WRAP: Self = Self(7);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkLogicOp.html>"]
 pub struct LogicOp(pub(crate) i32);
 impl LogicOp {
@@ -550,8 +500,6 @@ impl LogicOp {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl LogicOp {
     pub const CLEAR: Self = Self(0);
     pub const AND: Self = Self(1);
     pub const AND_REVERSE: Self = Self(2);
@@ -569,8 +517,8 @@ impl LogicOp {
     pub const NAND: Self = Self(14);
     pub const SET: Self = Self(15);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkInternalAllocationType.html>"]
 pub struct InternalAllocationType(pub(crate) i32);
 impl InternalAllocationType {
@@ -582,12 +530,10 @@ impl InternalAllocationType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl InternalAllocationType {
     pub const EXECUTABLE: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSystemAllocationScope.html>"]
 pub struct SystemAllocationScope(pub(crate) i32);
 impl SystemAllocationScope {
@@ -599,16 +545,14 @@ impl SystemAllocationScope {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SystemAllocationScope {
     pub const COMMAND: Self = Self(0);
     pub const OBJECT: Self = Self(1);
     pub const CACHE: Self = Self(2);
     pub const DEVICE: Self = Self(3);
     pub const INSTANCE: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceType.html>"]
 pub struct PhysicalDeviceType(pub(crate) i32);
 impl PhysicalDeviceType {
@@ -620,16 +564,14 @@ impl PhysicalDeviceType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PhysicalDeviceType {
     pub const OTHER: Self = Self(0);
     pub const INTEGRATED_GPU: Self = Self(1);
     pub const DISCRETE_GPU: Self = Self(2);
     pub const VIRTUAL_GPU: Self = Self(3);
     pub const CPU: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkVertexInputRate.html>"]
 pub struct VertexInputRate(pub(crate) i32);
 impl VertexInputRate {
@@ -641,13 +583,11 @@ impl VertexInputRate {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl VertexInputRate {
     pub const VERTEX: Self = Self(0);
     pub const INSTANCE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFormat.html>"]
 pub struct Format(pub(crate) i32);
 impl Format {
@@ -659,8 +599,6 @@ impl Format {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl Format {
     pub const UNDEFINED: Self = Self(0);
     pub const R4G4_UNORM_PACK8: Self = Self(1);
     pub const R4G4B4A4_UNORM_PACK16: Self = Self(2);
@@ -847,8 +785,8 @@ impl Format {
     pub const ASTC_12X12_UNORM_BLOCK: Self = Self(183);
     pub const ASTC_12X12_SRGB_BLOCK: Self = Self(184);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkStructureType.html>"]
 pub struct StructureType(pub(crate) i32);
 impl StructureType {
@@ -860,8 +798,6 @@ impl StructureType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl StructureType {
     pub const APPLICATION_INFO: Self = Self(0);
     pub const INSTANCE_CREATE_INFO: Self = Self(1);
     pub const DEVICE_QUEUE_CREATE_INFO: Self = Self(2);
@@ -914,8 +850,8 @@ impl StructureType {
     #[doc = "Reserved for internal use by the loader, layers, and ICDs"]
     pub const LOADER_DEVICE_CREATE_INFO: Self = Self(48);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSubpassContents.html>"]
 pub struct SubpassContents(pub(crate) i32);
 impl SubpassContents {
@@ -927,15 +863,13 @@ impl SubpassContents {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SubpassContents {
     pub const INLINE: Self = Self(0);
     pub const SECONDARY_COMMAND_BUFFERS: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkResult.html>"]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[must_use]
+#[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkResult.html>"]
 pub struct Result(pub(crate) i32);
 impl Result {
     #[inline]
@@ -946,8 +880,6 @@ impl Result {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl Result {
     #[doc = "Command completed successfully"]
     pub const SUCCESS: Self = Self(0);
     #[doc = "A fence or query has not yet completed"]
@@ -999,8 +931,8 @@ impl fmt::Display for Result {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDynamicState.html>"]
 pub struct DynamicState(pub(crate) i32);
 impl DynamicState {
@@ -1012,8 +944,6 @@ impl DynamicState {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DynamicState {
     pub const VIEWPORT: Self = Self(0);
     pub const SCISSOR: Self = Self(1);
     pub const LINE_WIDTH: Self = Self(2);
@@ -1024,8 +954,8 @@ impl DynamicState {
     pub const STENCIL_WRITE_MASK: Self = Self(7);
     pub const STENCIL_REFERENCE: Self = Self(8);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDescriptorUpdateTemplateType.html>"]
 pub struct DescriptorUpdateTemplateType(pub(crate) i32);
 impl DescriptorUpdateTemplateType {
@@ -1037,13 +967,11 @@ impl DescriptorUpdateTemplateType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DescriptorUpdateTemplateType {
     #[doc = "Create descriptor update template for descriptor set updates"]
     pub const DESCRIPTOR_SET: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkObjectType.html>"]
 pub struct ObjectType(pub(crate) i32);
 impl ObjectType {
@@ -1055,8 +983,6 @@ impl ObjectType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ObjectType {
     pub const UNKNOWN: Self = Self(0);
     pub const INSTANCE: Self = Self(1);
     pub const PHYSICAL_DEVICE: Self = Self(2);
@@ -1084,8 +1010,8 @@ impl ObjectType {
     pub const FRAMEBUFFER: Self = Self(24);
     pub const COMMAND_POOL: Self = Self(25);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkRayTracingInvocationReorderModeNV.html>"]
 pub struct RayTracingInvocationReorderModeNV(pub(crate) i32);
 impl RayTracingInvocationReorderModeNV {
@@ -1097,13 +1023,11 @@ impl RayTracingInvocationReorderModeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl RayTracingInvocationReorderModeNV {
     pub const NONE: Self = Self(0);
     pub const REORDER: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDirectDriverLoadingModeLUNARG.html>"]
 pub struct DirectDriverLoadingModeLUNARG(pub(crate) i32);
 impl DirectDriverLoadingModeLUNARG {
@@ -1115,13 +1039,11 @@ impl DirectDriverLoadingModeLUNARG {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DirectDriverLoadingModeLUNARG {
     pub const EXCLUSIVE: Self = Self(0);
     pub const INCLUSIVE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAntiLagModeAMD.html>"]
 pub struct AntiLagModeAMD(pub(crate) i32);
 impl AntiLagModeAMD {
@@ -1133,14 +1055,12 @@ impl AntiLagModeAMD {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AntiLagModeAMD {
     pub const DRIVER_CONTROL: Self = Self(0);
     pub const ON: Self = Self(1);
     pub const OFF: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAntiLagStageAMD.html>"]
 pub struct AntiLagStageAMD(pub(crate) i32);
 impl AntiLagStageAMD {
@@ -1152,13 +1072,11 @@ impl AntiLagStageAMD {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AntiLagStageAMD {
     pub const INPUT: Self = Self(0);
     pub const PRESENT: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSemaphoreType.html>"]
 pub struct SemaphoreType(pub(crate) i32);
 impl SemaphoreType {
@@ -1170,13 +1088,11 @@ impl SemaphoreType {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SemaphoreType {
     pub const BINARY: Self = Self(0);
     pub const TIMELINE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPresentModeKHR.html>"]
 pub struct PresentModeKHR(pub(crate) i32);
 impl PresentModeKHR {
@@ -1188,15 +1104,13 @@ impl PresentModeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PresentModeKHR {
     pub const IMMEDIATE: Self = Self(0);
     pub const MAILBOX: Self = Self(1);
     pub const FIFO: Self = Self(2);
     pub const FIFO_RELAXED: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkColorSpaceKHR.html>"]
 pub struct ColorSpaceKHR(pub(crate) i32);
 impl ColorSpaceKHR {
@@ -1208,12 +1122,10 @@ impl ColorSpaceKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ColorSpaceKHR {
     pub const SRGB_NONLINEAR: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkTimeDomainKHR.html>"]
 pub struct TimeDomainKHR(pub(crate) i32);
 impl TimeDomainKHR {
@@ -1225,15 +1137,13 @@ impl TimeDomainKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl TimeDomainKHR {
     pub const DEVICE: Self = Self(0);
     pub const CLOCK_MONOTONIC: Self = Self(1);
     pub const CLOCK_MONOTONIC_RAW: Self = Self(2);
     pub const QUERY_PERFORMANCE_COUNTER: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDebugReportObjectTypeEXT.html>"]
 pub struct DebugReportObjectTypeEXT(pub(crate) i32);
 impl DebugReportObjectTypeEXT {
@@ -1245,8 +1155,6 @@ impl DebugReportObjectTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DebugReportObjectTypeEXT {
     pub const UNKNOWN: Self = Self(0);
     pub const INSTANCE: Self = Self(1);
     pub const PHYSICAL_DEVICE: Self = Self(2);
@@ -1280,8 +1188,8 @@ impl DebugReportObjectTypeEXT {
     pub const DISPLAY_MODE_KHR: Self = Self(30);
     pub const VALIDATION_CACHE_EXT: Self = Self(33);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceMemoryReportEventTypeEXT.html>"]
 pub struct DeviceMemoryReportEventTypeEXT(pub(crate) i32);
 impl DeviceMemoryReportEventTypeEXT {
@@ -1293,16 +1201,14 @@ impl DeviceMemoryReportEventTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DeviceMemoryReportEventTypeEXT {
     pub const ALLOCATE: Self = Self(0);
     pub const FREE: Self = Self(1);
     pub const IMPORT: Self = Self(2);
     pub const UNIMPORT: Self = Self(3);
     pub const ALLOCATION_FAILED: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkRasterizationOrderAMD.html>"]
 pub struct RasterizationOrderAMD(pub(crate) i32);
 impl RasterizationOrderAMD {
@@ -1314,13 +1220,11 @@ impl RasterizationOrderAMD {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl RasterizationOrderAMD {
     pub const STRICT: Self = Self(0);
     pub const RELAXED: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkValidationCheckEXT.html>"]
 pub struct ValidationCheckEXT(pub(crate) i32);
 impl ValidationCheckEXT {
@@ -1332,13 +1236,11 @@ impl ValidationCheckEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ValidationCheckEXT {
     pub const ALL: Self = Self(0);
     pub const SHADERS: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkValidationFeatureEnableEXT.html>"]
 pub struct ValidationFeatureEnableEXT(pub(crate) i32);
 impl ValidationFeatureEnableEXT {
@@ -1350,16 +1252,14 @@ impl ValidationFeatureEnableEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ValidationFeatureEnableEXT {
     pub const GPU_ASSISTED: Self = Self(0);
     pub const GPU_ASSISTED_RESERVE_BINDING_SLOT: Self = Self(1);
     pub const BEST_PRACTICES: Self = Self(2);
     pub const DEBUG_PRINTF: Self = Self(3);
     pub const SYNCHRONIZATION_VALIDATION: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkValidationFeatureDisableEXT.html>"]
 pub struct ValidationFeatureDisableEXT(pub(crate) i32);
 impl ValidationFeatureDisableEXT {
@@ -1371,8 +1271,6 @@ impl ValidationFeatureDisableEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ValidationFeatureDisableEXT {
     pub const ALL: Self = Self(0);
     pub const SHADERS: Self = Self(1);
     pub const THREAD_SAFETY: Self = Self(2);
@@ -1382,8 +1280,8 @@ impl ValidationFeatureDisableEXT {
     pub const UNIQUE_HANDLES: Self = Self(6);
     pub const SHADER_VALIDATION_CACHE: Self = Self(7);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkLayerSettingTypeEXT.html>"]
 pub struct LayerSettingTypeEXT(pub(crate) i32);
 impl LayerSettingTypeEXT {
@@ -1395,8 +1293,6 @@ impl LayerSettingTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl LayerSettingTypeEXT {
     pub const BOOL32: Self = Self(0);
     pub const INT32: Self = Self(1);
     pub const INT64: Self = Self(2);
@@ -1406,8 +1302,8 @@ impl LayerSettingTypeEXT {
     pub const FLOAT64: Self = Self(6);
     pub const STRING: Self = Self(7);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkIndirectCommandsTokenTypeNV.html>"]
 pub struct IndirectCommandsTokenTypeNV(pub(crate) i32);
 impl IndirectCommandsTokenTypeNV {
@@ -1419,8 +1315,6 @@ impl IndirectCommandsTokenTypeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl IndirectCommandsTokenTypeNV {
     pub const SHADER_GROUP: Self = Self(0);
     pub const STATE_FLAGS: Self = Self(1);
     pub const INDEX_BUFFER: Self = Self(2);
@@ -1430,8 +1324,8 @@ impl IndirectCommandsTokenTypeNV {
     pub const DRAW: Self = Self(6);
     pub const DRAW_TASKS: Self = Self(7);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDisplayPowerStateEXT.html>"]
 pub struct DisplayPowerStateEXT(pub(crate) i32);
 impl DisplayPowerStateEXT {
@@ -1443,14 +1337,12 @@ impl DisplayPowerStateEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DisplayPowerStateEXT {
     pub const OFF: Self = Self(0);
     pub const SUSPEND: Self = Self(1);
     pub const ON: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceEventTypeEXT.html>"]
 pub struct DeviceEventTypeEXT(pub(crate) i32);
 impl DeviceEventTypeEXT {
@@ -1462,12 +1354,10 @@ impl DeviceEventTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DeviceEventTypeEXT {
     pub const DISPLAY_HOTPLUG: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDisplayEventTypeEXT.html>"]
 pub struct DisplayEventTypeEXT(pub(crate) i32);
 impl DisplayEventTypeEXT {
@@ -1479,12 +1369,10 @@ impl DisplayEventTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DisplayEventTypeEXT {
     pub const FIRST_PIXEL_OUT: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkViewportCoordinateSwizzleNV.html>"]
 pub struct ViewportCoordinateSwizzleNV(pub(crate) i32);
 impl ViewportCoordinateSwizzleNV {
@@ -1496,8 +1384,6 @@ impl ViewportCoordinateSwizzleNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ViewportCoordinateSwizzleNV {
     pub const POSITIVE_X: Self = Self(0);
     pub const NEGATIVE_X: Self = Self(1);
     pub const POSITIVE_Y: Self = Self(2);
@@ -1507,8 +1393,8 @@ impl ViewportCoordinateSwizzleNV {
     pub const POSITIVE_W: Self = Self(6);
     pub const NEGATIVE_W: Self = Self(7);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDiscardRectangleModeEXT.html>"]
 pub struct DiscardRectangleModeEXT(pub(crate) i32);
 impl DiscardRectangleModeEXT {
@@ -1520,13 +1406,11 @@ impl DiscardRectangleModeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DiscardRectangleModeEXT {
     pub const INCLUSIVE: Self = Self(0);
     pub const EXCLUSIVE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPointClippingBehavior.html>"]
 pub struct PointClippingBehavior(pub(crate) i32);
 impl PointClippingBehavior {
@@ -1538,13 +1422,11 @@ impl PointClippingBehavior {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PointClippingBehavior {
     pub const ALL_CLIP_PLANES: Self = Self(0);
     pub const USER_CLIP_PLANES_ONLY: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSamplerReductionMode.html>"]
 pub struct SamplerReductionMode(pub(crate) i32);
 impl SamplerReductionMode {
@@ -1556,14 +1438,12 @@ impl SamplerReductionMode {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SamplerReductionMode {
     pub const WEIGHTED_AVERAGE: Self = Self(0);
     pub const MIN: Self = Self(1);
     pub const MAX: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkTessellationDomainOrigin.html>"]
 pub struct TessellationDomainOrigin(pub(crate) i32);
 impl TessellationDomainOrigin {
@@ -1575,13 +1455,11 @@ impl TessellationDomainOrigin {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl TessellationDomainOrigin {
     pub const UPPER_LEFT: Self = Self(0);
     pub const LOWER_LEFT: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSamplerYcbcrModelConversion.html>"]
 pub struct SamplerYcbcrModelConversion(pub(crate) i32);
 impl SamplerYcbcrModelConversion {
@@ -1593,8 +1471,6 @@ impl SamplerYcbcrModelConversion {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SamplerYcbcrModelConversion {
     pub const RGB_IDENTITY: Self = Self(0);
     #[doc = "just range expansion"]
     pub const YCBCR_IDENTITY: Self = Self(1);
@@ -1605,8 +1481,8 @@ impl SamplerYcbcrModelConversion {
     #[doc = "aka UHD YUV"]
     pub const YCBCR_2020: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSamplerYcbcrRange.html>"]
 pub struct SamplerYcbcrRange(pub(crate) i32);
 impl SamplerYcbcrRange {
@@ -1618,15 +1494,13 @@ impl SamplerYcbcrRange {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SamplerYcbcrRange {
     #[doc = "Luma 0..1 maps to 0..255, chroma -0.5..0.5 to 1..255 (clamped)"]
     pub const ITU_FULL: Self = Self(0);
     #[doc = "Luma 0..1 maps to 16..235, chroma -0.5..0.5 to 16..240"]
     pub const ITU_NARROW: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkChromaLocation.html>"]
 pub struct ChromaLocation(pub(crate) i32);
 impl ChromaLocation {
@@ -1638,13 +1512,11 @@ impl ChromaLocation {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ChromaLocation {
     pub const COSITED_EVEN: Self = Self(0);
     pub const MIDPOINT: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBlendOverlapEXT.html>"]
 pub struct BlendOverlapEXT(pub(crate) i32);
 impl BlendOverlapEXT {
@@ -1656,14 +1528,12 @@ impl BlendOverlapEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BlendOverlapEXT {
     pub const UNCORRELATED: Self = Self(0);
     pub const DISJOINT: Self = Self(1);
     pub const CONJOINT: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCoverageModulationModeNV.html>"]
 pub struct CoverageModulationModeNV(pub(crate) i32);
 impl CoverageModulationModeNV {
@@ -1675,15 +1545,13 @@ impl CoverageModulationModeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CoverageModulationModeNV {
     pub const NONE: Self = Self(0);
     pub const RGB: Self = Self(1);
     pub const ALPHA: Self = Self(2);
     pub const RGBA: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCoverageReductionModeNV.html>"]
 pub struct CoverageReductionModeNV(pub(crate) i32);
 impl CoverageReductionModeNV {
@@ -1695,13 +1563,11 @@ impl CoverageReductionModeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CoverageReductionModeNV {
     pub const MERGE: Self = Self(0);
     pub const TRUNCATE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkValidationCacheHeaderVersionEXT.html>"]
 pub struct ValidationCacheHeaderVersionEXT(pub(crate) i32);
 impl ValidationCacheHeaderVersionEXT {
@@ -1713,12 +1579,10 @@ impl ValidationCacheHeaderVersionEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ValidationCacheHeaderVersionEXT {
     pub const ONE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkShaderInfoTypeAMD.html>"]
 pub struct ShaderInfoTypeAMD(pub(crate) i32);
 impl ShaderInfoTypeAMD {
@@ -1730,14 +1594,12 @@ impl ShaderInfoTypeAMD {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ShaderInfoTypeAMD {
     pub const STATISTICS: Self = Self(0);
     pub const BINARY: Self = Self(1);
     pub const DISASSEMBLY: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkQueueGlobalPriorityKHR.html>"]
 pub struct QueueGlobalPriorityKHR(pub(crate) i32);
 impl QueueGlobalPriorityKHR {
@@ -1749,8 +1611,6 @@ impl QueueGlobalPriorityKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl QueueGlobalPriorityKHR {
     pub const LOW: Self = Self(128);
     pub const MEDIUM: Self = Self(256);
     pub const HIGH: Self = Self(512);
@@ -1760,8 +1620,8 @@ impl QueueGlobalPriorityKHR {
     pub const HIGH_EXT: Self = Self::HIGH;
     pub const REALTIME_EXT: Self = Self::REALTIME;
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkConservativeRasterizationModeEXT.html>"]
 pub struct ConservativeRasterizationModeEXT(pub(crate) i32);
 impl ConservativeRasterizationModeEXT {
@@ -1773,14 +1633,12 @@ impl ConservativeRasterizationModeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ConservativeRasterizationModeEXT {
     pub const DISABLED: Self = Self(0);
     pub const OVERESTIMATE: Self = Self(1);
     pub const UNDERESTIMATE: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkVendorId.html>"]
 pub struct VendorId(pub(crate) i32);
 impl VendorId {
@@ -1792,8 +1650,6 @@ impl VendorId {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl VendorId {
     #[doc = "Khronos vendor ID"]
     pub const KHRONOS: Self = Self(0x10000);
     #[doc = "Vivante vendor ID"]
@@ -1811,8 +1667,8 @@ impl VendorId {
     #[doc = "Mobileye vendor ID"]
     pub const MOBILEYE: Self = Self(0x10007);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDriverId.html>"]
 pub struct DriverId(pub(crate) i32);
 impl DriverId {
@@ -1824,8 +1680,6 @@ impl DriverId {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DriverId {
     #[doc = "Advanced Micro Devices, Inc."]
     pub const AMD_PROPRIETARY: Self = Self(1);
     #[doc = "Advanced Micro Devices, Inc."]
@@ -1881,8 +1735,8 @@ impl DriverId {
     #[doc = "Reserved for undisclosed driver project"]
     pub const RESERVED_27: Self = Self(27);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkShadingRatePaletteEntryNV.html>"]
 pub struct ShadingRatePaletteEntryNV(pub(crate) i32);
 impl ShadingRatePaletteEntryNV {
@@ -1894,8 +1748,6 @@ impl ShadingRatePaletteEntryNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ShadingRatePaletteEntryNV {
     pub const NO_INVOCATIONS: Self = Self(0);
     pub const TYPE_16_INVOCATIONS_PER_PIXEL: Self = Self(1);
     pub const TYPE_8_INVOCATIONS_PER_PIXEL: Self = Self(2);
@@ -1909,8 +1761,8 @@ impl ShadingRatePaletteEntryNV {
     pub const TYPE_1_INVOCATION_PER_2X4_PIXELS: Self = Self(10);
     pub const TYPE_1_INVOCATION_PER_4X4_PIXELS: Self = Self(11);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCoarseSampleOrderTypeNV.html>"]
 pub struct CoarseSampleOrderTypeNV(pub(crate) i32);
 impl CoarseSampleOrderTypeNV {
@@ -1922,15 +1774,13 @@ impl CoarseSampleOrderTypeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CoarseSampleOrderTypeNV {
     pub const DEFAULT: Self = Self(0);
     pub const CUSTOM: Self = Self(1);
     pub const PIXEL_MAJOR: Self = Self(2);
     pub const SAMPLE_MAJOR: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCopyAccelerationStructureModeKHR.html>"]
 pub struct CopyAccelerationStructureModeKHR(pub(crate) i32);
 impl CopyAccelerationStructureModeKHR {
@@ -1942,15 +1792,13 @@ impl CopyAccelerationStructureModeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CopyAccelerationStructureModeKHR {
     pub const CLONE: Self = Self(0);
     pub const COMPACT: Self = Self(1);
     pub const SERIALIZE: Self = Self(2);
     pub const DESERIALIZE: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBuildAccelerationStructureModeKHR.html>"]
 pub struct BuildAccelerationStructureModeKHR(pub(crate) i32);
 impl BuildAccelerationStructureModeKHR {
@@ -1962,13 +1810,11 @@ impl BuildAccelerationStructureModeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BuildAccelerationStructureModeKHR {
     pub const BUILD: Self = Self(0);
     pub const UPDATE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureTypeKHR.html>"]
 pub struct AccelerationStructureTypeKHR(pub(crate) i32);
 impl AccelerationStructureTypeKHR {
@@ -1980,14 +1826,12 @@ impl AccelerationStructureTypeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AccelerationStructureTypeKHR {
     pub const TOP_LEVEL: Self = Self(0);
     pub const BOTTOM_LEVEL: Self = Self(1);
     pub const GENERIC: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkGeometryTypeKHR.html>"]
 pub struct GeometryTypeKHR(pub(crate) i32);
 impl GeometryTypeKHR {
@@ -1999,14 +1843,12 @@ impl GeometryTypeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl GeometryTypeKHR {
     pub const TRIANGLES: Self = Self(0);
     pub const AABBS: Self = Self(1);
     pub const INSTANCES: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureMemoryRequirementsTypeNV.html>"]
 pub struct AccelerationStructureMemoryRequirementsTypeNV(pub(crate) i32);
 impl AccelerationStructureMemoryRequirementsTypeNV {
@@ -2018,14 +1860,12 @@ impl AccelerationStructureMemoryRequirementsTypeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AccelerationStructureMemoryRequirementsTypeNV {
     pub const OBJECT: Self = Self(0);
     pub const BUILD_SCRATCH: Self = Self(1);
     pub const UPDATE_SCRATCH: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureBuildTypeKHR.html>"]
 pub struct AccelerationStructureBuildTypeKHR(pub(crate) i32);
 impl AccelerationStructureBuildTypeKHR {
@@ -2037,14 +1877,12 @@ impl AccelerationStructureBuildTypeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AccelerationStructureBuildTypeKHR {
     pub const HOST: Self = Self(0);
     pub const DEVICE: Self = Self(1);
     pub const HOST_OR_DEVICE: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkRayTracingShaderGroupTypeKHR.html>"]
 pub struct RayTracingShaderGroupTypeKHR(pub(crate) i32);
 impl RayTracingShaderGroupTypeKHR {
@@ -2056,14 +1894,12 @@ impl RayTracingShaderGroupTypeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl RayTracingShaderGroupTypeKHR {
     pub const GENERAL: Self = Self(0);
     pub const TRIANGLES_HIT_GROUP: Self = Self(1);
     pub const PROCEDURAL_HIT_GROUP: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureCompatibilityKHR.html>"]
 pub struct AccelerationStructureCompatibilityKHR(pub(crate) i32);
 impl AccelerationStructureCompatibilityKHR {
@@ -2075,13 +1911,11 @@ impl AccelerationStructureCompatibilityKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AccelerationStructureCompatibilityKHR {
     pub const COMPATIBLE: Self = Self(0);
     pub const INCOMPATIBLE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkShaderGroupShaderKHR.html>"]
 pub struct ShaderGroupShaderKHR(pub(crate) i32);
 impl ShaderGroupShaderKHR {
@@ -2093,15 +1927,13 @@ impl ShaderGroupShaderKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ShaderGroupShaderKHR {
     pub const GENERAL: Self = Self(0);
     pub const CLOSEST_HIT: Self = Self(1);
     pub const ANY_HIT: Self = Self(2);
     pub const INTERSECTION: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkMemoryOverallocationBehaviorAMD.html>"]
 pub struct MemoryOverallocationBehaviorAMD(pub(crate) i32);
 impl MemoryOverallocationBehaviorAMD {
@@ -2113,14 +1945,12 @@ impl MemoryOverallocationBehaviorAMD {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl MemoryOverallocationBehaviorAMD {
     pub const DEFAULT: Self = Self(0);
     pub const ALLOWED: Self = Self(1);
     pub const DISALLOWED: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFullScreenExclusiveEXT.html>"]
 pub struct FullScreenExclusiveEXT(pub(crate) i32);
 impl FullScreenExclusiveEXT {
@@ -2132,15 +1962,13 @@ impl FullScreenExclusiveEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl FullScreenExclusiveEXT {
     pub const DEFAULT: Self = Self(0);
     pub const ALLOWED: Self = Self(1);
     pub const DISALLOWED: Self = Self(2);
     pub const APPLICATION_CONTROLLED: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceCounterScopeKHR.html>"]
 pub struct PerformanceCounterScopeKHR(pub(crate) i32);
 impl PerformanceCounterScopeKHR {
@@ -2152,14 +1980,12 @@ impl PerformanceCounterScopeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceCounterScopeKHR {
     pub const COMMAND_BUFFER: Self = Self(0);
     pub const RENDER_PASS: Self = Self(1);
     pub const COMMAND: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceCounterUnitKHR.html>"]
 pub struct PerformanceCounterUnitKHR(pub(crate) i32);
 impl PerformanceCounterUnitKHR {
@@ -2171,8 +1997,6 @@ impl PerformanceCounterUnitKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceCounterUnitKHR {
     pub const GENERIC: Self = Self(0);
     pub const PERCENTAGE: Self = Self(1);
     pub const NANOSECONDS: Self = Self(2);
@@ -2185,8 +2009,8 @@ impl PerformanceCounterUnitKHR {
     pub const HERTZ: Self = Self(9);
     pub const CYCLES: Self = Self(10);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceCounterStorageKHR.html>"]
 pub struct PerformanceCounterStorageKHR(pub(crate) i32);
 impl PerformanceCounterStorageKHR {
@@ -2198,8 +2022,6 @@ impl PerformanceCounterStorageKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceCounterStorageKHR {
     pub const INT32: Self = Self(0);
     pub const INT64: Self = Self(1);
     pub const UINT32: Self = Self(2);
@@ -2207,8 +2029,8 @@ impl PerformanceCounterStorageKHR {
     pub const FLOAT32: Self = Self(4);
     pub const FLOAT64: Self = Self(5);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceConfigurationTypeINTEL.html>"]
 pub struct PerformanceConfigurationTypeINTEL(pub(crate) i32);
 impl PerformanceConfigurationTypeINTEL {
@@ -2220,12 +2042,10 @@ impl PerformanceConfigurationTypeINTEL {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceConfigurationTypeINTEL {
     pub const COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkQueryPoolSamplingModeINTEL.html>"]
 pub struct QueryPoolSamplingModeINTEL(pub(crate) i32);
 impl QueryPoolSamplingModeINTEL {
@@ -2237,12 +2057,10 @@ impl QueryPoolSamplingModeINTEL {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl QueryPoolSamplingModeINTEL {
     pub const MANUAL: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceOverrideTypeINTEL.html>"]
 pub struct PerformanceOverrideTypeINTEL(pub(crate) i32);
 impl PerformanceOverrideTypeINTEL {
@@ -2254,13 +2072,11 @@ impl PerformanceOverrideTypeINTEL {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceOverrideTypeINTEL {
     pub const NULL_HARDWARE: Self = Self(0);
     pub const FLUSH_GPU_CACHES: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceParameterTypeINTEL.html>"]
 pub struct PerformanceParameterTypeINTEL(pub(crate) i32);
 impl PerformanceParameterTypeINTEL {
@@ -2272,13 +2088,11 @@ impl PerformanceParameterTypeINTEL {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceParameterTypeINTEL {
     pub const HW_COUNTERS_SUPPORTED: Self = Self(0);
     pub const STREAM_MARKER_VALIDS: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPerformanceValueTypeINTEL.html>"]
 pub struct PerformanceValueTypeINTEL(pub(crate) i32);
 impl PerformanceValueTypeINTEL {
@@ -2290,16 +2104,14 @@ impl PerformanceValueTypeINTEL {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PerformanceValueTypeINTEL {
     pub const UINT32: Self = Self(0);
     pub const UINT64: Self = Self(1);
     pub const FLOAT: Self = Self(2);
     pub const BOOL: Self = Self(3);
     pub const STRING: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkShaderFloatControlsIndependence.html>"]
 pub struct ShaderFloatControlsIndependence(pub(crate) i32);
 impl ShaderFloatControlsIndependence {
@@ -2311,14 +2123,12 @@ impl ShaderFloatControlsIndependence {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ShaderFloatControlsIndependence {
     pub const TYPE_32_ONLY: Self = Self(0);
     pub const ALL: Self = Self(1);
     pub const NONE: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineExecutableStatisticFormatKHR.html>"]
 pub struct PipelineExecutableStatisticFormatKHR(pub(crate) i32);
 impl PipelineExecutableStatisticFormatKHR {
@@ -2330,15 +2140,13 @@ impl PipelineExecutableStatisticFormatKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PipelineExecutableStatisticFormatKHR {
     pub const BOOL32: Self = Self(0);
     pub const INT64: Self = Self(1);
     pub const UINT64: Self = Self(2);
     pub const FLOAT64: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkLineRasterizationModeKHR.html>"]
 pub struct LineRasterizationModeKHR(pub(crate) i32);
 impl LineRasterizationModeKHR {
@@ -2350,8 +2158,6 @@ impl LineRasterizationModeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl LineRasterizationModeKHR {
     pub const DEFAULT: Self = Self(0);
     pub const DEFAULT_EXT: Self = Self::DEFAULT;
     pub const RECTANGULAR: Self = Self(1);
@@ -2361,8 +2167,8 @@ impl LineRasterizationModeKHR {
     pub const RECTANGULAR_SMOOTH: Self = Self(3);
     pub const RECTANGULAR_SMOOTH_EXT: Self = Self::RECTANGULAR_SMOOTH;
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFragmentShadingRateCombinerOpKHR.html>"]
 pub struct FragmentShadingRateCombinerOpKHR(pub(crate) i32);
 impl FragmentShadingRateCombinerOpKHR {
@@ -2374,16 +2180,14 @@ impl FragmentShadingRateCombinerOpKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl FragmentShadingRateCombinerOpKHR {
     pub const KEEP: Self = Self(0);
     pub const REPLACE: Self = Self(1);
     pub const MIN: Self = Self(2);
     pub const MAX: Self = Self(3);
     pub const MUL: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFragmentShadingRateNV.html>"]
 pub struct FragmentShadingRateNV(pub(crate) i32);
 impl FragmentShadingRateNV {
@@ -2395,8 +2199,6 @@ impl FragmentShadingRateNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl FragmentShadingRateNV {
     pub const TYPE_1_INVOCATION_PER_PIXEL: Self = Self(0);
     pub const TYPE_1_INVOCATION_PER_1X2_PIXELS: Self = Self(1);
     pub const TYPE_1_INVOCATION_PER_2X1_PIXELS: Self = Self(4);
@@ -2410,8 +2212,8 @@ impl FragmentShadingRateNV {
     pub const TYPE_16_INVOCATIONS_PER_PIXEL: Self = Self(14);
     pub const NO_INVOCATIONS: Self = Self(15);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFragmentShadingRateTypeNV.html>"]
 pub struct FragmentShadingRateTypeNV(pub(crate) i32);
 impl FragmentShadingRateTypeNV {
@@ -2423,13 +2225,11 @@ impl FragmentShadingRateTypeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl FragmentShadingRateTypeNV {
     pub const FRAGMENT_SIZE: Self = Self(0);
     pub const ENUMS: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSubpassMergeStatusEXT.html>"]
 pub struct SubpassMergeStatusEXT(pub(crate) i32);
 impl SubpassMergeStatusEXT {
@@ -2441,8 +2241,6 @@ impl SubpassMergeStatusEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl SubpassMergeStatusEXT {
     pub const MERGED: Self = Self(0);
     pub const DISALLOWED: Self = Self(1);
     pub const NOT_MERGED_SIDE_EFFECTS: Self = Self(2);
@@ -2458,8 +2256,8 @@ impl SubpassMergeStatusEXT {
     pub const NOT_MERGED_SINGLE_SUBPASS: Self = Self(12);
     pub const NOT_MERGED_UNSPECIFIED: Self = Self(13);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkProvokingVertexModeEXT.html>"]
 pub struct ProvokingVertexModeEXT(pub(crate) i32);
 impl ProvokingVertexModeEXT {
@@ -2471,13 +2269,11 @@ impl ProvokingVertexModeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ProvokingVertexModeEXT {
     pub const FIRST_VERTEX: Self = Self(0);
     pub const LAST_VERTEX: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureMotionInstanceTypeNV.html>"]
 pub struct AccelerationStructureMotionInstanceTypeNV(pub(crate) i32);
 impl AccelerationStructureMotionInstanceTypeNV {
@@ -2489,14 +2285,12 @@ impl AccelerationStructureMotionInstanceTypeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl AccelerationStructureMotionInstanceTypeNV {
     pub const STATIC: Self = Self(0);
     pub const MATRIX_MOTION: Self = Self(1);
     pub const SRT_MOTION: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceAddressBindingTypeEXT.html>"]
 pub struct DeviceAddressBindingTypeEXT(pub(crate) i32);
 impl DeviceAddressBindingTypeEXT {
@@ -2508,13 +2302,11 @@ impl DeviceAddressBindingTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DeviceAddressBindingTypeEXT {
     pub const BIND: Self = Self(0);
     pub const UNBIND: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkQueryResultStatusKHR.html>"]
 pub struct QueryResultStatusKHR(pub(crate) i32);
 impl QueryResultStatusKHR {
@@ -2526,14 +2318,12 @@ impl QueryResultStatusKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl QueryResultStatusKHR {
     pub const ERROR: Self = Self(-1);
     pub const NOT_READY: Self = Self(0);
     pub const COMPLETE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeTuningModeKHR.html>"]
 pub struct VideoEncodeTuningModeKHR(pub(crate) i32);
 impl VideoEncodeTuningModeKHR {
@@ -2545,16 +2335,14 @@ impl VideoEncodeTuningModeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl VideoEncodeTuningModeKHR {
     pub const DEFAULT: Self = Self(0);
     pub const HIGH_QUALITY: Self = Self(1);
     pub const LOW_LATENCY: Self = Self(2);
     pub const ULTRA_LOW_LATENCY: Self = Self(3);
     pub const LOSSLESS: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineRobustnessBufferBehaviorEXT.html>"]
 pub struct PipelineRobustnessBufferBehaviorEXT(pub(crate) i32);
 impl PipelineRobustnessBufferBehaviorEXT {
@@ -2566,15 +2354,13 @@ impl PipelineRobustnessBufferBehaviorEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PipelineRobustnessBufferBehaviorEXT {
     pub const DEVICE_DEFAULT: Self = Self(0);
     pub const DISABLED: Self = Self(1);
     pub const ROBUST_BUFFER_ACCESS: Self = Self(2);
     pub const ROBUST_BUFFER_ACCESS_2: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineRobustnessImageBehaviorEXT.html>"]
 pub struct PipelineRobustnessImageBehaviorEXT(pub(crate) i32);
 impl PipelineRobustnessImageBehaviorEXT {
@@ -2586,15 +2372,13 @@ impl PipelineRobustnessImageBehaviorEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PipelineRobustnessImageBehaviorEXT {
     pub const DEVICE_DEFAULT: Self = Self(0);
     pub const DISABLED: Self = Self(1);
     pub const ROBUST_IMAGE_ACCESS: Self = Self(2);
     pub const ROBUST_IMAGE_ACCESS_2: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkOpticalFlowPerformanceLevelNV.html>"]
 pub struct OpticalFlowPerformanceLevelNV(pub(crate) i32);
 impl OpticalFlowPerformanceLevelNV {
@@ -2606,15 +2390,13 @@ impl OpticalFlowPerformanceLevelNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl OpticalFlowPerformanceLevelNV {
     pub const UNKNOWN: Self = Self(0);
     pub const SLOW: Self = Self(1);
     pub const MEDIUM: Self = Self(2);
     pub const FAST: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkOpticalFlowSessionBindingPointNV.html>"]
 pub struct OpticalFlowSessionBindingPointNV(pub(crate) i32);
 impl OpticalFlowSessionBindingPointNV {
@@ -2626,8 +2408,6 @@ impl OpticalFlowSessionBindingPointNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl OpticalFlowSessionBindingPointNV {
     pub const UNKNOWN: Self = Self(0);
     pub const INPUT: Self = Self(1);
     pub const REFERENCE: Self = Self(2);
@@ -2638,8 +2418,8 @@ impl OpticalFlowSessionBindingPointNV {
     pub const BACKWARD_COST: Self = Self(7);
     pub const GLOBAL_FLOW: Self = Self(8);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkMicromapTypeEXT.html>"]
 pub struct MicromapTypeEXT(pub(crate) i32);
 impl MicromapTypeEXT {
@@ -2651,12 +2431,10 @@ impl MicromapTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl MicromapTypeEXT {
     pub const OPACITY_MICROMAP: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCopyMicromapModeEXT.html>"]
 pub struct CopyMicromapModeEXT(pub(crate) i32);
 impl CopyMicromapModeEXT {
@@ -2668,15 +2446,13 @@ impl CopyMicromapModeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CopyMicromapModeEXT {
     pub const CLONE: Self = Self(0);
     pub const SERIALIZE: Self = Self(1);
     pub const DESERIALIZE: Self = Self(2);
     pub const COMPACT: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBuildMicromapModeEXT.html>"]
 pub struct BuildMicromapModeEXT(pub(crate) i32);
 impl BuildMicromapModeEXT {
@@ -2688,12 +2464,10 @@ impl BuildMicromapModeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BuildMicromapModeEXT {
     pub const BUILD: Self = Self(0);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkOpacityMicromapFormatEXT.html>"]
 pub struct OpacityMicromapFormatEXT(pub(crate) i32);
 impl OpacityMicromapFormatEXT {
@@ -2705,13 +2479,11 @@ impl OpacityMicromapFormatEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl OpacityMicromapFormatEXT {
     pub const TYPE_2_STATE: Self = Self(1);
     pub const TYPE_4_STATE: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkOpacityMicromapSpecialIndexEXT.html>"]
 pub struct OpacityMicromapSpecialIndexEXT(pub(crate) i32);
 impl OpacityMicromapSpecialIndexEXT {
@@ -2723,15 +2495,13 @@ impl OpacityMicromapSpecialIndexEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl OpacityMicromapSpecialIndexEXT {
     pub const FULLY_TRANSPARENT: Self = Self(-1);
     pub const FULLY_OPAQUE: Self = Self(-2);
     pub const FULLY_UNKNOWN_TRANSPARENT: Self = Self(-3);
     pub const FULLY_UNKNOWN_OPAQUE: Self = Self(-4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDepthBiasRepresentationEXT.html>"]
 pub struct DepthBiasRepresentationEXT(pub(crate) i32);
 impl DepthBiasRepresentationEXT {
@@ -2743,14 +2513,12 @@ impl DepthBiasRepresentationEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DepthBiasRepresentationEXT {
     pub const LEAST_REPRESENTABLE_VALUE_FORMAT: Self = Self(0);
     pub const LEAST_REPRESENTABLE_VALUE_FORCE_UNORM: Self = Self(1);
     pub const FLOAT: Self = Self(2);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceFaultAddressTypeEXT.html>"]
 pub struct DeviceFaultAddressTypeEXT(pub(crate) i32);
 impl DeviceFaultAddressTypeEXT {
@@ -2762,8 +2530,6 @@ impl DeviceFaultAddressTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DeviceFaultAddressTypeEXT {
     #[doc = "Currently unused"]
     pub const NONE: Self = Self(0);
     pub const READ_INVALID: Self = Self(1);
@@ -2773,8 +2539,8 @@ impl DeviceFaultAddressTypeEXT {
     pub const INSTRUCTION_POINTER_INVALID: Self = Self(5);
     pub const INSTRUCTION_POINTER_FAULT: Self = Self(6);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceFaultVendorBinaryHeaderVersionEXT.html>"]
 pub struct DeviceFaultVendorBinaryHeaderVersionEXT(pub(crate) i32);
 impl DeviceFaultVendorBinaryHeaderVersionEXT {
@@ -2786,12 +2552,10 @@ impl DeviceFaultVendorBinaryHeaderVersionEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DeviceFaultVendorBinaryHeaderVersionEXT {
     pub const ONE: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkIndirectExecutionSetInfoTypeEXT.html>"]
 pub struct IndirectExecutionSetInfoTypeEXT(pub(crate) i32);
 impl IndirectExecutionSetInfoTypeEXT {
@@ -2803,13 +2567,11 @@ impl IndirectExecutionSetInfoTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl IndirectExecutionSetInfoTypeEXT {
     pub const PIPELINES: Self = Self(0);
     pub const SHADER_OBJECTS: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkIndirectCommandsTokenTypeEXT.html>"]
 pub struct IndirectCommandsTokenTypeEXT(pub(crate) i32);
 impl IndirectCommandsTokenTypeEXT {
@@ -2821,8 +2583,6 @@ impl IndirectCommandsTokenTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl IndirectCommandsTokenTypeEXT {
     pub const EXECUTION_SET: Self = Self(0);
     pub const PUSH_CONSTANT: Self = Self(1);
     pub const SEQUENCE_INDEX: Self = Self(2);
@@ -2834,10 +2594,12 @@ impl IndirectCommandsTokenTypeEXT {
     pub const DRAW_COUNT: Self = Self(8);
     pub const DISPATCH: Self = Self(9);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg(feature = "provisional")]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDisplacementMicromapFormatNV.html>"]
 pub struct DisplacementMicromapFormatNV(pub(crate) i32);
+#[cfg(feature = "provisional")]
 impl DisplacementMicromapFormatNV {
     #[inline]
     pub const fn from_raw(x: i32) -> Self {
@@ -2847,14 +2609,12 @@ impl DisplacementMicromapFormatNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DisplacementMicromapFormatNV {
     pub const TYPE_64_TRIANGLES_64_BYTES: Self = Self(1);
     pub const TYPE_256_TRIANGLES_128_BYTES: Self = Self(2);
     pub const TYPE_1024_TRIANGLES_128_BYTES: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkShaderCodeTypeEXT.html>"]
 pub struct ShaderCodeTypeEXT(pub(crate) i32);
 impl ShaderCodeTypeEXT {
@@ -2866,13 +2626,11 @@ impl ShaderCodeTypeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ShaderCodeTypeEXT {
     pub const BINARY: Self = Self(0);
     pub const SPIRV: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkScopeKHR.html>"]
 pub struct ScopeKHR(pub(crate) i32);
 impl ScopeKHR {
@@ -2884,15 +2642,13 @@ impl ScopeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ScopeKHR {
     pub const DEVICE: Self = Self(1);
     pub const WORKGROUP: Self = Self(2);
     pub const SUBGROUP: Self = Self(3);
     pub const QUEUE_FAMILY: Self = Self(5);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkComponentTypeKHR.html>"]
 pub struct ComponentTypeKHR(pub(crate) i32);
 impl ComponentTypeKHR {
@@ -2904,8 +2660,6 @@ impl ComponentTypeKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl ComponentTypeKHR {
     pub const FLOAT16: Self = Self(0);
     pub const FLOAT32: Self = Self(1);
     pub const FLOAT64: Self = Self(2);
@@ -2918,8 +2672,8 @@ impl ComponentTypeKHR {
     pub const UINT32: Self = Self(9);
     pub const UINT64: Self = Self(10);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkCubicFilterWeightsQCOM.html>"]
 pub struct CubicFilterWeightsQCOM(pub(crate) i32);
 impl CubicFilterWeightsQCOM {
@@ -2931,15 +2685,13 @@ impl CubicFilterWeightsQCOM {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl CubicFilterWeightsQCOM {
     pub const CATMULL_ROM: Self = Self(0);
     pub const ZERO_TANGENT_CARDINAL: Self = Self(1);
     pub const B_SPLINE: Self = Self(2);
     pub const MITCHELL_NETRAVALI: Self = Self(3);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBlockMatchWindowCompareModeQCOM.html>"]
 pub struct BlockMatchWindowCompareModeQCOM(pub(crate) i32);
 impl BlockMatchWindowCompareModeQCOM {
@@ -2951,13 +2703,11 @@ impl BlockMatchWindowCompareModeQCOM {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl BlockMatchWindowCompareModeQCOM {
     pub const MIN: Self = Self(0);
     pub const MAX: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceLayeredApiKHR.html>"]
 pub struct PhysicalDeviceLayeredApiKHR(pub(crate) i32);
 impl PhysicalDeviceLayeredApiKHR {
@@ -2969,16 +2719,14 @@ impl PhysicalDeviceLayeredApiKHR {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl PhysicalDeviceLayeredApiKHR {
     pub const VULKAN: Self = Self(0);
     pub const D3D12: Self = Self(1);
     pub const METAL: Self = Self(2);
     pub const OPENGL: Self = Self(3);
     pub const OPENGLES: Self = Self(4);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkLayeredDriverUnderlyingApiMSFT.html>"]
 pub struct LayeredDriverUnderlyingApiMSFT(pub(crate) i32);
 impl LayeredDriverUnderlyingApiMSFT {
@@ -2990,13 +2738,11 @@ impl LayeredDriverUnderlyingApiMSFT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl LayeredDriverUnderlyingApiMSFT {
     pub const NONE: Self = Self(0);
     pub const D3D12: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkLatencyMarkerNV.html>"]
 pub struct LatencyMarkerNV(pub(crate) i32);
 impl LatencyMarkerNV {
@@ -3008,8 +2754,6 @@ impl LatencyMarkerNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl LatencyMarkerNV {
     pub const SIMULATION_START: Self = Self(0);
     pub const SIMULATION_END: Self = Self(1);
     pub const RENDERSUBMIT_START: Self = Self(2);
@@ -3023,8 +2767,8 @@ impl LatencyMarkerNV {
     pub const OUT_OF_BAND_PRESENT_START: Self = Self(10);
     pub const OUT_OF_BAND_PRESENT_END: Self = Self(11);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkOutOfBandQueueTypeNV.html>"]
 pub struct OutOfBandQueueTypeNV(pub(crate) i32);
 impl OutOfBandQueueTypeNV {
@@ -3036,13 +2780,11 @@ impl OutOfBandQueueTypeNV {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl OutOfBandQueueTypeNV {
     pub const RENDER: Self = Self(0);
     pub const PRESENT: Self = Self(1);
 }
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDepthClampModeEXT.html>"]
 pub struct DepthClampModeEXT(pub(crate) i32);
 impl DepthClampModeEXT {
@@ -3054,8 +2796,6 @@ impl DepthClampModeEXT {
     pub const fn as_raw(self) -> i32 {
         self.0
     }
-}
-impl DepthClampModeEXT {
     pub const VIEWPORT_RANGE: Self = Self(0);
     pub const USER_DEFINED_RANGE: Self = Self(1);
 }
@@ -3104,7 +2844,9 @@ impl fmt::Debug for ObjectType {
             Self::PERFORMANCE_CONFIGURATION_INTEL => Some("PERFORMANCE_CONFIGURATION_INTEL"),
             Self::DEFERRED_OPERATION_KHR => Some("DEFERRED_OPERATION_KHR"),
             Self::INDIRECT_COMMANDS_LAYOUT_NV => Some("INDIRECT_COMMANDS_LAYOUT_NV"),
+            #[cfg(feature = "provisional")]
             Self::CUDA_MODULE_NV => Some("CUDA_MODULE_NV"),
+            #[cfg(feature = "provisional")]
             Self::CUDA_FUNCTION_NV => Some("CUDA_FUNCTION_NV"),
             Self::BUFFER_COLLECTION_FUCHSIA => Some("BUFFER_COLLECTION_FUCHSIA"),
             Self::MICROMAP_EXT => Some("MICROMAP_EXT"),

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -972,18 +972,22 @@ impl StructureType {
         Self::SAMPLER_REDUCTION_MODE_CREATE_INFO;
 }
 #[doc = "Generated from 'VK_AMDX_shader_enqueue'"]
+#[cfg(feature = "provisional")]
 impl BufferUsageFlags {
     pub const EXECUTION_GRAPH_SCRATCH_AMDX: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_AMDX_shader_enqueue'"]
+#[cfg(feature = "provisional")]
 impl BufferUsageFlags2KHR {
     pub const EXECUTION_GRAPH_SCRATCH_AMDX: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_AMDX_shader_enqueue'"]
+#[cfg(feature = "provisional")]
 impl PipelineBindPoint {
     pub const EXECUTION_GRAPH_AMDX: Self = Self(1_000_134_000);
 }
 #[doc = "Generated from 'VK_AMDX_shader_enqueue'"]
+#[cfg(feature = "provisional")]
 impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX: Self = Self(1_000_134_000);
     pub const PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX: Self = Self(1_000_134_001);
@@ -1415,6 +1419,7 @@ impl StructureType {
         Self::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT;
 }
 #[doc = "Generated from 'VK_KHR_portability_subset'"]
+#[cfg(feature = "provisional")]
 impl StructureType {
     pub const PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: Self = Self(1_000_163_000);
     pub const PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR: Self = Self(1_000_163_001);
@@ -2532,16 +2537,19 @@ impl AttachmentStoreOp {
     pub const NONE_QCOM: Self = Self::NONE;
 }
 #[doc = "Generated from 'VK_NV_cuda_kernel_launch'"]
+#[cfg(feature = "provisional")]
 impl DebugReportObjectTypeEXT {
     pub const CUDA_MODULE_NV: Self = Self(1_000_307_000);
     pub const CUDA_FUNCTION_NV: Self = Self(1_000_307_001);
 }
 #[doc = "Generated from 'VK_NV_cuda_kernel_launch'"]
+#[cfg(feature = "provisional")]
 impl ObjectType {
     pub const CUDA_MODULE_NV: Self = Self(1_000_307_000);
     pub const CUDA_FUNCTION_NV: Self = Self(1_000_307_001);
 }
 #[doc = "Generated from 'VK_NV_cuda_kernel_launch'"]
+#[cfg(feature = "provisional")]
 impl StructureType {
     pub const CUDA_MODULE_CREATE_INFO_NV: Self = Self(1_000_307_000);
     pub const CUDA_FUNCTION_CREATE_INFO_NV: Self = Self(1_000_307_001);
@@ -3244,19 +3252,23 @@ impl StructureType {
     pub const ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT: Self = Self(1_000_396_009);
 }
 #[doc = "Generated from 'VK_NV_displacement_micromap'"]
+#[cfg(feature = "provisional")]
 impl BuildAccelerationStructureFlagsKHR {
     pub const ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV: Self = Self(0b10_0000_0000);
 }
 #[doc = "Generated from 'VK_NV_displacement_micromap'"]
+#[cfg(feature = "provisional")]
 impl MicromapTypeEXT {
     pub const DISPLACEMENT_MICROMAP_NV: Self = Self(1_000_397_000);
 }
 #[doc = "Generated from 'VK_NV_displacement_micromap'"]
+#[cfg(feature = "provisional")]
 impl PipelineCreateFlags {
     pub const RAY_TRACING_DISPLACEMENT_MICROMAP_NV: Self =
         Self(0b1_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_NV_displacement_micromap'"]
+#[cfg(feature = "provisional")]
 impl StructureType {
     pub const PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV: Self = Self(1_000_397_000);
     pub const PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV: Self = Self(1_000_397_001);
@@ -5429,9 +5441,12 @@ pub const KHR_STORAGE_BUFFER_STORAGE_CLASS_SPEC_VERSION: u32 = 1u32;
 pub const AMD_GPU_SHADER_INT16_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gpu_shader_int16\0") };
 pub const AMD_GPU_SHADER_INT16_SPEC_VERSION: u32 = 2u32;
+#[cfg(feature = "provisional")]
 pub const AMDX_SHADER_ENQUEUE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMDX_shader_enqueue\0") };
+#[cfg(feature = "provisional")]
 pub const AMDX_SHADER_ENQUEUE_SPEC_VERSION: u32 = 1u32;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateExecutionGraphPipelinesAMDX = unsafe extern "system" fn(
     device: crate::vk::Device,
@@ -5441,12 +5456,14 @@ pub type PFN_vkCreateExecutionGraphPipelinesAMDX = unsafe extern "system" fn(
     p_allocator: *const AllocationCallbacks,
     p_pipelines: *mut Pipeline,
 ) -> Result;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetExecutionGraphPipelineScratchSizeAMDX = unsafe extern "system" fn(
     device: crate::vk::Device,
     execution_graph: Pipeline,
     p_size_info: *mut ExecutionGraphPipelineScratchSizeAMDX<'_>,
 ) -> Result;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetExecutionGraphPipelineNodeIndexAMDX = unsafe extern "system" fn(
     device: crate::vk::Device,
@@ -5454,21 +5471,25 @@ pub type PFN_vkGetExecutionGraphPipelineNodeIndexAMDX = unsafe extern "system" f
     p_node_info: *const PipelineShaderStageNodeCreateInfoAMDX<'_>,
     p_node_index: *mut u32,
 ) -> Result;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdInitializeGraphScratchMemoryAMDX =
     unsafe extern "system" fn(command_buffer: CommandBuffer, scratch: DeviceAddress);
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDispatchGraphAMDX = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     scratch: DeviceAddress,
     p_count_info: *const DispatchGraphCountInfoAMDX,
 );
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDispatchGraphIndirectAMDX = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     scratch: DeviceAddress,
     p_count_info: *const DispatchGraphCountInfoAMDX,
 );
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDispatchGraphIndirectCountAMDX = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
@@ -5800,8 +5821,10 @@ pub const EXT_DESCRIPTOR_INDEXING_SPEC_VERSION: u32 = 2u32;
 pub const EXT_SHADER_VIEWPORT_INDEX_LAYER_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_viewport_index_layer\0") };
 pub const EXT_SHADER_VIEWPORT_INDEX_LAYER_SPEC_VERSION: u32 = 1u32;
+#[cfg(feature = "provisional")]
 pub const KHR_PORTABILITY_SUBSET_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_portability_subset\0") };
+#[cfg(feature = "provisional")]
 pub const KHR_PORTABILITY_SUBSET_SPEC_VERSION: u32 = 1u32;
 pub const NV_SHADING_RATE_IMAGE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_shading_rate_image\0") };
@@ -6745,9 +6768,12 @@ pub const NV_DEVICE_DIAGNOSTICS_CONFIG_SPEC_VERSION: u32 = 2u32;
 pub const QCOM_RENDER_PASS_STORE_OPS_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_render_pass_store_ops\0") };
 pub const QCOM_RENDER_PASS_STORE_OPS_SPEC_VERSION: u32 = 2u32;
+#[cfg(feature = "provisional")]
 pub const NV_CUDA_KERNEL_LAUNCH_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_cuda_kernel_launch\0") };
+#[cfg(feature = "provisional")]
 pub const NV_CUDA_KERNEL_LAUNCH_SPEC_VERSION: u32 = 2u32;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCudaModuleNV = unsafe extern "system" fn(
     device: crate::vk::Device,
@@ -6755,6 +6781,7 @@ pub type PFN_vkCreateCudaModuleNV = unsafe extern "system" fn(
     p_allocator: *const AllocationCallbacks,
     p_module: *mut CudaModuleNV,
 ) -> Result;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetCudaModuleCacheNV = unsafe extern "system" fn(
     device: crate::vk::Device,
@@ -6762,6 +6789,7 @@ pub type PFN_vkGetCudaModuleCacheNV = unsafe extern "system" fn(
     p_cache_size: *mut usize,
     p_cache_data: *mut c_void,
 ) -> Result;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCudaFunctionNV = unsafe extern "system" fn(
     device: crate::vk::Device,
@@ -6769,18 +6797,21 @@ pub type PFN_vkCreateCudaFunctionNV = unsafe extern "system" fn(
     p_allocator: *const AllocationCallbacks,
     p_function: *mut CudaFunctionNV,
 ) -> Result;
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCudaModuleNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     module: CudaModuleNV,
     p_allocator: *const AllocationCallbacks,
 );
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCudaFunctionNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     function: CudaFunctionNV,
     p_allocator: *const AllocationCallbacks,
 );
+#[cfg(feature = "provisional")]
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCudaLaunchKernelNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
@@ -7411,8 +7442,10 @@ pub type PFN_vkGetMicromapBuildSizesEXT = unsafe extern "system" fn(
     p_build_info: *const MicromapBuildInfoEXT<'_>,
     p_size_info: *mut MicromapBuildSizesInfoEXT<'_>,
 );
+#[cfg(feature = "provisional")]
 pub const NV_DISPLACEMENT_MICROMAP_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_displacement_micromap\0") };
+#[cfg(feature = "provisional")]
 pub const NV_DISPLACEMENT_MICROMAP_SPEC_VERSION: u32 = 2u32;
 pub const EXT_LOAD_STORE_OP_NONE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_load_store_op_none\0") };

--- a/ash/src/vk/macros.rs
+++ b/ash/src/vk/macros.rs
@@ -83,14 +83,13 @@ macro_rules! vk_bitflags_wrapped {
 }
 #[macro_export]
 macro_rules! handle_nondispatchable {
-    ($ name : ident , $ ty : ident) => {
-        handle_nondispatchable!($name, $ty, doc = "");
-    };
-    ($ name : ident , $ ty : ident , $ doc_link : meta) => {
+    ($ name : ident , $ ty : ident , $ doc_link : meta $(, $ cfgs : meta )?) => {
+        #[$doc_link]
+        $(#[$cfgs])?
         #[repr(transparent)]
         #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Default)]
-        #[$doc_link]
         pub struct $name(u64);
+        $(#[$cfgs])?
         impl Handle for $name {
             const TYPE: ObjectType = ObjectType::$ty;
             fn as_raw(self) -> u64 {
@@ -100,16 +99,19 @@ macro_rules! handle_nondispatchable {
                 Self(x)
             }
         }
+        $(#[$cfgs])?
         impl $name {
             pub const fn null() -> Self {
                 Self(0)
             }
         }
+        $(#[$cfgs])?
         impl fmt::Pointer for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "0x{:x}", self.0)
             }
         }
+        $(#[$cfgs])?
         impl fmt::Debug for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "0x{:x}", self.0)
@@ -119,19 +121,19 @@ macro_rules! handle_nondispatchable {
 }
 #[macro_export]
 macro_rules! define_handle {
-    ($ name : ident , $ ty : ident) => {
-        define_handle!($name, $ty, doc = "");
-    };
-    ($ name : ident , $ ty : ident , $ doc_link : meta) => {
+    ($ name : ident , $ ty : ident , $ doc_link : meta $(, $ cfgs : meta )?) => {
+        #[$doc_link]
+        $(#[$cfgs])?
         #[repr(transparent)]
         #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash)]
-        #[$doc_link]
         pub struct $name(*mut u8);
+        $(#[$cfgs])?
         impl Default for $name {
             fn default() -> Self {
                 Self::null()
             }
         }
+        $(#[$cfgs])?
         impl Handle for $name {
             const TYPE: ObjectType = ObjectType::$ty;
             fn as_raw(self) -> u64 {
@@ -141,18 +143,23 @@ macro_rules! define_handle {
                 Self(x as _)
             }
         }
+        $(#[$cfgs])?
         unsafe impl Send for $name {}
+        $(#[$cfgs])?
         unsafe impl Sync for $name {}
+        $(#[$cfgs])?
         impl $name {
             pub const fn null() -> Self {
                 Self(::core::ptr::null_mut())
             }
         }
+        $(#[$cfgs])?
         impl fmt::Pointer for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt::Pointer::fmt(&self.0, f)
             }
         }
+        $(#[$cfgs])?
         impl fmt::Debug for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt::Debug::fmt(&self.0, f)

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -26,7 +26,7 @@ use quote::*;
 use regex::Regex;
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
     fmt::Display,
     ops::Not,
     path::Path,
@@ -49,6 +49,7 @@ macro_rules! get_variant {
     };
     ($variant:path { $($member:ident),+ }) => {
         |enum_| match enum_ {
+            #[allow(clippy::double_parens, reason = "Occurs when only one member is queried")]
             $variant { $($member),+, .. } => Some(( $($member),+ )),
             _ => None,
         }
@@ -875,13 +876,21 @@ impl FieldExt for vk_parse::CommandParam {
     }
 }
 
-pub type CommandMap<'a> = HashMap<vkxml::Identifier, &'a vk_parse::CommandDefinition>;
+/// Amalgamated information about [`vk_parse::Feature`]s and [`vk_parse::Extension`]s providing
+/// this element.
+#[derive(Clone, Debug)]
+pub struct ProvidedBy<'a> {
+    pub names: Vec<&'a str>,
+    pub provisional: bool,
+}
+
+pub type CommandMap<'a> = HashMap<&'a str, (&'a vk_parse::CommandDefinition, &'a ProvidedBy<'a>)>;
 
 /// Returns (raw bindings, function pointer table)
 fn generate_function_pointers<'a>(
     ident: Ident,
-    commands: &[&'a vk_parse::CommandDefinition],
-    rename_commands: &HashMap<&'a str, &'a str>,
+    commands: &[(&'a vk_parse::CommandDefinition, &'a ProvidedBy<'_>)],
+    rename_commands: &HashMap<&str, &str>,
     fn_cache: &mut HashSet<&'a str>,
     has_lifetimes: &HashSet<Ident>,
     doc: &str,
@@ -890,7 +899,7 @@ fn generate_function_pointers<'a>(
     // really want to generate one function pointer.
     let commands = commands
         .iter()
-        .unique_by(|cmd| cmd.proto.name.as_str())
+        .unique_by(|cmd| cmd.0.proto.name.as_str())
         .collect::<Vec<_>>();
 
     struct Command<'a> {
@@ -903,12 +912,13 @@ fn generate_function_pointers<'a>(
         parameters_unused: TokenStream,
         returns: TokenStream,
         parameter_validstructs: Vec<(Ident, Vec<String>)>,
+        provided_by: &'a ProvidedBy<'a>,
     }
 
     let commands = commands
         .iter()
         .map(|cmd| {
-            let name = &cmd.proto.name;
+            let name = &cmd.0.proto.name;
             let pfn_type_name = format_ident!("PFN_{}", name);
 
             // We might need to generate a function pointer for an extension, where we are given the original
@@ -920,6 +930,7 @@ fn generate_function_pointers<'a>(
             let type_name = format_ident!("{}", type_name);
 
             let params = cmd
+                .0
                 .params
                 .iter()
                 .filter(|param| matches!(param.api.as_deref(), None | Some(DESIRED_API)));
@@ -955,6 +966,7 @@ fn generate_function_pointers<'a>(
                 .collect();
 
             let ret = cmd
+                .0
                 .proto
                 .type_name
                 .as_ref()
@@ -979,6 +991,7 @@ fn generate_function_pointers<'a>(
                     quote!(-> #ret_ty_tokens)
                 },
                 parameter_validstructs,
+                provided_by: cmd.1,
             }
         })
         .collect::<Vec<_>>();
@@ -997,12 +1010,18 @@ fn generate_function_pointers<'a>(
                     "Implemented for all types that can be passed as argument to `{}` in [`{}`]",
                     param_ident, self.0.pfn_type_name
                 );
+                let provisional = self
+                    .0
+                    .provided_by
+                    .provisional
+                    .then(|| quote!(#[cfg(feature = "provisional")]));
                 let param_trait_name = format_ident!(
                     "{}Param{}",
                     self.0.type_name,
                     param_ident.to_upper_camel_case()
                 );
                 quote! {
+                    #provisional
                     #[allow(non_camel_case_types)]
                     #[doc = #doc_string]
                     pub unsafe trait #param_trait_name {}
@@ -1023,7 +1042,14 @@ fn generate_function_pointers<'a>(
             let type_name = &self.0.pfn_type_name;
             let parameters = &self.0.parameters;
             let returns = &self.0.returns;
+            let provisional = self
+                .0
+                .provided_by
+                .provisional
+                .then(|| quote!(#[cfg(feature = "provisional")]));
+
             quote!(
+                #provisional
                 #[allow(non_camel_case_types)]
                 pub type #type_name = unsafe extern "system" fn(#parameters) #returns;
             )
@@ -1142,13 +1168,17 @@ impl ConstantExt for ExtensionConstant<'_> {
     }
 }
 
+/// Generates constants for definitions inside `<extension>` or `<feature>` children.
+///
+/// External constants that are referred by name only are skipped.
 pub fn generate_extension_constants<'a>(
-    extension_name: &str,
     extension_number: i64,
     extension_items: &'a [vk_parse::ExtensionChild],
+    provided_by: &ProvidedBy<'_>,
     const_cache: &mut HashSet<&'a str>,
     const_values: &mut BTreeMap<Ident, ConstantTypeInfo>,
 ) -> TokenStream {
+    // TODO: We already read this at a higher level, why again??
     let items = extension_items
         .iter()
         .filter_map(get_variant!(vk_parse::ExtensionChild::Require {
@@ -1203,6 +1233,7 @@ pub fn generate_extension_constants<'a>(
                     ident: ext_constant.variant_ident(&extends),
                     is_alias: matches!(ext_constant.constant, Constant::Alias(_)),
                     is_deprecated: enum_.deprecated.is_some(),
+                    is_provisional: provided_by.provisional,
                 });
 
             extended_enums
@@ -1214,11 +1245,20 @@ pub fn generate_extension_constants<'a>(
 
     let enum_tokens = extended_enums.iter().map(|(extends, constants)| {
         let ident = name_to_tokens(extends);
+        let [extension_name] = provided_by.names[..] else {
+            unreachable!()
+        };
         let doc_string = format!("Generated from '{extension_name}'");
-        let impl_block = bitflags_impl_block(ident, extends, &constants.iter().collect_vec());
+        let provisional = provided_by
+            .provisional
+            .then(|| quote!(#[cfg(feature = "provisional")]));
+        let impl_block = bitflags_impl_contents(extends, &constants.iter().collect_vec());
         quote! {
             #[doc = #doc_string]
-            #impl_block
+            #provisional
+            impl #ident {
+                #impl_block
+            }
         }
     });
     quote!(#(#enum_tokens)*)
@@ -1231,13 +1271,13 @@ pub struct ExtensionCommands<'a> {
 }
 
 pub fn generate_extension_commands<'a>(
-    full_extension_name: &'a str,
-    items: &'a [vk_parse::ExtensionChild],
+    extension: &'a vk_parse::Extension,
     cmd_map: &CommandMap<'a>,
     cmd_aliases: &HashMap<&'a str, &'a str>,
     fn_cache: &mut HashSet<&'a str>,
     has_lifetimes: &HashSet<Ident>,
 ) -> ExtensionCommands<'a> {
+    let full_extension_name = &extension.name;
     let byte_name_ident = Literal::byte_string(format!("{full_extension_name}\0").as_bytes());
 
     let extension_name = full_extension_name.strip_prefix("VK_").unwrap();
@@ -1250,7 +1290,8 @@ pub fn generate_extension_commands<'a>(
 
     let name_ident = format_ident!("{}_NAME", extension_name.to_uppercase());
     let spec_version_ident = format_ident!("{}_SPEC_VERSION", extension_name.to_uppercase());
-    let spec_version = items
+    let spec_version = extension
+        .children
         .iter()
         .filter_map(get_variant!(vk_parse::ExtensionChild::Require { items }))
         .flatten()
@@ -1269,7 +1310,8 @@ pub fn generate_extension_commands<'a>(
     let mut device_commands = Vec::new();
 
     let mut rename_commands = HashMap::new();
-    let names = items
+    let names = extension
+        .children
         .iter()
         .filter_map(get_variant!(vk_parse::ExtensionChild::Require {
             api,
@@ -1290,7 +1332,7 @@ pub fn generate_extension_commands<'a>(
         }
 
         let command = cmd_map[name];
-        match command.function_type() {
+        match command.0.function_type() {
             FunctionType::Static | FunctionType::Entry => unreachable!(),
             FunctionType::Instance => instance_commands.push(command),
             FunctionType::Device => device_commands.push(command),
@@ -1401,18 +1443,25 @@ pub fn generate_extension_commands<'a>(
         )
     });
 
+    let provisional = extension
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
+
     ExtensionCommands {
         vendor,
         raw: quote! {
+                #provisional
                 pub const #name_ident: &CStr = unsafe {
                     CStr::from_bytes_with_nul_unchecked(#byte_name_ident)
                 };
+                #provisional
                 #spec_version
                 #raw_instance_fp
                 #raw_device_fp
         },
         high_level: quote! {
             #[doc = #full_extension_name]
+            #provisional
             pub mod #extension_ident {
                 #hl_imports
 
@@ -1427,80 +1476,89 @@ pub fn generate_extension_commands<'a>(
 
 pub fn generate_define(
     define: &vk_parse::Type,
-    allowed_types: &HashSet<&str>,
+    allowed_types: &HashMap<&str, ProvidedBy<'_>>,
     identifier_renames: &mut BTreeMap<String, Ident>,
-) -> TokenStream {
+) -> Option<TokenStream> {
     let vk_parse::TypeSpec::Code(spec) = &define.spec else {
-        return quote!();
+        return None;
     };
     let [vk_parse::TypeCodeMarkup::Name(define_name), ..] = &spec.markup[..] else {
-        return quote!();
+        return None;
     };
 
-    if !allowed_types.contains(define_name.as_str()) {
-        return quote!();
-    }
+    let provided_by = allowed_types.get(define_name.as_str())?;
 
     let name = constant_name(define_name);
     let ident = format_ident!("{}", name);
 
-    if define_name.contains("VERSION") && !spec.code.contains("//#define") {
-        let link = khronos_link(define_name);
-        let (c_expr, (comment, (_name, parameters))) = parse_c_define_header(&spec.code).unwrap();
-        let c_expr = c_expr.trim().trim_start_matches('\\');
-        let c_expr = c_expr.replace("(uint32_t)", "");
-        let c_expr = convert_c_expression(&c_expr, identifier_renames);
-        let c_expr = discard_outmost_delimiter(c_expr);
-
-        let deprecated = comment
-            .and_then(|c| c.trim().strip_prefix("DEPRECATED: "))
-            .map(|comment| quote!(#[deprecated = #comment]))
-            .or_else(|| match define.deprecated.as_ref()?.as_str() {
-                "true" => Some(quote!(#[deprecated])),
-                x => panic!("Unknown deprecation reason {x}"),
-            });
-
-        let (code, ident) = if let Some(parameters) = parameters {
-            let params = parameters
-                .iter()
-                .map(|param| format_ident!("{}", param))
-                .map(|i| quote!(#i: u32));
-            let ident = format_ident!("{}", name.to_lowercase());
-            (
-                quote!(pub const fn #ident(#(#params),*) -> u32 { #c_expr }),
-                ident,
-            )
-        } else {
-            (quote!(pub const #ident: u32 = #c_expr;), ident)
-        };
-
-        identifier_renames.insert(define_name.clone(), ident);
-
-        quote! {
-            #deprecated
-            #[doc = #link]
-            #code
-        }
-    } else {
-        quote!()
+    if !define_name.contains("VERSION") || spec.code.contains("//#define") {
+        return None;
     }
+    let khronos_link = khronos_link(define_name);
+    let (c_expr, (comment, (_name, parameters))) = parse_c_define_header(&spec.code).unwrap();
+    let c_expr = c_expr.trim().trim_start_matches('\\');
+    let c_expr = c_expr.replace("(uint32_t)", "");
+    let c_expr = convert_c_expression(&c_expr, identifier_renames);
+    let c_expr = discard_outmost_delimiter(c_expr);
+
+    let deprecated = comment
+        .and_then(|c| c.trim().strip_prefix("DEPRECATED: "))
+        .map(|comment| quote!(#[deprecated = #comment]))
+        .or_else(|| match define.deprecated.as_ref()?.as_str() {
+            "true" => Some(quote!(#[deprecated])),
+            x => panic!("Unknown deprecation reason {}", x),
+        });
+
+    let (code, ident) = if let Some(parameters) = parameters {
+        let params = parameters
+            .iter()
+            .map(|param| format_ident!("{}", param))
+            .map(|i| quote!(#i: u32));
+        let ident = format_ident!("{}", name.to_lowercase());
+        (
+            quote!(pub const fn #ident(#(#params),*) -> u32 { #c_expr }),
+            ident,
+        )
+    } else {
+        (quote!(pub const #ident: u32 = #c_expr;), ident)
+    };
+
+    identifier_renames.insert(define_name.clone(), ident);
+
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
+
+    Some(quote! {
+        #provisional
+        #deprecated
+        #[doc = #khronos_link]
+        #code
+    })
 }
-pub fn generate_typedef(typedef: &vkxml::Typedef) -> TokenStream {
+pub fn generate_typedef(
+    typedef: &vkxml::Typedef,
+    provided_by: &ProvidedBy<'_>,
+) -> Option<TokenStream> {
     if typedef.basetype.is_empty() {
         // Ignore forward declarations
-        quote! {}
-    } else {
-        let typedef_name = name_to_tokens(&typedef.name);
-        let typedef_ty = name_to_tokens(&typedef.basetype);
-        let khronos_link = khronos_link(&typedef.name);
-        quote! {
-            #[doc = #khronos_link]
-            pub type #typedef_name = #typedef_ty;
-        }
+        return None;
     }
+    let typedef_name = name_to_tokens(&typedef.name);
+    let typedef_ty = name_to_tokens(&typedef.basetype);
+    let khronos_link = khronos_link(&typedef.name);
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
+    Some(quote! {
+        #provisional
+        #[doc = #khronos_link]
+        pub type #typedef_name = #typedef_ty;
+    })
 }
 pub fn generate_bitmask(
     bitmask: &vkxml::Bitmask,
+    provided_by: &ProvidedBy<'_>,
     bitflags_cache: &mut HashSet<Ident>,
     const_values: &mut BTreeMap<Ident, ConstantTypeInfo>,
 ) -> Option<TokenStream> {
@@ -1521,7 +1579,11 @@ pub fn generate_bitmask(
     const_values.insert(ident.clone(), Default::default());
     let khronos_link = khronos_link(&bitmask.name);
     let type_ = name_to_tokens(&bitmask.basetype);
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
     Some(quote! {
+        #provisional
         #[repr(transparent)]
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[doc = #khronos_link]
@@ -1620,11 +1682,7 @@ pub fn variant_ident(enum_name: &str, variant_name: &str) -> Ident {
     }
 }
 
-fn bitflags_impl_block(
-    ident: Ident,
-    enum_name: &str,
-    constants: &[&impl ConstantExt],
-) -> TokenStream {
+fn bitflags_impl_contents(enum_name: &str, constants: &[&impl ConstantExt]) -> TokenStream {
     let variants = constants.iter().map(|constant| {
         let deprecated = constant.deprecated().map(|deprecated| match deprecated {
             "true" => quote!(#[deprecated]),
@@ -1646,15 +1704,12 @@ fn bitflags_impl_block(
         }
     });
 
-    quote! {
-        impl #ident {
-            #(#variants)*
-        }
-    }
+    quote!(#(#variants)*)
 }
 
 pub fn generate_enum<'a>(
     enum_: &'a vk_parse::Enums,
+    provided_by: &ProvidedBy<'a>,
     const_cache: &mut HashSet<&'a str>,
     const_values: &mut BTreeMap<Ident, ConstantTypeInfo>,
     bitflags_cache: &mut HashSet<Ident>,
@@ -1681,6 +1736,8 @@ pub fn generate_enum<'a>(
             ident: constant.variant_ident(name),
             is_alias: constant.is_alias(),
             is_deprecated: constant.deprecated.is_some(),
+            // Never provisional, because the surrounding enum would be provisional
+            is_provisional: false,
         });
     }
     const_values.insert(
@@ -1688,10 +1745,14 @@ pub fn generate_enum<'a>(
         ConstantTypeInfo {
             values,
             bitwidth: enum_.bitwidth,
+            is_provisional: provided_by.provisional,
         },
     );
 
     let khronos_link = khronos_link(name);
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
 
     if name.contains("Bit") {
         let ident = format_ident!("{}", clean_name);
@@ -1705,45 +1766,49 @@ pub fn generate_enum<'a>(
         if !bitflags_cache.insert(ident.clone()) {
             EnumType::Bitflags(quote! {})
         } else {
-            let impl_bitflags = bitflags_impl_block(ident.clone(), name, &constants);
+            let impl_block = bitflags_impl_contents(name, &constants);
             let q = quote! {
+                #provisional
                 #[repr(transparent)]
                 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
                 #[doc = #khronos_link]
                 pub struct #ident(pub(crate) #type_);
                 vk_bitflags_wrapped!(#ident, #type_);
-                #impl_bitflags
+                impl #ident {
+                    #impl_block
+                }
             };
             EnumType::Bitflags(q)
         }
     } else {
         let (struct_attribute, special_quote) = match clean_name.as_str() {
             //"StructureType" => generate_structure_type(&_name, _enum, create_info_constants),
-            "Result" => (quote!(#[must_use]), generate_result(ident.clone(), enum_)),
+            "Result" => {
+                assert!(provisional.is_none());
+                (quote!(#[must_use]), generate_result(ident.clone(), enum_))
+            }
             _ => (quote!(), quote!()),
         };
 
-        let impl_block = bitflags_impl_block(ident.clone(), name, &constants);
-        let enum_quote = quote! {
-            #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+        let impl_block = bitflags_impl_contents(name, &constants);
+        EnumType::Enum(quote! {
+            #provisional
             #[repr(transparent)]
-            #[doc = #khronos_link]
+            #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
             #struct_attribute
+            #[doc = #khronos_link]
             pub struct #ident(pub(crate) i32);
+            #provisional
             impl #ident {
                 #[inline]
                 pub const fn from_raw(x: i32) -> Self { Self(x) }
                 #[inline]
                 pub const fn as_raw(self) -> i32 { self.0 }
-            }
-            #impl_block
-        };
-        let q = quote! {
-            #enum_quote
-            #special_quote
 
-        };
-        EnumType::Enum(q)
+                #impl_block
+            }
+            #special_quote
+        })
     }
 }
 
@@ -1800,6 +1865,7 @@ fn derive_default(
     struct_: &vkxml::Struct,
     members: &[PreprocessedMember<'_>],
     has_lifetime: bool,
+    provisional: &Option<TokenStream>,
 ) -> Option<TokenStream> {
     let name = name_to_tokens(&struct_.name);
     let is_structure_type = |field: &vkxml::Field| field.basetype == "VkStructureType";
@@ -1858,7 +1924,8 @@ fn derive_default(
     });
     let lifetime = has_lifetime.then(|| quote!(<'_>));
     let marker = has_lifetime.then(|| quote!(_marker: PhantomData,));
-    let q = quote! {
+    Some(quote! {
+        #provisional
         impl ::core::default::Default for #name #lifetime {
             #[inline]
             fn default() -> Self {
@@ -1871,11 +1938,14 @@ fn derive_default(
                 }
             }
         }
-    };
-    Some(q)
+    })
 }
 
-fn derive_send_sync(struct_: &vkxml::Struct, has_lifetime: bool) -> Option<TokenStream> {
+fn derive_send_sync(
+    struct_: &vkxml::Struct,
+    has_lifetime: bool,
+    provisional: &Option<TokenStream>,
+) -> Option<TokenStream> {
     if !struct_
         .elements
         .iter()
@@ -1888,7 +1958,9 @@ fn derive_send_sync(struct_: &vkxml::Struct, has_lifetime: bool) -> Option<Token
     let name = name_to_tokens(&struct_.name);
     let lifetime = has_lifetime.then(|| quote!(<'_>));
     let q = quote! {
+        #provisional
         unsafe impl Send for #name #lifetime {}
+        #provisional
         unsafe impl Sync for #name #lifetime {}
     };
     Some(q)
@@ -1899,6 +1971,7 @@ fn derive_debug(
     members: &[PreprocessedMember<'_>],
     union_types: &HashSet<&str>,
     has_lifetime: bool,
+    provisional: &Option<TokenStream>,
 ) -> Option<TokenStream> {
     let name = name_to_tokens(&struct_.name);
     let contains_pfn = members.iter().any(|member| {
@@ -1949,6 +2022,7 @@ fn derive_debug(
     let name_str = name.to_string();
     let lifetime = has_lifetime.then(|| quote!(<'_>));
     let q = quote! {
+        #provisional
         #[cfg(feature = "debug")]
         impl fmt::Debug for #name #lifetime {
             fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1965,6 +2039,8 @@ fn derive_getters_and_setters(
     struct_: &vkxml::Struct,
     members: &[PreprocessedMember<'_>],
     has_lifetimes: &HashSet<Ident>,
+    provisional: &Option<TokenStream>,
+    allowed_types: &HashMap<&str, ProvidedBy<'_>>,
 ) -> Option<TokenStream> {
     if &struct_.name == "VkBaseInStructure"
         || &struct_.name == "VkBaseOutStructure"
@@ -2290,8 +2366,16 @@ fn derive_getters_and_setters(
         .flat_map(|extends| extends.split(','))
         .map(|extends| {
             let base = name_to_tokens(extends);
+            let provisional = if allowed_types.get(extends).is_some_and(|p| p.provisional) {
+                Some(quote!(#[cfg(feature = "provisional")]))
+            } else {
+                provisional.clone()
+            };
             // Extension structs always have a pNext, and therefore always have a lifetime.
-            quote!(unsafe impl Extends<#base<'_>> for #name<'_> {})
+            quote! {
+                #provisional
+                unsafe impl Extends<#base<'_>> for #name<'_> {}
+            }
         });
 
     let impl_structure_type_trait = structure_type_field.map(|member| {
@@ -2306,6 +2390,7 @@ fn derive_getters_and_setters(
 
         let value = variant_ident("VkStructureType", value);
         quote! {
+            #provisional
             unsafe impl<'a> TaggedStructure<'a> for #name<'a> {
                 const STRUCTURE_TYPE: StructureType = StructureType::#value;
             }
@@ -2315,7 +2400,7 @@ fn derive_getters_and_setters(
     let q = quote! {
         #impl_structure_type_trait
         #(#impl_extend_trait)*
-
+        #provisional
         impl #lifetime #name #lifetime {
             #(#setters)*
         }
@@ -2344,6 +2429,8 @@ struct PreprocessedMember<'a> {
 
 pub fn generate_struct(
     struct_: &vkxml::Struct,
+    provided_by: &ProvidedBy<'_>,
+    allowed_types: &HashMap<&str, ProvidedBy<'_>>,
     vk_parse_types: &HashMap<String, &vk_parse::Type>,
     union_types: &HashSet<&str>,
     has_lifetimes: &HashSet<Ident>,
@@ -2354,8 +2441,14 @@ pub fn generate_struct(
         panic!()
     };
 
+    let khronos_link = khronos_link(&struct_.name);
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
+
     if &struct_.name == "VkTransformMatrixKHR" {
         return quote! {
+            #provisional
             #[repr(C)]
             #[derive(Copy, Clone)]
             pub struct TransformMatrixKHR {
@@ -2366,15 +2459,17 @@ pub fn generate_struct(
 
     if &struct_.name == "VkAccelerationStructureInstanceKHR" {
         return quote! {
+            #provisional
             #[repr(C)]
             #[derive(Copy, Clone)]
             pub union AccelerationStructureReferenceKHR {
                 pub device_handle: DeviceAddress,
                 pub host_handle: AccelerationStructureKHR,
             }
+            #provisional
             #[repr(C)]
             #[derive(Copy, Clone)]
-            #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureInstanceKHR.html>"]
+            #[doc = #khronos_link]
             pub struct AccelerationStructureInstanceKHR {
                 pub transform: TransformMatrixKHR,
                 /// Use [`Packed24_8::new(instance_custom_index, mask)`][Packed24_8::new()] to construct this field
@@ -2388,9 +2483,10 @@ pub fn generate_struct(
 
     if &struct_.name == "VkAccelerationStructureSRTMotionInstanceNV" {
         return quote! {
+            #provisional
             #[repr(C)]
             #[derive(Copy, Clone)]
-            #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureSRTMotionInstanceNV.html>"]
+            #[doc = #khronos_link]
             pub struct AccelerationStructureSRTMotionInstanceNV {
                 pub transform_t0: SRTDataNV,
                 pub transform_t1: SRTDataNV,
@@ -2405,9 +2501,10 @@ pub fn generate_struct(
 
     if &struct_.name == "VkAccelerationStructureMatrixMotionInstanceNV" {
         return quote! {
+            #provisional
             #[repr(C)]
             #[derive(Copy, Clone)]
-            #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/AccelerationStructureMatrixMotionInstanceNV.html>"]
+            #[doc = #khronos_link]
             pub struct AccelerationStructureMatrixMotionInstanceNV {
                 pub transform_t0: TransformMatrixKHR,
                 pub transform_t1: TransformMatrixKHR,
@@ -2477,26 +2574,32 @@ pub fn generate_struct(
         false => (quote!(), quote!()),
     };
 
-    let debug_tokens = derive_debug(struct_, &members, union_types, has_lifetime);
-    let default_tokens = derive_default(struct_, &members, has_lifetime);
-    let send_sync_tokens = derive_send_sync(struct_, has_lifetime);
-    let setter_tokens = derive_getters_and_setters(struct_, &members, has_lifetimes);
+    let debug_tokens = derive_debug(struct_, &members, union_types, has_lifetime, &provisional);
+    let default_tokens = derive_default(struct_, &members, has_lifetime, &provisional);
+    let send_sync_tokens = derive_send_sync(struct_, has_lifetime, &provisional);
+    let setter_tokens = derive_getters_and_setters(
+        struct_,
+        &members,
+        has_lifetimes,
+        &provisional,
+        allowed_types,
+    );
     let manual_derive_tokens = manual_derives(struct_);
-    let dbg_str = if debug_tokens.is_none() {
+    let derive_debug = if debug_tokens.is_none() {
         quote!(#[cfg_attr(feature = "debug", derive(Debug))])
     } else {
         quote!()
     };
-    let default_str = if default_tokens.is_none() {
+    let derive_default = if default_tokens.is_none() {
         quote!(Default,)
     } else {
         quote!()
     };
-    let khronos_link = khronos_link(&struct_.name);
     quote! {
+        #provisional
         #[repr(C)]
-        #dbg_str
-        #[derive(Copy, Clone, #default_str #manual_derive_tokens)]
+        #derive_debug
+        #[derive(Copy, Clone, #derive_default #manual_derive_tokens)]
         #[doc = #khronos_link]
         #[must_use]
         pub struct #name #lifetimes {
@@ -2510,32 +2613,34 @@ pub fn generate_struct(
     }
 }
 
-pub fn generate_handle(handle: &vkxml::Handle) -> Option<TokenStream> {
+pub fn generate_handle(
+    handle: &vkxml::Handle,
+    provided_by: &ProvidedBy<'_>,
+) -> Option<TokenStream> {
     if handle.name.is_empty() {
         return None;
     }
     let khronos_link = khronos_link(&handle.name);
-    let tokens = match handle.ty {
+    let name = handle.name.strip_prefix("Vk").unwrap();
+    let ty = format_ident!("{}", name.to_shouty_snake_case());
+    let name = format_ident!("{}", name);
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(, cfg(feature = "provisional")));
+    Some(match handle.ty {
         vkxml::HandleType::Dispatch => {
-            let name = handle.name.strip_prefix("Vk").unwrap();
-            let ty = format_ident!("{}", name.to_shouty_snake_case());
-            let name = format_ident!("{}", name);
-            quote! {
-                define_handle!(#name, #ty, doc = #khronos_link);
-            }
+            quote!(define_handle!(#name, #ty, doc = #khronos_link #provisional);)
         }
         vkxml::HandleType::NoDispatch => {
-            let name = handle.name.strip_prefix("Vk").unwrap();
-            let ty = format_ident!("{}", name.to_shouty_snake_case());
-            let name = format_ident!("{}", name);
-            quote! {
-                handle_nondispatchable!(#name, #ty, doc = #khronos_link);
-            }
+            quote!(handle_nondispatchable!(#name, #ty, doc = #khronos_link #provisional);)
         }
-    };
-    Some(tokens)
+    })
 }
-fn generate_funcptr(fnptr: &vkxml::FunctionPointer, has_lifetimes: &HashSet<Ident>) -> TokenStream {
+fn generate_funcptr(
+    fnptr: &vkxml::FunctionPointer,
+    provided_by: &ProvidedBy<'_>,
+    has_lifetimes: &HashSet<Ident>,
+) -> Option<TokenStream> {
     let name = format_ident!("{}", fnptr.name);
     let ret_ty_tokens = if fnptr.return_type.is_void() {
         quote!()
@@ -2554,14 +2659,22 @@ fn generate_funcptr(fnptr: &vkxml::FunctionPointer, has_lifetimes: &HashSet<Iden
         }
     });
     let khronos_link = khronos_link(&fnptr.name);
-    quote! {
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
+    Some(quote! {
+        #provisional
         #[allow(non_camel_case_types)]
         #[doc = #khronos_link]
         pub type #name = Option<unsafe extern "system" fn(#(#params),*) #ret_ty_tokens>;
-    }
+    })
 }
 
-fn generate_union(union: &vkxml::Union, has_lifetimes: &HashSet<Ident>) -> TokenStream {
+fn generate_union(
+    union: &vkxml::Union,
+    provided_by: &ProvidedBy<'_>,
+    has_lifetimes: &HashSet<Ident>,
+) -> Option<TokenStream> {
     let name = name_to_tokens(&union.name);
     let fields = union.elements.iter().map(|field| {
         let name = field.param_ident();
@@ -2574,25 +2687,30 @@ fn generate_union(union: &vkxml::Union, has_lifetimes: &HashSet<Ident>) -> Token
         }
     });
     let khronos_link = khronos_link(&union.name);
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
     let lifetime = has_lifetimes.contains(&name).then(|| quote!(<'a>));
-    quote! {
+    Some(quote! {
+        #provisional
         #[repr(C)]
         #[derive(Copy, Clone)]
         #[doc = #khronos_link]
         pub union #name #lifetime {
             #(#fields),*
         }
+        #provisional
         impl #lifetime ::core::default::Default for #name #lifetime {
             #[inline]
             fn default() -> Self {
                 unsafe { ::core::mem::zeroed() }
             }
         }
-    }
+    })
 }
 pub fn generate_definition_vk_parse(
     definition: &vk_parse::Type,
-    allowed_types: &HashSet<&str>,
+    allowed_types: &HashMap<&str, ProvidedBy<'_>>,
     identifier_renames: &mut BTreeMap<String, Ident>,
 ) -> Option<TokenStream> {
     if let Some(api) = &definition.api {
@@ -2602,18 +2720,14 @@ pub fn generate_definition_vk_parse(
     }
 
     match definition.category.as_deref() {
-        Some("define") => Some(generate_define(
-            definition,
-            allowed_types,
-            identifier_renames,
-        )),
+        Some("define") => generate_define(definition, allowed_types, identifier_renames),
         _ => None,
     }
 }
 #[allow(clippy::too_many_arguments)]
 pub fn generate_definition(
     definition: &vkxml::DefinitionsElement,
-    allowed_types: &HashSet<&str>,
+    allowed_types: &HashMap<&str, ProvidedBy<'_>>,
     union_types: &HashSet<&str>,
     has_lifetimes: &HashSet<Ident>,
     vk_parse_types: &HashMap<String, &vk_parse::Type>,
@@ -2621,45 +2735,44 @@ pub fn generate_definition(
     const_values: &mut BTreeMap<Ident, ConstantTypeInfo>,
 ) -> Option<TokenStream> {
     match *definition {
-        vkxml::DefinitionsElement::Typedef(ref typedef)
-            if allowed_types.contains(typedef.name.as_str()) =>
-        {
-            Some(generate_typedef(typedef))
+        vkxml::DefinitionsElement::Typedef(ref typedef) => {
+            let provided_by = allowed_types.get(typedef.name.as_str())?;
+            generate_typedef(typedef, provided_by)
         }
-        vkxml::DefinitionsElement::Struct(ref struct_)
-            if allowed_types.contains(struct_.name.as_str()) =>
-        {
+        vkxml::DefinitionsElement::Struct(ref struct_) => {
+            let provided_by = allowed_types.get(struct_.name.as_str())?;
+
             Some(generate_struct(
                 struct_,
+                provided_by,
+                allowed_types,
                 vk_parse_types,
                 union_types,
                 has_lifetimes,
             ))
         }
-        vkxml::DefinitionsElement::Bitmask(ref mask)
-            if allowed_types.contains(mask.name.as_str()) =>
-        {
-            generate_bitmask(mask, bitflags_cache, const_values)
+        vkxml::DefinitionsElement::Bitmask(ref mask) => {
+            let provided_by = allowed_types.get(mask.name.as_str())?;
+            generate_bitmask(mask, provided_by, bitflags_cache, const_values)
         }
-        vkxml::DefinitionsElement::Handle(ref handle)
-            if allowed_types.contains(handle.name.as_str()) =>
-        {
-            generate_handle(handle)
+        vkxml::DefinitionsElement::Handle(ref handle) => {
+            let provided_by = allowed_types.get(handle.name.as_str())?;
+            generate_handle(handle, provided_by)
         }
-        vkxml::DefinitionsElement::FuncPtr(ref fp) if allowed_types.contains(fp.name.as_str()) => {
-            Some(generate_funcptr(fp, has_lifetimes))
+        vkxml::DefinitionsElement::FuncPtr(ref fp) => {
+            let provided_by = allowed_types.get(fp.name.as_str())?;
+            generate_funcptr(fp, provided_by, has_lifetimes)
         }
-        vkxml::DefinitionsElement::Union(ref union)
-            if allowed_types.contains(union.name.as_str()) =>
-        {
-            Some(generate_union(union, has_lifetimes))
+        vkxml::DefinitionsElement::Union(ref union) => {
+            let provided_by = allowed_types.get(union.name.as_str())?;
+            generate_union(union, provided_by, has_lifetimes)
         }
         _ => None,
     }
 }
 pub fn generate_feature<'a>(
     feature: &vkxml::Feature,
-    commands: &CommandMap<'a>,
+    commands: &'a CommandMap<'a>,
     fn_cache: &mut HashSet<&'a str>,
     has_lifetimes: &HashSet<Ident>,
 ) -> (TokenStream, TokenStream) {
@@ -2673,11 +2786,11 @@ pub fn generate_feature<'a>(
         .filter_map(get_variant!(vkxml::FeatureElement::Require))
         .flat_map(|spec| &spec.elements)
         .filter_map(get_variant!(vkxml::FeatureReference::CommandReference))
-        .filter_map(|cmd_ref| commands.get(&cmd_ref.name))
+        .filter_map(|cmd_ref| commands.get(cmd_ref.name.as_str()))
         .fold(
             (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
             |mut accs, &cmd_ref| {
-                let acc = match cmd_ref.function_type() {
+                let acc = match cmd_ref.0.function_type() {
                     FunctionType::Static => &mut accs.0,
                     FunctionType::Entry => &mut accs.1,
                     FunctionType::Device => &mut accs.2,
@@ -2755,12 +2868,17 @@ pub fn constant_name(name: &str) -> &str {
 
 pub fn generate_constant<'a>(
     constant: &'a vk_parse::Enum,
+    provided_by: &ProvidedBy<'a>,
     global_const_cache: &mut HashMap<&'a str, CType>,
 ) -> TokenStream {
     let (c, _) = Constant::from_vk_parse_enum(constant, None, None).unwrap();
     let name = constant_name(&constant.name);
     let ident = format_ident!("{}", name);
     let notation = constant.doc_attribute();
+    let provisional = provided_by
+        .provisional
+        .then(|| quote!(#[cfg(feature = "provisional")]));
+
     let ty = if let Constant::Alias(a) = &c {
         // vk.xml currently defines all constants (with their type) before emitting any aliases
         // against it, allowing us to assert that the type is directly available here:
@@ -2773,6 +2891,7 @@ pub fn generate_constant<'a>(
     global_const_cache.insert(name, ty);
     quote! {
         #notation
+        #provisional
         pub const #ident: #ty = #c;
     }
 }
@@ -2789,9 +2908,13 @@ pub fn generate_feature_extension<'a>(
         .filter(|feature| contains_desired_api(&feature.api))
         .map(|feature| {
             generate_extension_constants(
-                &feature.name,
                 0,
                 &feature.children,
+                // TODO: the high-level already provided this structure, probably shouldn't iterate per feature again here.
+                &ProvidedBy {
+                    names: vec![&feature.name], // TODO: Collect alias names too!
+                    provisional: false,
+                },
                 const_cache,
                 const_values,
             )
@@ -2805,12 +2928,14 @@ pub struct ConstantMatchInfo {
     pub ident: Ident,
     pub is_alias: bool,
     pub is_deprecated: bool,
+    pub is_provisional: bool,
 }
 
 #[derive(Default)]
 pub struct ConstantTypeInfo {
     values: Vec<ConstantMatchInfo>,
     bitwidth: Option<u32>,
+    pub is_provisional: bool,
 }
 
 pub struct ConstDebugs {
@@ -2822,15 +2947,23 @@ pub fn generate_const_debugs(const_values: &BTreeMap<Ident, ConstantTypeInfo>) -
     let mut core = Vec::new();
     let mut extras = Vec::new();
     for (ty, values) in const_values {
-        let ConstantTypeInfo { values, bitwidth } = values;
+        let ConstantTypeInfo {
+            values,
+            bitwidth,
+            is_provisional,
+        } = values;
+        let provisional = is_provisional.then(|| quote!(#[cfg(feature = "provisional")]));
         let out = if ty.to_string().contains("Flags") {
             let cases = values.iter().filter_map(|value| {
                 if value.is_alias {
                     None
                 } else {
+                    let provisional = value
+                        .is_provisional
+                        .then(|| quote!(#[cfg(feature = "provisional")]));
                     let ident = &value.ident;
                     let name = ident.to_string();
-                    Some(quote! { (#ty::#ident.0, #name) })
+                    Some(quote! { #provisional (#ty::#ident.0, #name) })
                 }
             });
 
@@ -2841,6 +2974,7 @@ pub fn generate_const_debugs(const_values: &BTreeMap<Ident, ConstantTypeInfo>) -
             };
 
             quote! {
+                #provisional
                 impl fmt::Debug for #ty {
                     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         const KNOWN: &[(#type_, &str)] = &[#(#cases),*];
@@ -2857,10 +2991,14 @@ pub fn generate_const_debugs(const_values: &BTreeMap<Ident, ConstantTypeInfo>) -
                     let name = ident.to_string();
                     let allow_deprecated =
                         value.is_deprecated.then(|| quote!(#[allow(deprecated)]));
-                    Some(quote! { #allow_deprecated Self::#ident => Some(#name), })
+                    let provisional = value
+                        .is_provisional
+                        .then(|| quote!(#[cfg(feature = "provisional")]));
+                    Some(quote! { #provisional #allow_deprecated Self::#ident => Some(#name), })
                 }
             });
             quote! {
+                #provisional
                 impl fmt::Debug for #ty {
                     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         let name = match *self {
@@ -2940,37 +3078,23 @@ pub fn extract_native_types(registry: &vk_parse::Registry) -> (Vec<(String, Stri
 
     (header_includes, header_types)
 }
-pub fn generate_aliases_of_types(
-    types: &vk_parse::Types,
-    allowed_types: &HashSet<&str>,
+pub fn generate_alias_of_type(
+    ty: &vk_parse::Type,
     has_lifetimes: &HashSet<Ident>,
     ty_cache: &mut HashSet<Ident>,
-) -> TokenStream {
-    let aliases = types
-        .children
-        .iter()
-        .filter_map(get_variant!(vk_parse::TypesChild::Type))
-        .filter_map(|ty| {
-            let name = ty.name.as_ref()?;
-            if !allowed_types.contains(name.as_str()) {
-                return None;
-            }
-            let alias = ty.alias.as_ref()?;
-            let name_ident = name_to_tokens(name);
-            if !ty_cache.insert(name_ident.clone()) {
-                return None;
-            };
-            let alias_ident = name_to_tokens(alias);
-            let tokens = if has_lifetimes.contains(&alias_ident) {
-                quote!(pub type #name_ident<'a> = #alias_ident<'a>;)
-            } else {
-                quote!(pub type #name_ident = #alias_ident;)
-            };
-            Some(tokens)
-        });
-    quote! {
-        #(#aliases)*
-    }
+) -> Option<TokenStream> {
+    let name = ty.name.as_ref()?;
+    let alias = ty.alias.as_ref()?;
+    let name_ident = name_to_tokens(name);
+    if !ty_cache.insert(name_ident.clone()) {
+        return None;
+    };
+    let alias_ident = name_to_tokens(alias);
+    Some(if has_lifetimes.contains(&alias_ident) {
+        quote!(pub type #name_ident<'a> = #alias_ident<'a>;)
+    } else {
+        quote!(pub type #name_ident = #alias_ident;)
+    })
 }
 pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let vk_xml = vk_headers_dir.join("registry/vk.xml");
@@ -3025,32 +3149,73 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .filter_map(get_variant!(vk_parse::EnumsChild::Enum))
         .collect();
 
+    /// Minimized, generalized description of [`vk_parse::Feature`] and [`vk_parse::Extension`]
+    #[derive(Clone, Debug)]
+    struct FeatureDescription<'a> {
+        name: &'a str,
+        provisional: bool,
+        children: &'a Vec<vk_parse::ExtensionChild>,
+    }
+
     let features_children = spec2
         .0
         .iter()
         .filter_map(get_variant!(vk_parse::RegistryChild::Feature))
         .filter(|feature| contains_desired_api(&feature.api))
-        .flat_map(|features| &features.children);
-
-    let extension_children = extensions.iter().flat_map(|extension| &extension.children);
-
-    let (required_types, required_commands) = features_children
-        .chain(extension_children)
-        .filter_map(get_variant!(vk_parse::FeatureChild::Require { api, items }))
-        .filter(|(api, _items)| matches!(api.as_deref(), None | Some(DESIRED_API)))
-        .flat_map(|(_api, items)| items)
-        .fold((HashSet::new(), HashSet::new()), |mut acc, elem| {
-            match elem {
-                vk_parse::InterfaceItem::Type { name, .. } => {
-                    acc.0.insert(name.as_str());
-                }
-                vk_parse::InterfaceItem::Command { name, .. } => {
-                    acc.1.insert(name.as_str());
-                }
-                _ => {}
-            };
-            acc
+        .map(|features| FeatureDescription {
+            name: &features.name,
+            provisional: false,
+            children: &features.children,
         });
+
+    let extension_children = extensions.iter().map(|extension| FeatureDescription {
+        name: &extension.name,
+        provisional: extension.provisional,
+        children: &extension.children,
+    });
+
+    let mut required_types = HashMap::<_, ProvidedBy<'_>>::new();
+    let mut required_commands = HashMap::<_, ProvidedBy<'_>>::new();
+    let mut required_enums = HashMap::<_, ProvidedBy<'_>>::new();
+    for feature in features_children.chain(extension_children) {
+        for child in feature.children {
+            let vk_parse::FeatureChild::Require { api, items, .. } = child else {
+                continue;
+            };
+            if !matches!(api.as_deref(), None | Some(DESIRED_API)) {
+                continue;
+            }
+            for elem in items {
+                let provided_by = match elem {
+                    vk_parse::InterfaceItem::Type { name, .. } => {
+                        required_types.entry(name.as_str())
+                    }
+                    vk_parse::InterfaceItem::Command { name, .. } => {
+                        required_commands.entry(name.as_str())
+                    }
+                    vk_parse::InterfaceItem::Enum(vk_parse::Enum {
+                        name,
+                        spec: vk_parse::EnumSpec::None,
+                        ..
+                    }) => required_enums.entry(name.as_str()),
+                    _ => continue,
+                };
+                match provided_by {
+                    Entry::Occupied(mut e) => {
+                        let provided_by = e.get_mut();
+                        assert_eq!(provided_by.provisional, feature.provisional);
+                        provided_by.names.push(feature.name);
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(ProvidedBy {
+                            names: vec![feature.name],
+                            provisional: feature.provisional,
+                        });
+                    }
+                }
+            }
+        }
+    }
 
     let commands: CommandMap<'_> = spec2
         .0
@@ -3058,8 +3223,11 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .filter_map(get_variant!(vk_parse::RegistryChild::Commands))
         .flat_map(|cmds| &cmds.children)
         .filter_map(get_variant!(vk_parse::Command::Definition))
-        .filter(|cmd| required_commands.contains(&cmd.proto.name.as_str()))
-        .map(|cmd| (cmd.proto.name.clone(), cmd))
+        .filter_map(|cmd| {
+            required_commands
+                .get(cmd.proto.name.as_str())
+                .map(|feature| (cmd.proto.name.as_str(), (cmd, feature)))
+        })
         .collect();
 
     let cmd_aliases: HashMap<_, _> = spec2
@@ -3068,7 +3236,8 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .filter_map(get_variant!(vk_parse::RegistryChild::Commands))
         .flat_map(|cmds| &cmds.children)
         .filter_map(get_variant!(vk_parse::Command::Alias { name, alias }))
-        .filter(|(name, _alias)| required_commands.contains(name.as_str()))
+        // TODO: Pass through feature info
+        .filter(|(name, _alias)| required_commands.contains_key(name.as_str()))
         .map(|(name, alias)| (name.as_str(), alias.as_str()))
         .collect();
 
@@ -3082,14 +3251,22 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .0
         .iter()
         .filter_map(get_variant!(vk_parse::RegistryChild::Enums))
-        .filter(|enums| enums.kind.is_some())
-        .filter(|enums| {
-            enums
-                .name
-                .as_ref()
-                .is_none_or(|n| required_types.contains(n.replace("FlagBits", "Flags").as_str()))
+        // .filter(|enums| enums.kind.is_some())
+        .filter(|enums| matches!(enums.kind.as_deref(), Some("enum" | "bitmask")))
+        .filter_map(|e| {
+            let n = e.name.as_ref().unwrap();
+            let t = required_types.get(n.replace("FlagBits", "Flags").as_str())?;
+            Some((e, t))
         })
-        .map(|e| generate_enum(e, &mut const_cache, &mut const_values, &mut bitflags_cache))
+        .map(|(e, p)| {
+            generate_enum(
+                e,
+                p,
+                &mut const_cache,
+                &mut const_values,
+                &mut bitflags_cache,
+            )
+        })
         .fold((Vec::new(), Vec::new()), |mut acc, elem| {
             match elem {
                 EnumType::Enum(token) => acc.0.push(token),
@@ -3101,7 +3278,10 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let mut global_const_cache = HashMap::new();
     let constants_code: Vec<_> = constants
         .iter()
-        .map(|constant| generate_constant(constant, &mut global_const_cache))
+        .map(|constant| {
+            let provided_by = required_enums.get(constant.name.as_str()).unwrap();
+            generate_constant(constant, provided_by, &mut global_const_cache)
+        })
         .collect();
 
     let union_types = definitions
@@ -3168,9 +3348,12 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .iter()
         .map(|ext| {
             generate_extension_constants(
-                &ext.name,
-                ext.number.unwrap_or(0),
+                ext.number.unwrap(),
                 &ext.children,
+                &ProvidedBy {
+                    names: vec![&ext.name], // TODO: Collect alias names too!
+                    provisional: ext.provisional,
+                },
                 &mut const_cache,
                 &mut const_values,
             )
@@ -3181,8 +3364,7 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     let mut extension_cmds = Vec::<TokenStream>::new();
     for ext in extensions.iter() {
         let cmds = generate_extension_commands(
-            &ext.name,
-            &ext.children,
+            ext,
             &commands,
             &cmd_aliases,
             &mut fn_cache,
@@ -3226,9 +3408,9 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .into_iter()
         .filter_map(|t| t.name.clone().map(|n| (n, t)))
         .collect::<HashMap<_, _>>();
-    let definition_code: Vec<_> = vk_parse_definitions
+    let vk_parse_types: Vec<_> = definitions
         .into_iter()
-        .chain(definitions.into_iter().filter_map(|def| {
+        .filter_map(|def| {
             generate_definition(
                 def,
                 &required_types,
@@ -3238,7 +3420,7 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
                 &mut bitflags_cache,
                 &mut const_values,
             )
-        }))
+        })
         .collect();
 
     let mut ty_cache = HashSet::new();
@@ -3246,7 +3428,14 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         .0
         .iter()
         .filter_map(get_variant!(vk_parse::RegistryChild::Types))
-        .map(|ty| generate_aliases_of_types(ty, &required_types, &has_lifetimes, &mut ty_cache))
+        .flat_map(|types| &types.children)
+        .filter_map(get_variant!(vk_parse::TypesChild::Type))
+        .filter(|ty| {
+            ty.name
+                .as_ref()
+                .is_some_and(|name| required_types.contains_key(name.as_str()))
+        })
+        .filter_map(|ty| generate_alias_of_type(ty, &has_lifetimes, &mut ty_cache))
         .collect();
 
     let (feature_fp_code, feature_table_code): (Vec<_>, Vec<_>) = features
@@ -3306,7 +3495,8 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         use core::ffi::*;
         use core::fmt;
         use core::marker::PhantomData;
-        #(#definition_code)*
+        #(#vk_parse_definitions)*
+        #(#vk_parse_types)*
     };
 
     let enum_code = quote! {


### PR DESCRIPTION
Fixes #343

Provisional extensions are susceptible to **breaking** API changes at any point (with accompanying `SPEC_VERSION` bump).  By hiding them behind a non-default feature flag, we can document that opting into this feature allows us to do breaking changes to these modules in non-breaking `ash` releases when driven by upstream `Vulkan-Headers` changes to `vk.xml`.

Moreover, upstream Khronos repositories that build `ash` in their CI can continue to build-test their changes without compile-testing any extension behind a `provisional` flag, which is especially useful if we've already wrapped a `provisonal` extension that is seeing breaking changes.

---

One important feature that is missing in this PR and the reason for its draft state is that we don't yet wrap any types `<require>`d by provisional changes.  While these types are unlikely to be useful without enabling the extension, non-breaking releases with breaking changes to such types should be considered invalid.  And there may be provisional extensions that solely consist of new types (extending existing types via `pNext`).

Secondly, feature flags may not technically exempt us from semver compatibility in releases, even if the feature flag is documented as such.  We could "do this anyway" for simplicity, or move to something more aggressive like `cfg` definitions.
