### PR TITLE
generator: Omit lifetime on `vk::AllocationCallbacks` for opaque pointer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `get_pipeline_executable_statistics()`.
   The expected length of this array can be queried with the respective `*_len()` variant of these functions.
 
+### Removed
+
+- Removed unused lifetime from `vk::AllocationCallbacks` structure (#968)
+
 ## [0.38.0] - 2024-04-01
 
 With over two years of collecting breaking changes (since the `0.37.0` release in March 2022), April 2024 marks the next breaking release of `ash`.  This release introduces an overhaul of all Vulkan structures, restructures modules around extensions, and separates extension wrappers between `Instance` and `Device` functions.  The crate contains all bindings defined by the latest `1.3.281` Vulkan specification, and many old and new extensions have received a hand-written extension wrapper.  For a full overview of all individual changes, see the list at the end of this post.

--- a/ash-window/src/lib.rs
+++ b/ash-window/src/lib.rs
@@ -38,7 +38,7 @@ pub unsafe fn create_surface(
     instance: &Instance,
     display_handle: RawDisplayHandle,
     window_handle: RawWindowHandle,
-    allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+    allocation_callbacks: Option<&vk::AllocationCallbacks>,
 ) -> VkResult<vk::SurfaceKHR> {
     match (display_handle, window_handle) {
         (RawDisplayHandle::Windows(_), RawWindowHandle::Win32(window)) => {

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -76,7 +76,7 @@ impl Device {
     pub unsafe fn create_private_data_slot(
         &self,
         create_info: &vk::PrivateDataSlotCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::PrivateDataSlot> {
         let mut private_data_slot = mem::MaybeUninit::uninit();
         (self.device_fn_1_3.create_private_data_slot)(
@@ -93,7 +93,7 @@ impl Device {
     pub unsafe fn destroy_private_data_slot(
         &self,
         private_data_slot: vk::PrivateDataSlot,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_3.destroy_private_data_slot)(
             self.handle,
@@ -612,7 +612,7 @@ impl Device {
     pub unsafe fn create_render_pass2(
         &self,
         create_info: &vk::RenderPassCreateInfo2<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::MaybeUninit::uninit();
         (self.device_fn_1_2.create_render_pass2)(
@@ -896,7 +896,7 @@ impl Device {
     pub unsafe fn create_sampler_ycbcr_conversion(
         &self,
         create_info: &vk::SamplerYcbcrConversionCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
         let mut ycbcr_conversion = mem::MaybeUninit::uninit();
         (self.device_fn_1_1.create_sampler_ycbcr_conversion)(
@@ -913,7 +913,7 @@ impl Device {
     pub unsafe fn destroy_sampler_ycbcr_conversion(
         &self,
         ycbcr_conversion: vk::SamplerYcbcrConversion,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_1.destroy_sampler_ycbcr_conversion)(
             self.handle(),
@@ -927,7 +927,7 @@ impl Device {
     pub unsafe fn create_descriptor_update_template(
         &self,
         create_info: &vk::DescriptorUpdateTemplateCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DescriptorUpdateTemplate> {
         let mut descriptor_update_template = mem::MaybeUninit::uninit();
         (self.device_fn_1_1.create_descriptor_update_template)(
@@ -944,7 +944,7 @@ impl Device {
     pub unsafe fn destroy_descriptor_update_template(
         &self,
         descriptor_update_template: vk::DescriptorUpdateTemplate,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_1.destroy_descriptor_update_template)(
             self.handle(),
@@ -989,10 +989,7 @@ impl Device {
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkDestroyDevice.html>
     #[inline]
-    pub unsafe fn destroy_device(
-        &self,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
-    ) {
+    pub unsafe fn destroy_device(&self, allocation_callbacks: Option<&vk::AllocationCallbacks>) {
         (self.device_fn_1_0.destroy_device)(self.handle(), allocation_callbacks.as_raw_ptr());
     }
 
@@ -1001,7 +998,7 @@ impl Device {
     pub unsafe fn destroy_sampler(
         &self,
         sampler: vk::Sampler,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_sampler)(
             self.handle(),
@@ -1015,7 +1012,7 @@ impl Device {
     pub unsafe fn free_memory(
         &self,
         memory: vk::DeviceMemory,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.free_memory)(self.handle(), memory, allocation_callbacks.as_raw_ptr());
     }
@@ -1040,7 +1037,7 @@ impl Device {
     pub unsafe fn create_event(
         &self,
         create_info: &vk::EventCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Event> {
         let mut event = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_event)(
@@ -1131,7 +1128,7 @@ impl Device {
     pub unsafe fn destroy_fence(
         &self,
         fence: vk::Fence,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_fence)(self.handle(), fence, allocation_callbacks.as_raw_ptr());
     }
@@ -1141,7 +1138,7 @@ impl Device {
     pub unsafe fn destroy_event(
         &self,
         event: vk::Event,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_event)(self.handle(), event, allocation_callbacks.as_raw_ptr());
     }
@@ -1151,7 +1148,7 @@ impl Device {
     pub unsafe fn destroy_image(
         &self,
         image: vk::Image,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_image)(self.handle(), image, allocation_callbacks.as_raw_ptr());
     }
@@ -1161,7 +1158,7 @@ impl Device {
     pub unsafe fn destroy_command_pool(
         &self,
         pool: vk::CommandPool,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_command_pool)(
             self.handle(),
@@ -1175,7 +1172,7 @@ impl Device {
     pub unsafe fn destroy_image_view(
         &self,
         image_view: vk::ImageView,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_image_view)(
             self.handle(),
@@ -1189,7 +1186,7 @@ impl Device {
     pub unsafe fn destroy_render_pass(
         &self,
         renderpass: vk::RenderPass,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_render_pass)(
             self.handle(),
@@ -1203,7 +1200,7 @@ impl Device {
     pub unsafe fn destroy_framebuffer(
         &self,
         framebuffer: vk::Framebuffer,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_framebuffer)(
             self.handle(),
@@ -1217,7 +1214,7 @@ impl Device {
     pub unsafe fn destroy_pipeline_layout(
         &self,
         pipeline_layout: vk::PipelineLayout,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_pipeline_layout)(
             self.handle(),
@@ -1231,7 +1228,7 @@ impl Device {
     pub unsafe fn destroy_pipeline_cache(
         &self,
         pipeline_cache: vk::PipelineCache,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_pipeline_cache)(
             self.handle(),
@@ -1245,7 +1242,7 @@ impl Device {
     pub unsafe fn destroy_buffer(
         &self,
         buffer: vk::Buffer,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_buffer)(
             self.handle(),
@@ -1259,7 +1256,7 @@ impl Device {
     pub unsafe fn destroy_shader_module(
         &self,
         shader: vk::ShaderModule,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_shader_module)(
             self.handle(),
@@ -1273,7 +1270,7 @@ impl Device {
     pub unsafe fn destroy_pipeline(
         &self,
         pipeline: vk::Pipeline,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_pipeline)(
             self.handle(),
@@ -1287,7 +1284,7 @@ impl Device {
     pub unsafe fn destroy_semaphore(
         &self,
         semaphore: vk::Semaphore,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_semaphore)(
             self.handle(),
@@ -1301,7 +1298,7 @@ impl Device {
     pub unsafe fn destroy_descriptor_pool(
         &self,
         pool: vk::DescriptorPool,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_descriptor_pool)(
             self.handle(),
@@ -1315,7 +1312,7 @@ impl Device {
     pub unsafe fn destroy_query_pool(
         &self,
         pool: vk::QueryPool,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_query_pool)(
             self.handle(),
@@ -1329,7 +1326,7 @@ impl Device {
     pub unsafe fn destroy_descriptor_set_layout(
         &self,
         layout: vk::DescriptorSetLayout,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_descriptor_set_layout)(
             self.handle(),
@@ -1375,7 +1372,7 @@ impl Device {
     pub unsafe fn create_sampler(
         &self,
         create_info: &vk::SamplerCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Sampler> {
         let mut sampler = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_sampler)(
@@ -1564,7 +1561,7 @@ impl Device {
     pub unsafe fn create_descriptor_set_layout(
         &self,
         create_info: &vk::DescriptorSetLayoutCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DescriptorSetLayout> {
         let mut layout = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_descriptor_set_layout)(
@@ -1587,7 +1584,7 @@ impl Device {
     pub unsafe fn create_descriptor_pool(
         &self,
         create_info: &vk::DescriptorPoolCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DescriptorPool> {
         let mut pool = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_descriptor_pool)(
@@ -2132,7 +2129,7 @@ impl Device {
     pub unsafe fn create_semaphore(
         &self,
         create_info: &vk::SemaphoreCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Semaphore> {
         let mut semaphore = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_semaphore)(
@@ -2154,7 +2151,7 @@ impl Device {
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::GraphicsPipelineCreateInfo<'_>],
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.device_fn_1_0.create_graphics_pipelines)(
@@ -2182,7 +2179,7 @@ impl Device {
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::ComputePipelineCreateInfo<'_>],
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.device_fn_1_0.create_compute_pipelines)(
@@ -2205,7 +2202,7 @@ impl Device {
     pub unsafe fn create_buffer(
         &self,
         create_info: &vk::BufferCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Buffer> {
         let mut buffer = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_buffer)(
@@ -2222,7 +2219,7 @@ impl Device {
     pub unsafe fn create_pipeline_layout(
         &self,
         create_info: &vk::PipelineLayoutCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::PipelineLayout> {
         let mut pipeline_layout = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_pipeline_layout)(
@@ -2239,7 +2236,7 @@ impl Device {
     pub unsafe fn create_pipeline_cache(
         &self,
         create_info: &vk::PipelineCacheCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::PipelineCache> {
         let mut pipeline_cache = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_pipeline_cache)(
@@ -2343,7 +2340,7 @@ impl Device {
     pub unsafe fn create_framebuffer(
         &self,
         create_info: &vk::FramebufferCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Framebuffer> {
         let mut framebuffer = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_framebuffer)(
@@ -2399,7 +2396,7 @@ impl Device {
     pub unsafe fn create_render_pass(
         &self,
         create_info: &vk::RenderPassCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_render_pass)(
@@ -2500,7 +2497,7 @@ impl Device {
     pub unsafe fn create_buffer_view(
         &self,
         create_info: &vk::BufferViewCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::BufferView> {
         let mut buffer_view = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_buffer_view)(
@@ -2517,7 +2514,7 @@ impl Device {
     pub unsafe fn destroy_buffer_view(
         &self,
         buffer_view: vk::BufferView,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.device_fn_1_0.destroy_buffer_view)(
             self.handle(),
@@ -2531,7 +2528,7 @@ impl Device {
     pub unsafe fn create_image_view(
         &self,
         create_info: &vk::ImageViewCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::ImageView> {
         let mut image_view = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_image_view)(
@@ -2563,7 +2560,7 @@ impl Device {
     pub unsafe fn create_command_pool(
         &self,
         create_info: &vk::CommandPoolCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::CommandPool> {
         let mut pool = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_command_pool)(
@@ -2580,7 +2577,7 @@ impl Device {
     pub unsafe fn create_query_pool(
         &self,
         create_info: &vk::QueryPoolCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::QueryPool> {
         let mut pool = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_query_pool)(
@@ -2597,7 +2594,7 @@ impl Device {
     pub unsafe fn create_image(
         &self,
         create_info: &vk::ImageCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Image> {
         let mut image = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_image)(
@@ -2658,7 +2655,7 @@ impl Device {
     pub unsafe fn allocate_memory(
         &self,
         allocate_info: &vk::MemoryAllocateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DeviceMemory> {
         let mut memory = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.allocate_memory)(
@@ -2675,7 +2672,7 @@ impl Device {
     pub unsafe fn create_shader_module(
         &self,
         create_info: &vk::ShaderModuleCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::ShaderModule> {
         let mut shader = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_shader_module)(
@@ -2692,7 +2689,7 @@ impl Device {
     pub unsafe fn create_fence(
         &self,
         create_info: &vk::FenceCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Fence> {
         let mut fence = mem::MaybeUninit::uninit();
         (self.device_fn_1_0.create_fence)(

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -252,7 +252,7 @@ impl Entry {
     pub unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Instance> {
         let mut instance = mem::MaybeUninit::uninit();
         let instance = (self.entry_fn_1_0.create_instance)(

--- a/ash/src/extensions/amdx/shader_enqueue.rs
+++ b/ash/src/extensions/amdx/shader_enqueue.rs
@@ -17,7 +17,7 @@ impl crate::amdx::shader_enqueue::Device {
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::ExecutionGraphPipelineCreateInfoAMDX<'_>],
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.fp.create_execution_graph_pipelines_amdx)(

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -11,7 +11,7 @@ impl crate::ext::debug_report::Instance {
     pub unsafe fn destroy_debug_report_callback(
         &self,
         debug: vk::DebugReportCallbackEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_debug_report_callback_ext)(
             self.handle,
@@ -25,7 +25,7 @@ impl crate::ext::debug_report::Instance {
     pub unsafe fn create_debug_report_callback(
         &self,
         create_info: &vk::DebugReportCallbackCreateInfoEXT<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugReportCallbackEXT> {
         let mut debug_cb = mem::MaybeUninit::uninit();
         (self.fp.create_debug_report_callback_ext)(

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -83,7 +83,7 @@ impl crate::ext::debug_utils::Instance {
     pub unsafe fn create_debug_utils_messenger(
         &self,
         create_info: &vk::DebugUtilsMessengerCreateInfoEXT<'_>,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugUtilsMessengerEXT> {
         let mut messenger = mem::MaybeUninit::uninit();
         (self.fp.create_debug_utils_messenger_ext)(
@@ -100,7 +100,7 @@ impl crate::ext::debug_utils::Instance {
     pub unsafe fn destroy_debug_utils_messenger(
         &self,
         messenger: vk::DebugUtilsMessengerEXT,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_debug_utils_messenger_ext)(self.handle, messenger, allocator.as_raw_ptr());
     }

--- a/ash/src/extensions/ext/headless_surface.rs
+++ b/ash/src/extensions/ext/headless_surface.rs
@@ -11,7 +11,7 @@ impl crate::ext::headless_surface::Instance {
     pub unsafe fn create_headless_surface(
         &self,
         create_info: &vk::HeadlessSurfaceCreateInfoEXT<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_headless_surface_ext)(

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -11,7 +11,7 @@ impl crate::ext::metal_surface::Instance {
     pub unsafe fn create_metal_surface(
         &self,
         create_info: &vk::MetalSurfaceCreateInfoEXT<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_metal_surface_ext)(

--- a/ash/src/extensions/ext/private_data.rs
+++ b/ash/src/extensions/ext/private_data.rs
@@ -11,7 +11,7 @@ impl crate::ext::private_data::Device {
     pub unsafe fn create_private_data_slot(
         &self,
         create_info: &vk::PrivateDataSlotCreateInfoEXT<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::PrivateDataSlotEXT> {
         let mut private_data_slot = mem::MaybeUninit::uninit();
         (self.fp.create_private_data_slot_ext)(
@@ -28,7 +28,7 @@ impl crate::ext::private_data::Device {
     pub unsafe fn destroy_private_data_slot(
         &self,
         private_data_slot: vk::PrivateDataSlotEXT,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_private_data_slot_ext)(
             self.handle,

--- a/ash/src/extensions/ext/shader_object.rs
+++ b/ash/src/extensions/ext/shader_object.rs
@@ -21,7 +21,7 @@ impl crate::ext::shader_object::Device {
     pub unsafe fn create_shaders(
         &self,
         create_infos: &[vk::ShaderCreateInfoEXT<'_>],
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) -> Result<Vec<vk::ShaderEXT>, (Vec<vk::ShaderEXT>, vk::Result)> {
         let mut shaders = Vec::with_capacity(create_infos.len());
         let err_code = (self.fp.create_shaders_ext)(
@@ -43,7 +43,7 @@ impl crate::ext::shader_object::Device {
     pub unsafe fn destroy_shader(
         &self,
         shader: vk::ShaderEXT,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_shader_ext)(self.handle, shader, allocator.as_raw_ptr())
     }

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -12,7 +12,7 @@ impl crate::khr::acceleration_structure::Device {
     pub unsafe fn create_acceleration_structure(
         &self,
         create_info: &vk::AccelerationStructureCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
         let mut accel_struct = mem::MaybeUninit::uninit();
         (self.fp.create_acceleration_structure_khr)(
@@ -29,7 +29,7 @@ impl crate::khr::acceleration_structure::Device {
     pub unsafe fn destroy_acceleration_structure(
         &self,
         accel_struct: vk::AccelerationStructureKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_acceleration_structure_khr)(
             self.handle,

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -11,7 +11,7 @@ impl crate::khr::android_surface::Instance {
     pub unsafe fn create_android_surface(
         &self,
         create_info: &vk::AndroidSurfaceCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_android_surface_khr)(

--- a/ash/src/extensions/khr/create_renderpass2.rs
+++ b/ash/src/extensions/khr/create_renderpass2.rs
@@ -11,7 +11,7 @@ impl crate::khr::create_renderpass2::Device {
     pub unsafe fn create_render_pass2(
         &self,
         create_info: &vk::RenderPassCreateInfo2<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::MaybeUninit::uninit();
         (self.fp.create_render_pass2_khr)(

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -10,7 +10,7 @@ impl crate::khr::deferred_host_operations::Device {
     #[inline]
     pub unsafe fn create_deferred_operation(
         &self,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DeferredOperationKHR> {
         let mut operation = mem::MaybeUninit::uninit();
         (self.fp.create_deferred_operation_khr)(
@@ -35,7 +35,7 @@ impl crate::khr::deferred_host_operations::Device {
     pub unsafe fn destroy_deferred_operation(
         &self,
         operation: vk::DeferredOperationKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_deferred_operation_khr)(
             self.handle,

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -65,7 +65,7 @@ impl crate::khr::display::Instance {
         physical_device: vk::PhysicalDevice,
         display: vk::DisplayKHR,
         create_info: &vk::DisplayModeCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DisplayModeKHR> {
         let mut display_mode = mem::MaybeUninit::uninit();
         (self.fp.create_display_mode_khr)(
@@ -101,7 +101,7 @@ impl crate::khr::display::Instance {
     pub unsafe fn create_display_plane_surface(
         &self,
         create_info: &vk::DisplaySurfaceCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_display_plane_surface_khr)(

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -11,7 +11,7 @@ impl crate::khr::display_swapchain::Device {
     pub unsafe fn create_shared_swapchains(
         &self,
         create_infos: &[vk::SwapchainCreateInfoKHR<'_>],
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::SwapchainKHR>> {
         let mut swapchains = Vec::with_capacity(create_infos.len());
         (self.fp.create_shared_swapchains_khr)(

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -42,7 +42,7 @@ impl crate::khr::ray_tracing_pipeline::Device {
         deferred_operation: vk::DeferredOperationKHR,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::RayTracingPipelineCreateInfoKHR<'_>],
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.fp.create_ray_tracing_pipelines_khr)(

--- a/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
+++ b/ash/src/extensions/khr/sampler_ycbcr_conversion.rs
@@ -11,7 +11,7 @@ impl crate::khr::sampler_ycbcr_conversion::Device {
     pub unsafe fn create_sampler_ycbcr_conversion(
         &self,
         create_info: &vk::SamplerYcbcrConversionCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
         let mut ycbcr_conversion = mem::MaybeUninit::uninit();
         (self.fp.create_sampler_ycbcr_conversion_khr)(
@@ -28,7 +28,7 @@ impl crate::khr::sampler_ycbcr_conversion::Device {
     pub unsafe fn destroy_sampler_ycbcr_conversion(
         &self,
         ycbcr_conversion: vk::SamplerYcbcrConversion,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_sampler_ycbcr_conversion_khr)(
             self.handle,

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -76,7 +76,7 @@ impl crate::khr::surface::Instance {
     pub unsafe fn destroy_surface(
         &self,
         surface: vk::SurfaceKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_surface_khr)(self.handle, surface, allocation_callbacks.as_raw_ptr());
     }

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -14,7 +14,7 @@ impl crate::khr::swapchain::Device {
     pub unsafe fn create_swapchain(
         &self,
         create_info: &vk::SwapchainCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SwapchainKHR> {
         let mut swapchain = mem::MaybeUninit::uninit();
         (self.fp.create_swapchain_khr)(
@@ -31,7 +31,7 @@ impl crate::khr::swapchain::Device {
     pub unsafe fn destroy_swapchain(
         &self,
         swapchain: vk::SwapchainKHR,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_swapchain_khr)(self.handle, swapchain, allocation_callbacks.as_raw_ptr());
     }

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -11,7 +11,7 @@ impl crate::khr::wayland_surface::Instance {
     pub unsafe fn create_wayland_surface(
         &self,
         create_info: &vk::WaylandSurfaceCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_wayland_surface_khr)(

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -11,7 +11,7 @@ impl crate::khr::win32_surface::Instance {
     pub unsafe fn create_win32_surface(
         &self,
         create_info: &vk::Win32SurfaceCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_win32_surface_khr)(

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -11,7 +11,7 @@ impl crate::khr::xcb_surface::Instance {
     pub unsafe fn create_xcb_surface(
         &self,
         create_info: &vk::XcbSurfaceCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_xcb_surface_khr)(

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -11,7 +11,7 @@ impl crate::khr::xlib_surface::Instance {
     pub unsafe fn create_xlib_surface(
         &self,
         create_info: &vk::XlibSurfaceCreateInfoKHR<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_xlib_surface_khr)(

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -11,7 +11,7 @@ impl crate::mvk::ios_surface::Instance {
     pub unsafe fn create_ios_surface(
         &self,
         create_info: &vk::IOSSurfaceCreateInfoMVK<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_ios_surface_mvk)(

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -11,7 +11,7 @@ impl crate::mvk::macos_surface::Instance {
     pub unsafe fn create_mac_os_surface(
         &self,
         create_info: &vk::MacOSSurfaceCreateInfoMVK<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_mac_os_surface_mvk)(

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -11,7 +11,7 @@ impl crate::nn::vi_surface::Instance {
     pub unsafe fn create_vi_surface(
         &self,
         create_info: &vk::ViSurfaceCreateInfoNN<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::uninit();
         (self.fp.create_vi_surface_nn)(

--- a/ash/src/extensions/nv/cuda_kernel_launch.rs
+++ b/ash/src/extensions/nv/cuda_kernel_launch.rs
@@ -12,7 +12,7 @@ impl crate::nv::cuda_kernel_launch::Device {
     pub unsafe fn create_cuda_module(
         &self,
         create_info: &vk::CudaModuleCreateInfoNV<'_>,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::CudaModuleNV> {
         let mut module = mem::MaybeUninit::uninit();
         (self.fp.create_cuda_module_nv)(
@@ -37,7 +37,7 @@ impl crate::nv::cuda_kernel_launch::Device {
     pub unsafe fn create_cuda_function(
         &self,
         create_info: &vk::CudaFunctionCreateInfoNV<'_>,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::CudaFunctionNV> {
         let mut function = mem::MaybeUninit::uninit();
         (self.fp.create_cuda_function_nv)(
@@ -54,7 +54,7 @@ impl crate::nv::cuda_kernel_launch::Device {
     pub unsafe fn destroy_cuda_module(
         &self,
         module: vk::CudaModuleNV,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_cuda_module_nv)(self.handle, module, allocator.as_raw_ptr())
     }
@@ -64,7 +64,7 @@ impl crate::nv::cuda_kernel_launch::Device {
     pub unsafe fn destroy_cuda_function(
         &self,
         function: vk::CudaFunctionNV,
-        allocator: Option<&vk::AllocationCallbacks<'_>>,
+        allocator: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_cuda_function_nv)(self.handle, function, allocator.as_raw_ptr())
     }

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -13,7 +13,7 @@ impl crate::nv::ray_tracing::Device {
     pub unsafe fn create_acceleration_structure(
         &self,
         create_info: &vk::AccelerationStructureCreateInfoNV<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureNV> {
         let mut accel_struct = mem::MaybeUninit::uninit();
         (self.fp.create_acceleration_structure_nv)(
@@ -30,7 +30,7 @@ impl crate::nv::ray_tracing::Device {
     pub unsafe fn destroy_acceleration_structure(
         &self,
         accel_struct: vk::AccelerationStructureNV,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
         (self.fp.destroy_acceleration_structure_nv)(
             self.handle,
@@ -156,7 +156,7 @@ impl crate::nv::ray_tracing::Device {
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::RayTracingPipelineCreateInfoNV<'_>],
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
         let mut pipelines = Vec::with_capacity(create_infos.len());
         let err_code = (self.fp.create_ray_tracing_pipelines_nv)(

--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -567,7 +567,7 @@ pub mod amdx {
                             _pipeline_cache: PipelineCache,
                             _create_info_count: u32,
                             _p_create_infos: *const ExecutionGraphPipelineCreateInfoAMDX<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_pipelines: *mut Pipeline,
                         ) -> Result {
                             panic!(concat!(
@@ -1052,7 +1052,7 @@ pub mod ext {
                         unsafe extern "system" fn create_debug_report_callback_ext(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const DebugReportCallbackCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_callback: *mut DebugReportCallbackEXT,
                         ) -> Result {
                             panic!(concat!(
@@ -1074,7 +1074,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_debug_report_callback_ext(
                             _instance: crate::vk::Instance,
                             _callback: DebugReportCallbackEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -1888,7 +1888,7 @@ pub mod ext {
                         unsafe extern "system" fn register_device_event_ext(
                             _device: crate::vk::Device,
                             _p_device_event_info: *const DeviceEventInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_fence: *mut Fence,
                         ) -> Result {
                             panic!(concat!(
@@ -1910,7 +1910,7 @@ pub mod ext {
                             _device: crate::vk::Device,
                             _display: DisplayKHR,
                             _p_display_event_info: *const DisplayEventInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_fence: *mut Fence,
                         ) -> Result {
                             panic!(concat!(
@@ -2215,7 +2215,7 @@ pub mod ext {
                         unsafe extern "system" fn create_debug_utils_messenger_ext(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const DebugUtilsMessengerCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_messenger: *mut DebugUtilsMessengerEXT,
                         ) -> Result {
                             panic!(concat!(
@@ -2237,7 +2237,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_debug_utils_messenger_ext(
                             _instance: crate::vk::Instance,
                             _messenger: DebugUtilsMessengerEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -2761,7 +2761,7 @@ pub mod ext {
                         unsafe extern "system" fn create_validation_cache_ext(
                             _device: crate::vk::Device,
                             _p_create_info: *const ValidationCacheCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_validation_cache: *mut ValidationCacheEXT,
                         ) -> Result {
                             panic!(concat!(
@@ -2782,7 +2782,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_validation_cache_ext(
                             _device: crate::vk::Device,
                             _validation_cache: ValidationCacheEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -3148,7 +3148,7 @@ pub mod ext {
                         unsafe extern "system" fn create_metal_surface_ext(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const MetalSurfaceCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -3611,7 +3611,7 @@ pub mod ext {
                         unsafe extern "system" fn create_headless_surface_ext(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const HeadlessSurfaceCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -4553,7 +4553,7 @@ pub mod ext {
                         unsafe extern "system" fn create_private_data_slot_ext(
                             _device: crate::vk::Device,
                             _p_create_info: *const PrivateDataSlotCreateInfo<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_private_data_slot: *mut PrivateDataSlot,
                         ) -> Result {
                             panic!(concat!(
@@ -4574,7 +4574,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_private_data_slot_ext(
                             _device: crate::vk::Device,
                             _private_data_slot: PrivateDataSlot,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -5359,7 +5359,7 @@ pub mod ext {
                         unsafe extern "system" fn create_direct_fb_surface_ext(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const DirectFBSurfaceCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -5994,7 +5994,7 @@ pub mod ext {
                         unsafe extern "system" fn create_micromap_ext(
                             _device: crate::vk::Device,
                             _p_create_info: *const MicromapCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_micromap: *mut MicromapEXT,
                         ) -> Result {
                             panic!(concat!("Unable to load ", stringify!(create_micromap_ext)))
@@ -6011,7 +6011,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_micromap_ext(
                             _device: crate::vk::Device,
                             _micromap: MicromapEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!("Unable to load ", stringify!(destroy_micromap_ext)))
                         }
@@ -7327,7 +7327,7 @@ pub mod ext {
                             _device: crate::vk::Device,
                             _create_info_count: u32,
                             _p_create_infos: *const ShaderCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_shaders: *mut ShaderEXT,
                         ) -> Result {
                             panic!(concat!("Unable to load ", stringify!(create_shaders_ext)))
@@ -7344,7 +7344,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_shader_ext(
                             _device: crate::vk::Device,
                             _shader: ShaderEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!("Unable to load ", stringify!(destroy_shader_ext)))
                         }
@@ -8625,7 +8625,7 @@ pub mod ext {
                         unsafe extern "system" fn create_indirect_commands_layout_ext(
                             _device: crate::vk::Device,
                             _p_create_info: *const IndirectCommandsLayoutCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_indirect_commands_layout: *mut IndirectCommandsLayoutEXT,
                         ) -> Result {
                             panic!(concat!(
@@ -8647,7 +8647,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_indirect_commands_layout_ext(
                             _device: crate::vk::Device,
                             _indirect_commands_layout: IndirectCommandsLayoutEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -8668,7 +8668,7 @@ pub mod ext {
                         unsafe extern "system" fn create_indirect_execution_set_ext(
                             _device: crate::vk::Device,
                             _p_create_info: *const IndirectExecutionSetCreateInfoEXT<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_indirect_execution_set: *mut IndirectExecutionSetEXT,
                         ) -> Result {
                             panic!(concat!(
@@ -8690,7 +8690,7 @@ pub mod ext {
                         unsafe extern "system" fn destroy_indirect_execution_set_ext(
                             _device: crate::vk::Device,
                             _indirect_execution_set: IndirectExecutionSetEXT,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -8874,7 +8874,7 @@ pub mod fuchsia {
                         unsafe extern "system" fn create_image_pipe_surface_fuchsia(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -9133,7 +9133,7 @@ pub mod fuchsia {
                         unsafe extern "system" fn create_buffer_collection_fuchsia(
                             _device: crate::vk::Device,
                             _p_create_info: *const BufferCollectionCreateInfoFUCHSIA<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_collection: *mut BufferCollectionFUCHSIA,
                         ) -> Result {
                             panic!(concat!(
@@ -9197,7 +9197,7 @@ pub mod fuchsia {
                         unsafe extern "system" fn destroy_buffer_collection_fuchsia(
                             _device: crate::vk::Device,
                             _collection: BufferCollectionFUCHSIA,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -9289,7 +9289,7 @@ pub mod ggp {
                         unsafe extern "system" fn create_stream_descriptor_surface_ggp(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10024,7 +10024,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_surface_khr(
                             _instance: crate::vk::Instance,
                             _surface: SurfaceKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!("Unable to load ", stringify!(destroy_surface_khr)))
                         }
@@ -10245,7 +10245,7 @@ pub mod khr {
                         unsafe extern "system" fn create_swapchain_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const SwapchainCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_swapchain: *mut SwapchainKHR,
                         ) -> Result {
                             panic!(concat!("Unable to load ", stringify!(create_swapchain_khr)))
@@ -10262,7 +10262,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_swapchain_khr(
                             _device: crate::vk::Device,
                             _swapchain: SwapchainKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -10541,7 +10541,7 @@ pub mod khr {
                             _physical_device: PhysicalDevice,
                             _display: DisplayKHR,
                             _p_create_info: *const DisplayModeCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_mode: *mut DisplayModeKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10584,7 +10584,7 @@ pub mod khr {
                         unsafe extern "system" fn create_display_plane_surface_khr(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const DisplaySurfaceCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10654,7 +10654,7 @@ pub mod khr {
                             _device: crate::vk::Device,
                             _swapchain_count: u32,
                             _p_create_infos: *const SwapchainCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_swapchains: *mut SwapchainKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10724,7 +10724,7 @@ pub mod khr {
                         unsafe extern "system" fn create_xlib_surface_khr(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const XlibSurfaceCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10816,7 +10816,7 @@ pub mod khr {
                         unsafe extern "system" fn create_xcb_surface_khr(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const XcbSurfaceCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10907,7 +10907,7 @@ pub mod khr {
                         unsafe extern "system" fn create_wayland_surface_khr(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const WaylandSurfaceCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -10996,7 +10996,7 @@ pub mod khr {
                         unsafe extern "system" fn create_android_surface_khr(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const AndroidSurfaceCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -11066,7 +11066,7 @@ pub mod khr {
                         unsafe extern "system" fn create_win32_surface_khr(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const Win32SurfaceCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -11257,7 +11257,7 @@ pub mod khr {
                         unsafe extern "system" fn create_video_session_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const VideoSessionCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_video_session: *mut VideoSessionKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -11278,7 +11278,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_video_session_khr(
                             _device: crate::vk::Device,
                             _video_session: VideoSessionKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -11341,7 +11341,7 @@ pub mod khr {
                         unsafe extern "system" fn create_video_session_parameters_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const VideoSessionParametersCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_video_session_parameters: *mut VideoSessionParametersKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -11384,7 +11384,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_video_session_parameters_khr(
                             _device: crate::vk::Device,
                             _video_session_parameters: VideoSessionParametersKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -12910,7 +12910,7 @@ pub mod khr {
                         unsafe extern "system" fn create_descriptor_update_template_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const DescriptorUpdateTemplateCreateInfo<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_descriptor_update_template: *mut DescriptorUpdateTemplate,
                         ) -> Result {
                             panic!(concat!(
@@ -12932,7 +12932,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_descriptor_update_template_khr(
                             _device: crate::vk::Device,
                             _descriptor_update_template: DescriptorUpdateTemplate,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -13056,7 +13056,7 @@ pub mod khr {
                         unsafe extern "system" fn create_render_pass2_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const RenderPassCreateInfo2<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_render_pass: *mut RenderPass,
                         ) -> Result {
                             panic!(concat!(
@@ -14078,7 +14078,7 @@ pub mod khr {
                         unsafe extern "system" fn create_acceleration_structure_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const AccelerationStructureCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_acceleration_structure: *mut AccelerationStructureKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -14100,7 +14100,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_acceleration_structure_khr(
                             _device: crate::vk::Device,
                             _acceleration_structure: AccelerationStructureKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -14506,7 +14506,7 @@ pub mod khr {
                             _pipeline_cache: PipelineCache,
                             _create_info_count: u32,
                             _p_create_infos: *const RayTracingPipelineCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_pipelines: *mut Pipeline,
                         ) -> Result {
                             panic!(concat!(
@@ -14697,7 +14697,7 @@ pub mod khr {
                         unsafe extern "system" fn create_sampler_ycbcr_conversion_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const SamplerYcbcrConversionCreateInfo<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_ycbcr_conversion: *mut SamplerYcbcrConversion,
                         ) -> Result {
                             panic!(concat!(
@@ -14719,7 +14719,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_sampler_ycbcr_conversion_khr(
                             _device: crate::vk::Device,
                             _ycbcr_conversion: SamplerYcbcrConversion,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -15681,7 +15681,7 @@ pub mod khr {
                     create_deferred_operation_khr: unsafe {
                         unsafe extern "system" fn create_deferred_operation_khr(
                             _device: crate::vk::Device,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_deferred_operation: *mut DeferredOperationKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -15702,7 +15702,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_deferred_operation_khr(
                             _device: crate::vk::Device,
                             _operation: DeferredOperationKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -16953,7 +16953,7 @@ pub mod khr {
                         unsafe extern "system" fn create_pipeline_binaries_khr(
                             _device: crate::vk::Device,
                             _p_create_info: *const PipelineBinaryCreateInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_binaries: *mut PipelineBinaryHandlesInfoKHR<'_>,
                         ) -> Result {
                             panic!(concat!(
@@ -16974,7 +16974,7 @@ pub mod khr {
                         unsafe extern "system" fn destroy_pipeline_binary_khr(
                             _device: crate::vk::Device,
                             _pipeline_binary: PipelineBinaryKHR,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -17032,7 +17032,7 @@ pub mod khr {
                         unsafe extern "system" fn release_captured_pipeline_data_khr(
                             _device: crate::vk::Device,
                             _p_info: *const ReleaseCapturedPipelineDataInfoKHR<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) -> Result {
                             panic!(concat!(
                                 "Unable to load ",
@@ -17653,7 +17653,7 @@ pub mod mvk {
                         unsafe extern "system" fn create_ios_surface_mvk(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const IOSSurfaceCreateInfoMVK<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -17720,7 +17720,7 @@ pub mod mvk {
                         unsafe extern "system" fn create_mac_os_surface_mvk(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const MacOSSurfaceCreateInfoMVK<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(
@@ -17791,7 +17791,7 @@ pub mod nn {
                         unsafe extern "system" fn create_vi_surface_nn(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const ViSurfaceCreateInfoNN<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!("Unable to load ", stringify!(create_vi_surface_nn)))
@@ -18297,7 +18297,7 @@ pub mod nv {
                         unsafe extern "system" fn create_acceleration_structure_nv(
                             _device: crate::vk::Device,
                             _p_create_info: *const AccelerationStructureCreateInfoNV<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_acceleration_structure: *mut AccelerationStructureNV,
                         ) -> Result {
                             panic!(concat!(
@@ -18319,7 +18319,7 @@ pub mod nv {
                         unsafe extern "system" fn destroy_acceleration_structure_nv(
                             _device: crate::vk::Device,
                             _acceleration_structure: AccelerationStructureNV,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -18461,7 +18461,7 @@ pub mod nv {
                             _pipeline_cache: PipelineCache,
                             _create_info_count: u32,
                             _p_create_infos: *const RayTracingPipelineCreateInfoNV<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_pipelines: *mut Pipeline,
                         ) -> Result {
                             panic!(concat!(
@@ -19180,7 +19180,7 @@ pub mod nv {
                         unsafe extern "system" fn create_indirect_commands_layout_nv(
                             _device: crate::vk::Device,
                             _p_create_info: *const IndirectCommandsLayoutCreateInfoNV<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_indirect_commands_layout: *mut IndirectCommandsLayoutNV,
                         ) -> Result {
                             panic!(concat!(
@@ -19202,7 +19202,7 @@ pub mod nv {
                         unsafe extern "system" fn destroy_indirect_commands_layout_nv(
                             _device: crate::vk::Device,
                             _indirect_commands_layout: IndirectCommandsLayoutNV,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -19299,7 +19299,7 @@ pub mod nv {
                         unsafe extern "system" fn create_cuda_module_nv(
                             _device: crate::vk::Device,
                             _p_create_info: *const CudaModuleCreateInfoNV<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_module: *mut CudaModuleNV,
                         ) -> Result {
                             panic!(concat!(
@@ -19340,7 +19340,7 @@ pub mod nv {
                         unsafe extern "system" fn create_cuda_function_nv(
                             _device: crate::vk::Device,
                             _p_create_info: *const CudaFunctionCreateInfoNV<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_function: *mut CudaFunctionNV,
                         ) -> Result {
                             panic!(concat!(
@@ -19361,7 +19361,7 @@ pub mod nv {
                         unsafe extern "system" fn destroy_cuda_module_nv(
                             _device: crate::vk::Device,
                             _module: CudaModuleNV,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -19380,7 +19380,7 @@ pub mod nv {
                         unsafe extern "system" fn destroy_cuda_function_nv(
                             _device: crate::vk::Device,
                             _function: CudaFunctionNV,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -20081,7 +20081,7 @@ pub mod nv {
                         unsafe extern "system" fn create_optical_flow_session_nv(
                             _device: crate::vk::Device,
                             _p_create_info: *const OpticalFlowSessionCreateInfoNV<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_session: *mut OpticalFlowSessionNV,
                         ) -> Result {
                             panic!(concat!(
@@ -20102,7 +20102,7 @@ pub mod nv {
                         unsafe extern "system" fn destroy_optical_flow_session_nv(
                             _device: crate::vk::Device,
                             _session: OpticalFlowSessionNV,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -20427,7 +20427,7 @@ pub mod nvx {
                         unsafe extern "system" fn create_cu_module_nvx(
                             _device: crate::vk::Device,
                             _p_create_info: *const CuModuleCreateInfoNVX<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_module: *mut CuModuleNVX,
                         ) -> Result {
                             panic!(concat!("Unable to load ", stringify!(create_cu_module_nvx)))
@@ -20444,7 +20444,7 @@ pub mod nvx {
                         unsafe extern "system" fn create_cu_function_nvx(
                             _device: crate::vk::Device,
                             _p_create_info: *const CuFunctionCreateInfoNVX<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_function: *mut CuFunctionNVX,
                         ) -> Result {
                             panic!(concat!(
@@ -20464,7 +20464,7 @@ pub mod nvx {
                         unsafe extern "system" fn destroy_cu_module_nvx(
                             _device: crate::vk::Device,
                             _module: CuModuleNVX,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -20483,7 +20483,7 @@ pub mod nvx {
                         unsafe extern "system" fn destroy_cu_function_nvx(
                             _device: crate::vk::Device,
                             _function: CuFunctionNVX,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                         ) {
                             panic!(concat!(
                                 "Unable to load ",
@@ -20860,7 +20860,7 @@ pub mod qnx {
                         unsafe extern "system" fn create_screen_surface_qnx(
                             _instance: crate::vk::Instance,
                             _p_create_info: *const ScreenSurfaceCreateInfoQNX<'_>,
-                            _p_allocator: *const AllocationCallbacks<'_>,
+                            _p_allocator: *const AllocationCallbacks,
                             _p_surface: *mut SurfaceKHR,
                         ) -> Result {
                             panic!(concat!(

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -363,7 +363,7 @@ impl Instance {
         &self,
         physical_device: vk::PhysicalDevice,
         create_info: &vk::DeviceCreateInfo<'_>,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Device> {
         let mut device = mem::MaybeUninit::uninit();
         let device = (self.instance_fn_1_0.create_device)(
@@ -388,10 +388,7 @@ impl Instance {
 
     /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkDestroyInstance.html>
     #[inline]
-    pub unsafe fn destroy_instance(
-        &self,
-        allocation_callbacks: Option<&vk::AllocationCallbacks<'_>>,
-    ) {
+    pub unsafe fn destroy_instance(&self, allocation_callbacks: Option<&vk::AllocationCallbacks>) {
         (self.instance_fn_1_0.destroy_instance)(self.handle(), allocation_callbacks.as_raw_ptr());
     }
 

--- a/ash/src/tables.rs
+++ b/ash/src/tables.rs
@@ -53,7 +53,7 @@ impl EntryFnV1_0 {
             create_instance: unsafe {
                 unsafe extern "system" fn create_instance(
                     _p_create_info: *const InstanceCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_instance: *mut crate::vk::Instance,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_instance)))
@@ -138,7 +138,7 @@ impl InstanceFnV1_0 {
             destroy_instance: unsafe {
                 unsafe extern "system" fn destroy_instance(
                     _instance: crate::vk::Instance,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_instance)))
                 }
@@ -309,7 +309,7 @@ impl InstanceFnV1_0 {
                 unsafe extern "system" fn create_device(
                     _physical_device: PhysicalDevice,
                     _p_create_info: *const DeviceCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_device: *mut crate::vk::Device,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_device)))
@@ -527,7 +527,7 @@ impl DeviceFnV1_0 {
             destroy_device: unsafe {
                 unsafe extern "system" fn destroy_device(
                     _device: crate::vk::Device,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_device)))
                 }
@@ -601,7 +601,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn allocate_memory(
                     _device: crate::vk::Device,
                     _p_allocate_info: *const MemoryAllocateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_memory: *mut DeviceMemory,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(allocate_memory)))
@@ -618,7 +618,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn free_memory(
                     _device: crate::vk::Device,
                     _memory: DeviceMemory,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(free_memory)))
                 }
@@ -836,7 +836,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_fence(
                     _device: crate::vk::Device,
                     _p_create_info: *const FenceCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_fence: *mut Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_fence)))
@@ -853,7 +853,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_fence(
                     _device: crate::vk::Device,
                     _fence: Fence,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_fence)))
                 }
@@ -918,7 +918,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_semaphore(
                     _device: crate::vk::Device,
                     _p_create_info: *const SemaphoreCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_semaphore: *mut Semaphore,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_semaphore)))
@@ -935,7 +935,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_semaphore(
                     _device: crate::vk::Device,
                     _semaphore: Semaphore,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_semaphore)))
                 }
@@ -951,7 +951,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_event(
                     _device: crate::vk::Device,
                     _p_create_info: *const EventCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_event: *mut Event,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_event)))
@@ -968,7 +968,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_event(
                     _device: crate::vk::Device,
                     _event: Event,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_event)))
                 }
@@ -1029,7 +1029,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_query_pool(
                     _device: crate::vk::Device,
                     _p_create_info: *const QueryPoolCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_query_pool: *mut QueryPool,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_query_pool)))
@@ -1046,7 +1046,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_query_pool(
                     _device: crate::vk::Device,
                     _query_pool: QueryPool,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_query_pool)))
                 }
@@ -1086,7 +1086,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_buffer(
                     _device: crate::vk::Device,
                     _p_create_info: *const BufferCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_buffer: *mut Buffer,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_buffer)))
@@ -1103,7 +1103,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_buffer(
                     _device: crate::vk::Device,
                     _buffer: Buffer,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_buffer)))
                 }
@@ -1119,7 +1119,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_buffer_view(
                     _device: crate::vk::Device,
                     _p_create_info: *const BufferViewCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_view: *mut BufferView,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_buffer_view)))
@@ -1136,7 +1136,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_buffer_view(
                     _device: crate::vk::Device,
                     _buffer_view: BufferView,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_buffer_view)))
                 }
@@ -1152,7 +1152,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_image(
                     _device: crate::vk::Device,
                     _p_create_info: *const ImageCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_image: *mut Image,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_image)))
@@ -1169,7 +1169,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_image(
                     _device: crate::vk::Device,
                     _image: Image,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_image)))
                 }
@@ -1205,7 +1205,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_image_view(
                     _device: crate::vk::Device,
                     _p_create_info: *const ImageViewCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_view: *mut ImageView,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_image_view)))
@@ -1222,7 +1222,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_image_view(
                     _device: crate::vk::Device,
                     _image_view: ImageView,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_image_view)))
                 }
@@ -1238,7 +1238,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_shader_module(
                     _device: crate::vk::Device,
                     _p_create_info: *const ShaderModuleCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_shader_module: *mut ShaderModule,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_shader_module)))
@@ -1255,7 +1255,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_shader_module(
                     _device: crate::vk::Device,
                     _shader_module: ShaderModule,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1274,7 +1274,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_pipeline_cache(
                     _device: crate::vk::Device,
                     _p_create_info: *const PipelineCacheCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_pipeline_cache: *mut PipelineCache,
                 ) -> Result {
                     panic!(concat!(
@@ -1294,7 +1294,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_pipeline_cache(
                     _device: crate::vk::Device,
                     _pipeline_cache: PipelineCache,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1355,7 +1355,7 @@ impl DeviceFnV1_0 {
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
                     _p_create_infos: *const GraphicsPipelineCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -1377,7 +1377,7 @@ impl DeviceFnV1_0 {
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
                     _p_create_infos: *const ComputePipelineCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_pipelines: *mut Pipeline,
                 ) -> Result {
                     panic!(concat!(
@@ -1397,7 +1397,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_pipeline(
                     _device: crate::vk::Device,
                     _pipeline: Pipeline,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_pipeline)))
                 }
@@ -1413,7 +1413,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_pipeline_layout(
                     _device: crate::vk::Device,
                     _p_create_info: *const PipelineLayoutCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_pipeline_layout: *mut PipelineLayout,
                 ) -> Result {
                     panic!(concat!(
@@ -1433,7 +1433,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_pipeline_layout(
                     _device: crate::vk::Device,
                     _pipeline_layout: PipelineLayout,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1452,7 +1452,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_sampler(
                     _device: crate::vk::Device,
                     _p_create_info: *const SamplerCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_sampler: *mut Sampler,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_sampler)))
@@ -1469,7 +1469,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_sampler(
                     _device: crate::vk::Device,
                     _sampler: Sampler,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_sampler)))
                 }
@@ -1485,7 +1485,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_descriptor_set_layout(
                     _device: crate::vk::Device,
                     _p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_set_layout: *mut DescriptorSetLayout,
                 ) -> Result {
                     panic!(concat!(
@@ -1505,7 +1505,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_descriptor_set_layout(
                     _device: crate::vk::Device,
                     _descriptor_set_layout: DescriptorSetLayout,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1524,7 +1524,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_descriptor_pool(
                     _device: crate::vk::Device,
                     _p_create_info: *const DescriptorPoolCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_descriptor_pool: *mut DescriptorPool,
                 ) -> Result {
                     panic!(concat!(
@@ -1544,7 +1544,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_descriptor_pool(
                     _device: crate::vk::Device,
                     _descriptor_pool: DescriptorPool,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -1639,7 +1639,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_framebuffer(
                     _device: crate::vk::Device,
                     _p_create_info: *const FramebufferCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_framebuffer: *mut Framebuffer,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_framebuffer)))
@@ -1656,7 +1656,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_framebuffer(
                     _device: crate::vk::Device,
                     _framebuffer: Framebuffer,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_framebuffer)))
                 }
@@ -1672,7 +1672,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_render_pass(
                     _device: crate::vk::Device,
                     _p_create_info: *const RenderPassCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_render_pass: *mut RenderPass,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_render_pass)))
@@ -1689,7 +1689,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_render_pass(
                     _device: crate::vk::Device,
                     _render_pass: RenderPass,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_render_pass)))
                 }
@@ -1724,7 +1724,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn create_command_pool(
                     _device: crate::vk::Device,
                     _p_create_info: *const CommandPoolCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_command_pool: *mut CommandPool,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_command_pool)))
@@ -1741,7 +1741,7 @@ impl DeviceFnV1_0 {
                 unsafe extern "system" fn destroy_command_pool(
                     _device: crate::vk::Device,
                     _command_pool: CommandPool,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(destroy_command_pool)))
                 }
@@ -3176,7 +3176,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn create_sampler_ycbcr_conversion(
                     _device: crate::vk::Device,
                     _p_create_info: *const SamplerYcbcrConversionCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_ycbcr_conversion: *mut SamplerYcbcrConversion,
                 ) -> Result {
                     panic!(concat!(
@@ -3197,7 +3197,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn destroy_sampler_ycbcr_conversion(
                     _device: crate::vk::Device,
                     _ycbcr_conversion: SamplerYcbcrConversion,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3217,7 +3217,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn create_descriptor_update_template(
                     _device: crate::vk::Device,
                     _p_create_info: *const DescriptorUpdateTemplateCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_descriptor_update_template: *mut DescriptorUpdateTemplate,
                 ) -> Result {
                     panic!(concat!(
@@ -3238,7 +3238,7 @@ impl DeviceFnV1_1 {
                 unsafe extern "system" fn destroy_descriptor_update_template(
                     _device: crate::vk::Device,
                     _descriptor_update_template: DescriptorUpdateTemplate,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -3379,7 +3379,7 @@ impl DeviceFnV1_2 {
                 unsafe extern "system" fn create_render_pass2(
                     _device: crate::vk::Device,
                     _p_create_info: *const RenderPassCreateInfo2<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_render_pass: *mut RenderPass,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(create_render_pass2)))
@@ -3659,7 +3659,7 @@ impl DeviceFnV1_3 {
                 unsafe extern "system" fn create_private_data_slot(
                     _device: crate::vk::Device,
                     _p_create_info: *const PrivateDataSlotCreateInfo<'_>,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                     _p_private_data_slot: *mut PrivateDataSlot,
                 ) -> Result {
                     panic!(concat!(
@@ -3679,7 +3679,7 @@ impl DeviceFnV1_3 {
                 unsafe extern "system" fn destroy_private_data_slot(
                     _device: crate::vk::Device,
                     _private_data_slot: PrivateDataSlot,
-                    _p_allocator: *const AllocationCallbacks<'_>,
+                    _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
                         "Unable to load ",

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -1144,19 +1144,18 @@ impl<'a> ApplicationInfo<'a> {
 #[derive(Copy, Clone)]
 #[doc = "<https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAllocationCallbacks.html>"]
 #[must_use]
-pub struct AllocationCallbacks<'a> {
+pub struct AllocationCallbacks {
     pub p_user_data: *mut c_void,
     pub pfn_allocation: PFN_vkAllocationFunction,
     pub pfn_reallocation: PFN_vkReallocationFunction,
     pub pfn_free: PFN_vkFreeFunction,
     pub pfn_internal_allocation: PFN_vkInternalAllocationNotification,
     pub pfn_internal_free: PFN_vkInternalFreeNotification,
-    pub _marker: PhantomData<&'a ()>,
 }
-unsafe impl Send for AllocationCallbacks<'_> {}
-unsafe impl Sync for AllocationCallbacks<'_> {}
+unsafe impl Send for AllocationCallbacks {}
+unsafe impl Sync for AllocationCallbacks {}
 #[cfg(feature = "debug")]
-impl fmt::Debug for AllocationCallbacks<'_> {
+impl fmt::Debug for AllocationCallbacks {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("AllocationCallbacks")
             .field("p_user_data", &self.p_user_data)
@@ -1180,7 +1179,7 @@ impl fmt::Debug for AllocationCallbacks<'_> {
             .finish()
     }
 }
-impl ::core::default::Default for AllocationCallbacks<'_> {
+impl ::core::default::Default for AllocationCallbacks {
     #[inline]
     fn default() -> Self {
         Self {
@@ -1190,11 +1189,10 @@ impl ::core::default::Default for AllocationCallbacks<'_> {
             pfn_free: PFN_vkFreeFunction::default(),
             pfn_internal_allocation: PFN_vkInternalAllocationNotification::default(),
             pfn_internal_free: PFN_vkInternalFreeNotification::default(),
-            _marker: PhantomData,
         }
     }
 }
-impl<'a> AllocationCallbacks<'a> {
+impl AllocationCallbacks {
     #[inline]
     pub fn user_data(mut self, user_data: *mut c_void) -> Self {
         self.p_user_data = user_data;

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -4118,7 +4118,7 @@ pub const KHR_SURFACE_SPEC_VERSION: u32 = 25u32;
 pub type PFN_vkDestroySurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     surface: SurfaceKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSurfaceSupportKHR = unsafe extern "system" fn(
@@ -4161,14 +4161,14 @@ pub type PFN_vkGetPhysicalDevicePresentRectanglesKHR = unsafe extern "system" fn
 pub type PFN_vkCreateSwapchainKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const SwapchainCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_swapchain: *mut SwapchainKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySwapchainKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     swapchain: SwapchainKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSwapchainImagesKHR = unsafe extern "system" fn(
@@ -4240,7 +4240,7 @@ pub type PFN_vkCreateDisplayModeKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     display: DisplayKHR,
     p_create_info: *const DisplayModeCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_mode: *mut DisplayModeKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4254,7 +4254,7 @@ pub type PFN_vkGetDisplayPlaneCapabilitiesKHR = unsafe extern "system" fn(
 pub type PFN_vkCreateDisplayPlaneSurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const DisplaySurfaceCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const KHR_DISPLAY_SWAPCHAIN_NAME: &CStr =
@@ -4265,7 +4265,7 @@ pub type PFN_vkCreateSharedSwapchainsKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     swapchain_count: u32,
     p_create_infos: *const SwapchainCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_swapchains: *mut SwapchainKHR,
 ) -> Result;
 pub const KHR_XLIB_SURFACE_NAME: &CStr =
@@ -4275,7 +4275,7 @@ pub const KHR_XLIB_SURFACE_SPEC_VERSION: u32 = 6u32;
 pub type PFN_vkCreateXlibSurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const XlibSurfaceCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4292,7 +4292,7 @@ pub const KHR_XCB_SURFACE_SPEC_VERSION: u32 = 6u32;
 pub type PFN_vkCreateXcbSurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const XcbSurfaceCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4309,7 +4309,7 @@ pub const KHR_WAYLAND_SURFACE_SPEC_VERSION: u32 = 6u32;
 pub type PFN_vkCreateWaylandSurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const WaylandSurfaceCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4326,7 +4326,7 @@ pub const KHR_ANDROID_SURFACE_SPEC_VERSION: u32 = 6u32;
 pub type PFN_vkCreateAndroidSurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const AndroidSurfaceCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const KHR_WIN32_SURFACE_NAME: &CStr =
@@ -4336,7 +4336,7 @@ pub const KHR_WIN32_SURFACE_SPEC_VERSION: u32 = 6u32;
 pub type PFN_vkCreateWin32SurfaceKHR = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const Win32SurfaceCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4384,14 +4384,14 @@ pub const EXT_DEBUG_REPORT_SPEC_VERSION: u32 = 10u32;
 pub type PFN_vkCreateDebugReportCallbackEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const DebugReportCallbackCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_callback: *mut DebugReportCallbackEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDebugReportCallbackEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     callback: DebugReportCallbackEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkDebugReportMessageEXT = unsafe extern "system" fn(
@@ -4470,14 +4470,14 @@ pub type PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR = unsafe extern "system
 pub type PFN_vkCreateVideoSessionKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const VideoSessionCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_video_session: *mut VideoSessionKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyVideoSessionKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     video_session: VideoSessionKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetVideoSessionMemoryRequirementsKHR = unsafe extern "system" fn(
@@ -4497,7 +4497,7 @@ pub type PFN_vkBindVideoSessionMemoryKHR = unsafe extern "system" fn(
 pub type PFN_vkCreateVideoSessionParametersKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const VideoSessionParametersCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_video_session_parameters: *mut VideoSessionParametersKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -4510,7 +4510,7 @@ pub type PFN_vkUpdateVideoSessionParametersKHR = unsafe extern "system" fn(
 pub type PFN_vkDestroyVideoSessionParametersKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     video_session_parameters: VideoSessionParametersKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBeginVideoCodingKHR = unsafe extern "system" fn(
@@ -4601,27 +4601,27 @@ pub const NVX_BINARY_IMPORT_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateCuModuleNVX = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const CuModuleCreateInfoNVX<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_module: *mut CuModuleNVX,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateCuFunctionNVX = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const CuFunctionCreateInfoNVX<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_function: *mut CuFunctionNVX,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCuModuleNVX = unsafe extern "system" fn(
     device: crate::vk::Device,
     module: CuModuleNVX,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCuFunctionNVX = unsafe extern "system" fn(
     device: crate::vk::Device,
     function: CuFunctionNVX,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCuLaunchKernelNVX = unsafe extern "system" fn(
@@ -4718,7 +4718,7 @@ pub const GGP_STREAM_DESCRIPTOR_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateStreamDescriptorSurfaceGGP = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const NV_CORNER_SAMPLED_IMAGE_NAME: &CStr =
@@ -4838,7 +4838,7 @@ pub const NN_VI_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateViSurfaceNN = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const ViSurfaceCreateInfoNN<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const KHR_SHADER_DRAW_PARAMETERS_NAME: &CStr =
@@ -5011,14 +5011,14 @@ pub const KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateDescriptorUpdateTemplate = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const DescriptorUpdateTemplateCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_descriptor_update_template: *mut DescriptorUpdateTemplate,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDescriptorUpdateTemplate = unsafe extern "system" fn(
     device: crate::vk::Device,
     descriptor_update_template: DescriptorUpdateTemplate,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkUpdateDescriptorSetWithTemplate = unsafe extern "system" fn(
@@ -5081,7 +5081,7 @@ pub type PFN_vkDisplayPowerControlEXT = unsafe extern "system" fn(
 pub type PFN_vkRegisterDeviceEventEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_device_event_info: *const DeviceEventInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -5089,7 +5089,7 @@ pub type PFN_vkRegisterDisplayEventEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     display: DisplayKHR,
     p_display_event_info: *const DisplayEventInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -5177,7 +5177,7 @@ pub const KHR_CREATE_RENDERPASS2_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateRenderPass2 = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const RenderPassCreateInfo2<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_render_pass: *mut RenderPass,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -5329,7 +5329,7 @@ pub const MVK_IOS_SURFACE_SPEC_VERSION: u32 = 3u32;
 pub type PFN_vkCreateIOSSurfaceMVK = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const IOSSurfaceCreateInfoMVK<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const MVK_MACOS_SURFACE_NAME: &CStr =
@@ -5339,7 +5339,7 @@ pub const MVK_MACOS_SURFACE_SPEC_VERSION: u32 = 3u32;
 pub type PFN_vkCreateMacOSSurfaceMVK = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const MacOSSurfaceCreateInfoMVK<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const EXT_EXTERNAL_MEMORY_DMA_BUF_NAME: &CStr =
@@ -5358,14 +5358,14 @@ pub const EXT_DEBUG_UTILS_SPEC_VERSION: u32 = 2u32;
 pub type PFN_vkCreateDebugUtilsMessengerEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const DebugUtilsMessengerCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_messenger: *mut DebugUtilsMessengerEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDebugUtilsMessengerEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     messenger: DebugUtilsMessengerEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkSubmitDebugUtilsMessageEXT = unsafe extern "system" fn(
@@ -5438,7 +5438,7 @@ pub type PFN_vkCreateExecutionGraphPipelinesAMDX = unsafe extern "system" fn(
     pipeline_cache: PipelineCache,
     create_info_count: u32,
     p_create_infos: *const ExecutionGraphPipelineCreateInfoAMDX<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -5542,14 +5542,14 @@ pub const KHR_ACCELERATION_STRUCTURE_SPEC_VERSION: u32 = 13u32;
 pub type PFN_vkCreateAccelerationStructureKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const AccelerationStructureCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_acceleration_structure: *mut AccelerationStructureKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyAccelerationStructureKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     acceleration_structure: AccelerationStructureKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBuildAccelerationStructuresKHR = unsafe extern "system" fn(
@@ -5668,7 +5668,7 @@ pub type PFN_vkCreateRayTracingPipelinesKHR = unsafe extern "system" fn(
     pipeline_cache: PipelineCache,
     create_info_count: u32,
     p_create_infos: *const RayTracingPipelineCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -5731,14 +5731,14 @@ pub const KHR_SAMPLER_YCBCR_CONVERSION_SPEC_VERSION: u32 = 14u32;
 pub type PFN_vkCreateSamplerYcbcrConversion = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const SamplerYcbcrConversionCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_ycbcr_conversion: *mut SamplerYcbcrConversion,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySamplerYcbcrConversion = unsafe extern "system" fn(
     device: crate::vk::Device,
     ycbcr_conversion: SamplerYcbcrConversion,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 pub const KHR_BIND_MEMORY2_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_bind_memory2\0") };
@@ -5771,14 +5771,14 @@ pub const EXT_VALIDATION_CACHE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateValidationCacheEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const ValidationCacheCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_validation_cache: *mut ValidationCacheEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyValidationCacheEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     validation_cache: ValidationCacheEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkMergeValidationCachesEXT = unsafe extern "system" fn(
@@ -5833,14 +5833,14 @@ pub const NV_RAY_TRACING_SPEC_VERSION: u32 = 3u32;
 pub type PFN_vkCreateAccelerationStructureNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const AccelerationStructureCreateInfoNV<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_acceleration_structure: *mut AccelerationStructureNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyAccelerationStructureNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     acceleration_structure: AccelerationStructureNV,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetAccelerationStructureMemoryRequirementsNV = unsafe extern "system" fn(
@@ -5897,7 +5897,7 @@ pub type PFN_vkCreateRayTracingPipelinesNV = unsafe extern "system" fn(
     pipeline_cache: PipelineCache,
     create_info_count: u32,
     p_create_infos: *const RayTracingPipelineCreateInfoNV<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -6185,7 +6185,7 @@ pub const FUCHSIA_IMAGEPIPE_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateImagePipeSurfaceFUCHSIA = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const KHR_SHADER_TERMINATE_INVOCATION_NAME: &CStr =
@@ -6198,7 +6198,7 @@ pub const EXT_METAL_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateMetalSurfaceEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const MetalSurfaceCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const EXT_FRAGMENT_DENSITY_MAP_NAME: &CStr =
@@ -6368,7 +6368,7 @@ pub const EXT_HEADLESS_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateHeadlessSurfaceEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const HeadlessSurfaceCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub const KHR_BUFFER_DEVICE_ADDRESS_NAME: &CStr =
@@ -6473,14 +6473,14 @@ pub const KHR_DEFERRED_HOST_OPERATIONS_SPEC_VERSION: u32 = 4u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDeferredOperationKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_deferred_operation: *mut DeferredOperationKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDeferredOperationKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     operation: DeferredOperationKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeferredOperationMaxConcurrencyKHR =
@@ -6612,14 +6612,14 @@ pub type PFN_vkCmdBindPipelineShaderGroupNV = unsafe extern "system" fn(
 pub type PFN_vkCreateIndirectCommandsLayoutNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const IndirectCommandsLayoutCreateInfoNV<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_indirect_commands_layout: *mut IndirectCommandsLayoutNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyIndirectCommandsLayoutNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     indirect_commands_layout: IndirectCommandsLayoutNV,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 pub const NV_INHERITED_VIEWPORT_SCISSOR_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_inherited_viewport_scissor\0") };
@@ -6688,14 +6688,14 @@ pub const EXT_PRIVATE_DATA_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreatePrivateDataSlot = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const PrivateDataSlotCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_private_data_slot: *mut PrivateDataSlot,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPrivateDataSlot = unsafe extern "system" fn(
     device: crate::vk::Device,
     private_data_slot: PrivateDataSlot,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkSetPrivateData = unsafe extern "system" fn(
@@ -6752,7 +6752,7 @@ pub const NV_CUDA_KERNEL_LAUNCH_SPEC_VERSION: u32 = 2u32;
 pub type PFN_vkCreateCudaModuleNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const CudaModuleCreateInfoNV<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_module: *mut CudaModuleNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -6766,20 +6766,20 @@ pub type PFN_vkGetCudaModuleCacheNV = unsafe extern "system" fn(
 pub type PFN_vkCreateCudaFunctionNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const CudaFunctionCreateInfoNV<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_function: *mut CudaFunctionNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCudaModuleNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     module: CudaModuleNV,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCudaFunctionNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     function: CudaFunctionNV,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdCudaLaunchKernelNV = unsafe extern "system" fn(
@@ -7078,7 +7078,7 @@ pub const EXT_DIRECTFB_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateDirectFBSurfaceEXT = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const DirectFBSurfaceCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -7154,7 +7154,7 @@ pub const FUCHSIA_BUFFER_COLLECTION_SPEC_VERSION: u32 = 2u32;
 pub type PFN_vkCreateBufferCollectionFUCHSIA = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const BufferCollectionCreateInfoFUCHSIA<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_collection: *mut BufferCollectionFUCHSIA,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -7173,7 +7173,7 @@ pub type PFN_vkSetBufferCollectionBufferConstraintsFUCHSIA = unsafe extern "syst
 pub type PFN_vkDestroyBufferCollectionFUCHSIA = unsafe extern "system" fn(
     device: crate::vk::Device,
     collection: BufferCollectionFUCHSIA,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferCollectionPropertiesFUCHSIA = unsafe extern "system" fn(
@@ -7251,7 +7251,7 @@ pub const QNX_SCREEN_SURFACE_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreateScreenSurfaceQNX = unsafe extern "system" fn(
     instance: crate::vk::Instance,
     p_create_info: *const ScreenSurfaceCreateInfoQNX<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -7324,14 +7324,14 @@ pub const EXT_OPACITY_MICROMAP_SPEC_VERSION: u32 = 2u32;
 pub type PFN_vkCreateMicromapEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const MicromapCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_micromap: *mut MicromapEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyMicromapEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     micromap: MicromapEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdBuildMicromapsEXT = unsafe extern "system" fn(
@@ -7758,14 +7758,14 @@ pub type PFN_vkGetPhysicalDeviceOpticalFlowImageFormatsNV = unsafe extern "syste
 pub type PFN_vkCreateOpticalFlowSessionNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const OpticalFlowSessionCreateInfoNV<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_session: *mut OpticalFlowSessionNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyOpticalFlowSessionNV = unsafe extern "system" fn(
     device: crate::vk::Device,
     session: OpticalFlowSessionNV,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkBindOpticalFlowSessionImageNV = unsafe extern "system" fn(
@@ -7830,14 +7830,14 @@ pub type PFN_vkCreateShadersEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     create_info_count: u32,
     p_create_infos: *const ShaderCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_shaders: *mut ShaderEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyShaderEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     shader: ShaderEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetShaderBinaryDataEXT = unsafe extern "system" fn(
@@ -7866,14 +7866,14 @@ pub const KHR_PIPELINE_BINARY_SPEC_VERSION: u32 = 1u32;
 pub type PFN_vkCreatePipelineBinariesKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const PipelineBinaryCreateInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_binaries: *mut PipelineBinaryHandlesInfoKHR<'_>,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipelineBinaryKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     pipeline_binary: PipelineBinaryKHR,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineKeyKHR = unsafe extern "system" fn(
@@ -7893,7 +7893,7 @@ pub type PFN_vkGetPipelineBinaryDataKHR = unsafe extern "system" fn(
 pub type PFN_vkReleaseCapturedPipelineDataKHR = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_info: *const ReleaseCapturedPipelineDataInfoKHR<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 ) -> Result;
 pub const QCOM_TILE_PROPERTIES_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_tile_properties\0") };
@@ -8128,27 +8128,27 @@ pub type PFN_vkCmdExecuteGeneratedCommandsEXT = unsafe extern "system" fn(
 pub type PFN_vkCreateIndirectCommandsLayoutEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const IndirectCommandsLayoutCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_indirect_commands_layout: *mut IndirectCommandsLayoutEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyIndirectCommandsLayoutEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     indirect_commands_layout: IndirectCommandsLayoutEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateIndirectExecutionSetEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const IndirectExecutionSetCreateInfoEXT<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_indirect_execution_set: *mut IndirectExecutionSetEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyIndirectExecutionSetEXT = unsafe extern "system" fn(
     device: crate::vk::Device,
     indirect_execution_set: IndirectExecutionSetEXT,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkUpdateIndirectExecutionSetPipelineEXT = unsafe extern "system" fn(

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -10,7 +10,7 @@ pub type PFN_vkGetInstanceProcAddr = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateInstance = unsafe extern "system" fn(
     p_create_info: *const InstanceCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_instance: *mut crate::vk::Instance,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -27,7 +27,7 @@ pub type PFN_vkEnumerateInstanceLayerProperties = unsafe extern "system" fn(
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyInstance = unsafe extern "system" fn(
     instance: crate::vk::Instance,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkEnumeratePhysicalDevices = unsafe extern "system" fn(
@@ -81,7 +81,7 @@ pub type PFN_vkGetDeviceProcAddr = unsafe extern "system" fn(
 pub type PFN_vkCreateDevice = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_create_info: *const DeviceCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_device: *mut crate::vk::Device,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -109,10 +109,8 @@ pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties = unsafe extern "sys
     p_properties: *mut SparseImageFormatProperties,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDevice = unsafe extern "system" fn(
-    device: crate::vk::Device,
-    p_allocator: *const AllocationCallbacks<'_>,
-);
+pub type PFN_vkDestroyDevice =
+    unsafe extern "system" fn(device: crate::vk::Device, p_allocator: *const AllocationCallbacks);
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceQueue = unsafe extern "system" fn(
     device: crate::vk::Device,
@@ -135,14 +133,14 @@ pub type PFN_vkDeviceWaitIdle = unsafe extern "system" fn(device: crate::vk::Dev
 pub type PFN_vkAllocateMemory = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_allocate_info: *const MemoryAllocateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_memory: *mut DeviceMemory,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkFreeMemory = unsafe extern "system" fn(
     device: crate::vk::Device,
     memory: DeviceMemory,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkMapMemory = unsafe extern "system" fn(
@@ -218,14 +216,14 @@ pub type PFN_vkQueueBindSparse = unsafe extern "system" fn(
 pub type PFN_vkCreateFence = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const FenceCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyFence = unsafe extern "system" fn(
     device: crate::vk::Device,
     fence: Fence,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetFences = unsafe extern "system" fn(
@@ -248,27 +246,27 @@ pub type PFN_vkWaitForFences = unsafe extern "system" fn(
 pub type PFN_vkCreateSemaphore = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const SemaphoreCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_semaphore: *mut Semaphore,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySemaphore = unsafe extern "system" fn(
     device: crate::vk::Device,
     semaphore: Semaphore,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateEvent = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const EventCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_event: *mut Event,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyEvent = unsafe extern "system" fn(
     device: crate::vk::Device,
     event: Event,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetEventStatus =
@@ -283,14 +281,14 @@ pub type PFN_vkResetEvent =
 pub type PFN_vkCreateQueryPool = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const QueryPoolCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_query_pool: *mut QueryPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyQueryPool = unsafe extern "system" fn(
     device: crate::vk::Device,
     query_pool: QueryPool,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetQueryPoolResults = unsafe extern "system" fn(
@@ -307,40 +305,40 @@ pub type PFN_vkGetQueryPoolResults = unsafe extern "system" fn(
 pub type PFN_vkCreateBuffer = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const BufferCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_buffer: *mut Buffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyBuffer = unsafe extern "system" fn(
     device: crate::vk::Device,
     buffer: Buffer,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateBufferView = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const BufferViewCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_view: *mut BufferView,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyBufferView = unsafe extern "system" fn(
     device: crate::vk::Device,
     buffer_view: BufferView,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateImage = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const ImageCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_image: *mut Image,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyImage = unsafe extern "system" fn(
     device: crate::vk::Device,
     image: Image,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageSubresourceLayout = unsafe extern "system" fn(
@@ -353,40 +351,40 @@ pub type PFN_vkGetImageSubresourceLayout = unsafe extern "system" fn(
 pub type PFN_vkCreateImageView = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const ImageViewCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_view: *mut ImageView,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyImageView = unsafe extern "system" fn(
     device: crate::vk::Device,
     image_view: ImageView,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateShaderModule = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const ShaderModuleCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_shader_module: *mut ShaderModule,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyShaderModule = unsafe extern "system" fn(
     device: crate::vk::Device,
     shader_module: ShaderModule,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreatePipelineCache = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const PipelineCacheCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipeline_cache: *mut PipelineCache,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipelineCache = unsafe extern "system" fn(
     device: crate::vk::Device,
     pipeline_cache: PipelineCache,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPipelineCacheData = unsafe extern "system" fn(
@@ -408,7 +406,7 @@ pub type PFN_vkCreateGraphicsPipelines = unsafe extern "system" fn(
     pipeline_cache: PipelineCache,
     create_info_count: u32,
     p_create_infos: *const GraphicsPipelineCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
@@ -417,66 +415,66 @@ pub type PFN_vkCreateComputePipelines = unsafe extern "system" fn(
     pipeline_cache: PipelineCache,
     create_info_count: u32,
     p_create_infos: *const ComputePipelineCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipeline = unsafe extern "system" fn(
     device: crate::vk::Device,
     pipeline: Pipeline,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreatePipelineLayout = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const PipelineLayoutCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_pipeline_layout: *mut PipelineLayout,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyPipelineLayout = unsafe extern "system" fn(
     device: crate::vk::Device,
     pipeline_layout: PipelineLayout,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateSampler = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const SamplerCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_sampler: *mut Sampler,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroySampler = unsafe extern "system" fn(
     device: crate::vk::Device,
     sampler: Sampler,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDescriptorSetLayout = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const DescriptorSetLayoutCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_set_layout: *mut DescriptorSetLayout,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDescriptorSetLayout = unsafe extern "system" fn(
     device: crate::vk::Device,
     descriptor_set_layout: DescriptorSetLayout,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDescriptorPool = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const DescriptorPoolCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_descriptor_pool: *mut DescriptorPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDescriptorPool = unsafe extern "system" fn(
     device: crate::vk::Device,
     descriptor_pool: DescriptorPool,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetDescriptorPool = unsafe extern "system" fn(
@@ -509,27 +507,27 @@ pub type PFN_vkUpdateDescriptorSets = unsafe extern "system" fn(
 pub type PFN_vkCreateFramebuffer = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const FramebufferCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_framebuffer: *mut Framebuffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyFramebuffer = unsafe extern "system" fn(
     device: crate::vk::Device,
     framebuffer: Framebuffer,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateRenderPass = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const RenderPassCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_render_pass: *mut RenderPass,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyRenderPass = unsafe extern "system" fn(
     device: crate::vk::Device,
     render_pass: RenderPass,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetRenderAreaGranularity = unsafe extern "system" fn(
@@ -541,14 +539,14 @@ pub type PFN_vkGetRenderAreaGranularity = unsafe extern "system" fn(
 pub type PFN_vkCreateCommandPool = unsafe extern "system" fn(
     device: crate::vk::Device,
     p_create_info: *const CommandPoolCreateInfo<'_>,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
     p_command_pool: *mut CommandPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyCommandPool = unsafe extern "system" fn(
     device: crate::vk::Device,
     command_pool: CommandPool,
-    p_allocator: *const AllocationCallbacks<'_>,
+    p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetCommandPool = unsafe extern "system" fn(

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1905,7 +1905,7 @@ fn derive_default(
     Some(q)
 }
 
-fn derive_send_sync(struct_: &vkxml::Struct) -> Option<TokenStream> {
+fn derive_send_sync(struct_: &vkxml::Struct, has_lifetime: bool) -> Option<TokenStream> {
     if !struct_
         .elements
         .iter()
@@ -1916,9 +1916,10 @@ fn derive_send_sync(struct_: &vkxml::Struct) -> Option<TokenStream> {
         return None;
     }
     let name = name_to_tokens(&struct_.name);
+    let lifetime = has_lifetime.then(|| quote!(<'_>));
     let q = quote! {
-        unsafe impl Send for #name <'_> {}
-        unsafe impl Sync for #name <'_> {}
+        unsafe impl Send for #name #lifetime {}
+        unsafe impl Sync for #name #lifetime {}
     };
     Some(q)
 }
@@ -2563,7 +2564,7 @@ pub fn generate_struct(
 
     let debug_tokens = derive_debug(struct_, &members, union_types, has_lifetime);
     let default_tokens = derive_default(struct_, &members, has_lifetime);
-    let send_sync_tokens = derive_send_sync(struct_);
+    let send_sync_tokens = derive_send_sync(struct_, has_lifetime);
     let setter_tokens = derive_getters_and_setters(struct_, &members, root_structs, has_lifetimes);
     let manual_derive_tokens = manual_derives(struct_);
     let dbg_str = if debug_tokens.is_none() {
@@ -3222,6 +3223,14 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
             s.elements
                 .iter()
                 .filter_map(get_variant!(vkxml::StructElement::Member))
+                .filter(|x| {
+                    x.name.as_deref() == Some("pNext")
+                        // Opaque types (typically external system handles) are treated as pointers
+                        // rather than borrows. They don't carry a lifetime, unless they are wrapped
+                        // in a slice which inherently is lifetime-bounded.
+                        || x.size.is_some()
+                        || !is_opaque_type(&x.basetype)
+                })
                 .any(|x| x.reference.is_some())
         })
         .map(|s| name_to_tokens(&s.name))


### PR DESCRIPTION
Depends on #967

When a struct only contains pointers to opaque types (only `vk::AllocationCallbacks` was found to match this predicate), which we don't track in the builder, the lifetime parameter is completely unnecessary and useless as we don't have anything useful to key this off of.  The builder shouldn't force the incoming pointer to be any specific Rust thing to track the lifetime through, especially since its lifetime protrudes the lifetime of the `vk::AllocationCallbacks` structure and is passed into the callbacks whenever Vulkan wishes to call them, which could happen after an API command completes and a (stack-local) `vk::AllocationCallbacks` instance is destroyed again.
