### PR TITLE
generator: Demote `vk-parse` error-asserts to a warning message

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -3079,10 +3079,9 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
     use std::fs::File;
     use std::io::Write;
     let (spec2, errors) = vk_parse::parse_file(&vk_xml).expect("Invalid xml file");
-    assert!(
-        errors.is_empty(),
-        "vk_parse encountered one or more errors while parsing: {errors:?}"
-    );
+    if !errors.is_empty() {
+        eprintln!("vk_parse encountered one or more errors while parsing: {errors:?}")
+    }
     let extensions: Vec<&vk_parse::Extension> = spec2
         .0
         .iter()


### PR DESCRIPTION
Fixes #959

When `vk-parse` encounters XML parsing errors (e.g. on unknown attributes or elements) it skips the element and emits an error in a list of errors that are returned to the caller.  We were originally never checking these leading to hard-to-debug issues, but eventually started asserting on this list being empty or otherwise panicking in #930.

Since `ash`'s generator is used in Khronos' upstream CI (in a fallible yet warning way), any new attribute would cause the generator to fail and subsequently require updates to `vk-parse` and `ash` before their CI is no longer flagged as "succeeded with warnings".  "Solve" this by once again allowing errors to exist, while still at least printing them to `stderr` for insights (that were previously missing...) to anyone running the generator.

Note @oddhack that this once again allows the generator to fail further in the chain when expected elements are missing, in which case an update is required either way.  If this happens often we can adjust `vk-parse` to be more lenient in still emitting errors but continuing to parse said element, if the new/unrecognized elements or attributes are considered harmless to the parsing process.
