### PR TITLE
Fix synchronization in the ash-examples

### DIFF
--- a/ash-examples/src/bin/texture.rs
+++ b/ash-examples/src/bin/texture.rs
@@ -688,6 +688,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let graphic_pipeline = graphics_pipelines[0];
 
         let _ = base.render_loop(|| {
+            base.device.wait_for_fences(&[base.draw_commands_reuse_fence], true, u64::MAX).unwrap();
+
             let (present_index, _) = base
                 .swapchain_loader
                 .acquire_next_image(

--- a/ash-examples/src/bin/triangle.rs
+++ b/ash-examples/src/bin/triangle.rs
@@ -350,6 +350,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let graphic_pipeline = graphics_pipelines[0];
 
         let _ = base.render_loop(|| {
+            base.device.wait_for_fences(&[base.draw_commands_reuse_fence], true, u64::MAX).unwrap();
+
             let (present_index, _) = base
                 .swapchain_loader
                 .acquire_next_image(


### PR DESCRIPTION
## What is this PR doing?
When `ash-examples` is executed with Vulkan 1.3.290.0, it generates error messages.

```sh
cargo run -p ash-examples --bin triangle

ERROR:
VALIDATION [VUID-vkAcquireNextImageKHR-semaphore-01779 (1461184347)] : Validation Error: [ VUID-vkAcquireNextImageKHR-semaphore-01779 ] Object 0: handle = 0xd5b26f0000000010, type = VK_OBJECT_TYPE_SEMAPHORE; | MessageID = 0x5717e75b | vkAcquireNextImageKHR():  Semaphore must not have any pending operations. The Vulkan spec states: If semaphore is not VK_NULL_HANDLE it must not have any uncompleted signal or wait operations pending (https://vulkan.lunarg.com/doc/view/1.3.290.0/mac/1.3-extensions/vkspec.html#VUID-vkAcquireNextImageKHR-semaphore-01779)
```

The PR is fixing this synchronization by including `draw_commands_reuse_fence` into the render_loop.