### PR TITLE
fix(ohos): OpenHarmony should link libvulkan.so

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -69,12 +69,13 @@ impl Entry {
                 target_os = "macos",
                 target_os = "ios",
                 target_os = "android",
-                target_os = "fuchsia"
+                target_os = "fuchsia",
+                target_env = "ohos"
             ))
         ))]
         const LIB_PATH: &str = "libvulkan.so.1";
 
-        #[cfg(any(target_os = "android", target_os = "fuchsia"))]
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_env = "ohos"))]
         const LIB_PATH: &str = "libvulkan.so";
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
For OpenHarmony/HarmonyNext, we need to link `libvulkan.so` not `libvulkan.so.1`. See detail with [doc](https://developer.huawei.com/consumer/en/doc/harmonyos-references-V5/vulkan-guidelines-V5#how-to-develop)