### PR TITLE
examples: Only use `image`'s `png` feature to speed up compile

### DIFF
--- a/ash-examples/Cargo.toml
+++ b/ash-examples/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-image = "0.25"
+image = { version = "0.25", default-features = false, features = ["png"] }
 winit = { version = "0.29", features = ["rwh_06"] }
 # The examples require the validation layers, which means the SDK or
 # equivalent development packages should be present, so we can link


### PR DESCRIPTION
The examples only needs the png feature, so disable default features and only add the png feature.

This saves ~4s (16s->12s) and reduces the built dependencies from 180 to 113 on Linux with a 5900x.