### PR TITLE
generator: Bump nom to 8.0.0

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 bindgen = "=0.69.4"
 heck = "0.5"
 itertools = "0.14"
-nom = "7.1"
+nom = "8"
 once_cell = "1.7"
 proc-macro2 = "1.0"
 quote = "1.0"


### PR DESCRIPTION
The main change is that we now have to call `.parse(i)` instead of the previous closure-based `(i)` call.

Supersedes #981.