### PR TITLE
examples: Import `align_of()` from `mem` to build on on MSRV < 1.80

### DIFF
--- a/ash-examples/src/bin/texture.rs
+++ b/ash-examples/src/bin/texture.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use std::ffi;
 use std::io::Cursor;
 use std::mem;
-use std::mem::{size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
+use std::mem::{align_of, size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
 use std::os::raw::c_void;
 
 use ash::util::*;

--- a/ash-examples/src/bin/triangle.rs
+++ b/ash-examples/src/bin/triangle.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use std::ffi;
 use std::io::Cursor;
 use std::mem;
-use std::mem::{size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
+use std::mem::{align_of, size_of, size_of_val}; // TODO: Remove when bumping MSRV to 1.80
 
 use ash::util::*;
 use ash::vk;


### PR DESCRIPTION
Fixes #954

In #931 we worked around "unnecessary import" warnings for the `size_of(_val)()` functions being added to the prelude in Rust 1.80 while maintaining some form of MSRV back-compatibility (despite not testing the examples against this), but forgot about `align_of()`. This means the examples still build on Rust 1.80 or higher because `align_of()` is always in scope via the prelude there, but not on older compilers.  Fix this by adding it to the import that's tagged to be removed when we bump all of `ash` to MSRV 1.80.
