### PR TITLE
Deduplicate `push()`/`extend()` helpers as a default impl on `TaggedStructure`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VK_EXT_metal_objects` device extension (#942)
 - Added `VK_AMD_anti_lag` device extension (#943)
 - Added `VK_KHR_video_queue`, `VK_KHR_video_encode_queue`, and `VK_KHR_video_decode_queue` device extensions (#965)
+- Added `AnyTaggedStructure` trait that is implemented for every (`dyn`amic) Vulkan structure. (#994)
 
 ### Changed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `push_next()` has been renamed to `extend()` and marked as `unsafe`. Users are encouraged to call `push()` for singular structs instead. (#909)
 - Changed and renamed `RawPtr::as_raw_ptr(&self)` trait function to a by-value `RawPtr::to_raw_ptr(self)` function. (#965)
 - All `Extends{Root}` traits have been replaced with a single `Extends<Root>` trait using generics. (#971)
+- Moved `push()` and `extend()` methods from individual Vulkan structs (builders) into the new `AnyTaggedStructure` trait. (#994)
 
 ### Removed
 

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -49,25 +49,9 @@ pub trait Handle: Sized {
     }
 }
 
-/// Structures implementing this trait are layout-compatible with [`BaseInStructure`] and
-/// [`BaseOutStructure`]. Such structures have an `s_type` field indicating its type, which must
-/// always match the value of [`TaggedStructure::STRUCTURE_TYPE`].
-pub unsafe trait TaggedStructure {
-    const STRUCTURE_TYPE: StructureType;
-}
-
-/// Implemented for every structure that extends base structure `B`. Concretely that means struct
-/// `B` is listed in its array of [`structextends` in the Vulkan registry][1].
-///
-/// Similar to [`TaggedStructure`], all `unsafe` implementers of this trait must guarantee that
-/// their structure is layout-compatible [`BaseInStructure`] and [`BaseOutStructure`].
-///
-/// [1]: https://registry.khronos.org/vulkan/specs/latest/styleguide.html#extensions-interactions
-pub unsafe trait Extends<B> {}
-
 /// Iterates through the pointer chain. Includes the item that is passed into the function.
 /// Stops at the last [`BaseOutStructure`] that has a null [`BaseOutStructure::p_next`] field.
-pub(crate) unsafe fn ptr_chain_iter<T: ?Sized>(
+pub(crate) unsafe fn ptr_chain_iter<'a, T: AnyTaggedStructure<'a> + ?Sized>(
     ptr: &mut T,
 ) -> impl Iterator<Item = *mut BaseOutStructure<'_>> {
     let ptr = <*mut T>::cast::<BaseOutStructure<'_>>(ptr);
@@ -81,6 +65,103 @@ pub(crate) unsafe fn ptr_chain_iter<T: ?Sized>(
         Some(old)
     })
 }
+
+/// Structures implementing this trait are layout-compatible with [`BaseInStructure`] and
+/// [`BaseOutStructure`]. Such structures have an `s_type` field indicating its type, which must
+/// always match the value of [`TaggedStructure::STRUCTURE_TYPE`].
+pub unsafe trait AnyTaggedStructure<'a> {
+    /// Prepends the given extension struct between the root and the first pointer. This
+    /// method only exists on structs that can be passed to a function directly. Only
+    /// valid extension structs can be pushed into the chain.
+    /// If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the
+    /// chain will look like `A -> D -> B -> C`.
+    ///
+    /// # Panics
+    /// If `next` contains a pointer chain of its own, this function will panic.  Call
+    /// `unsafe` [`Self::extend()`] to insert this chain instead.
+    fn push<T: Extends<'a, Self> + ?Sized>(mut self, next: &'a mut T) -> Self
+    where
+        Self: Sized,
+    {
+        // SAFETY: All implementors of `AnyTaggedStructure` are required to have the `BaseOutStructure` layout
+        let slf_base = unsafe { &mut *<*mut _>::cast::<BaseOutStructure<'_>>(&mut self) };
+        // SAFETY: All implementors of `T: Extends<'a, >: AnyTaggedStructure` are required to have the `BaseOutStructure` layout
+        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'_>>(next) };
+        // `next` here can contain a pointer chain.  This function refuses to insert the struct,
+        // in favour of calling unsafe extend().
+        assert!(
+            next_base.p_next.is_null(),
+            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
+        );
+        next_base.p_next = slf_base.p_next;
+        slf_base.p_next = next_base;
+        self
+    }
+
+    /// Prepends the given extension struct between the root and the first pointer. This
+    /// method only exists on structs that can be passed to a function directly. Only
+    /// valid extension structs can be pushed into the chain.
+    /// If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,
+    /// then the chain will look like `A -> D -> E -> B -> C`.
+    ///
+    /// # Safety
+    /// This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring
+    /// all non-`NULL` pointers to point to a valid Vulkan structure starting with the
+    /// [`BaseOutStructure`] layout.
+    ///
+    /// The last struct in this chain (i.e. the one where `p_next` is `NULL`) must
+    /// be writable memory, as its `p_next` field will be updated with the value of
+    /// `self.p_next`.
+    unsafe fn extend<T: Extends<'a, Self> + ?Sized>(mut self, next: &'a mut T) -> Self
+    where
+        Self: Sized,
+    {
+        // `next` here can contain a pointer chain. This means that we must correctly
+        // attach he head to the root and the tail to the rest of the chain
+        // For example:
+        //
+        // next = A -> B
+        // Before: `Root -> C -> D -> E`
+        // After: `Root -> A -> B -> C -> D -> E`
+        //                 ^^^^^^
+        //                 next chain
+        let slf_base = unsafe { &mut *<*mut _>::cast::<BaseOutStructure<'_>>(&mut self) };
+        let next_base = <*mut T>::cast::<BaseOutStructure<'_>>(next);
+        let last_next = ptr_chain_iter(next).last().unwrap();
+        (*last_next).p_next = slf_base.p_next;
+        slf_base.p_next = next_base;
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
+    unsafe fn push_next<T: Extends<'a, Self> + ?Sized>(self, next: &'a mut T) -> Self
+    where
+        Self: Sized,
+    {
+        self.extend(next)
+    }
+}
+
+/// Non-object-safe variant of [`AnyTaggedStructure`], meaning that a `dyn TaggedStructure` cannot
+/// exist but as a consequence the [`TaggedStructure::STRUCTURE_TYPE`] associated constant is
+/// available.
+///
+/// [`AnyTaggedStructure`]s have a [`BaseInStructure::s_type`] field indicating its type, which must
+/// always match the value of [`TaggedStructure::STRUCTURE_TYPE`].
+pub unsafe trait TaggedStructure<'a>: AnyTaggedStructure<'a> {
+    const STRUCTURE_TYPE: StructureType;
+}
+unsafe impl<'a, T: TaggedStructure<'a>> AnyTaggedStructure<'a> for T {}
+
+/// Implemented for every structure that extends base structure `B`. Concretely that means struct
+/// `B` is listed in its array of [`structextends` in the Vulkan registry][1].
+///
+/// Similar to [`TaggedStructure`], all `unsafe` implementers of this trait must guarantee that
+/// their structure is layout-compatible [`BaseInStructure`] and [`BaseOutStructure`].
+///
+/// [1]: https://registry.khronos.org/vulkan/specs/latest/styleguide.html#extensions-interactions
+pub unsafe trait Extends<'a, B: AnyTaggedStructure<'a>>: AnyTaggedStructure<'a> {}
 
 /// Holds 24 bits in the least significant bits of memory,
 /// and 8 bytes in the most significant bits of that memory,
@@ -211,6 +292,7 @@ pub(crate) fn debug_flags<Value: Into<u64> + Copy>(
 #[cfg(test)]
 mod tests {
     use crate::vk;
+    use crate::vk::AnyTaggedStructure as _;
     use alloc::vec::Vec;
     #[test]
     fn test_ptr_chains() {
@@ -275,7 +357,7 @@ mod tests {
     #[test]
     fn test_dynamic_add_to_ptr_chain() {
         let mut variable_pointers = vk::PhysicalDeviceVariablePointerFeatures::default();
-        let variable_pointers: &mut dyn vk::Extends<vk::DeviceCreateInfo<'_>> =
+        let variable_pointers: &mut dyn vk::Extends<'_, vk::DeviceCreateInfo<'_>> =
             &mut variable_pointers;
         let chain = alloc::vec![<*mut _>::cast(variable_pointers)];
         let mut device_create_info = vk::DeviceCreateInfo::default().push(variable_pointers);

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -6,8 +6,8 @@ use super::enums::*;
 use super::native::*;
 use super::platform_types::*;
 use super::{
-    ptr_chain_iter, wrap_c_str_slice_until_nul, write_c_str_slice_with_nul,
-    CStrTooLargeForStaticArray, Extends, Handle, Packed24_8, TaggedStructure,
+    wrap_c_str_slice_until_nul, write_c_str_slice_with_nul, CStrTooLargeForStaticArray, Extends,
+    Handle, Packed24_8, TaggedStructure,
 };
 use core::ffi::*;
 use core::fmt;
@@ -1096,7 +1096,7 @@ impl ::core::default::Default for ApplicationInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ApplicationInfo<'a> {
+unsafe impl TaggedStructure<'_> for ApplicationInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::APPLICATION_INFO;
 }
 impl<'a> ApplicationInfo<'a> {
@@ -1259,7 +1259,7 @@ impl ::core::default::Default for DeviceQueueCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceQueueCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceQueueCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_QUEUE_CREATE_INFO;
 }
 impl<'a> DeviceQueueCreateInfo<'a> {
@@ -1278,50 +1278,6 @@ impl<'a> DeviceQueueCreateInfo<'a> {
         self.queue_count = queue_priorities.len() as _;
         self.p_queue_priorities = queue_priorities.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -1365,7 +1321,7 @@ impl ::core::default::Default for DeviceCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_CREATE_INFO;
 }
 impl<'a> DeviceCreateInfo<'a> {
@@ -1402,50 +1358,6 @@ impl<'a> DeviceCreateInfo<'a> {
         self.p_enabled_features = enabled_features;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -1481,7 +1393,7 @@ impl ::core::default::Default for InstanceCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for InstanceCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for InstanceCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INSTANCE_CREATE_INFO;
 }
 impl<'a> InstanceCreateInfo<'a> {
@@ -1506,50 +1418,6 @@ impl<'a> InstanceCreateInfo<'a> {
         self.enabled_extension_count = enabled_extension_names.len() as _;
         self.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -1668,7 +1536,7 @@ impl ::core::default::Default for MemoryAllocateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for MemoryAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_ALLOCATE_INFO;
 }
 impl<'a> MemoryAllocateInfo<'a> {
@@ -1681,50 +1549,6 @@ impl<'a> MemoryAllocateInfo<'a> {
     pub fn memory_type_index(mut self, memory_type_index: u32) -> Self {
         self.memory_type_index = memory_type_index;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -1890,7 +1714,7 @@ impl ::core::default::Default for MappedMemoryRange<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MappedMemoryRange<'a> {
+unsafe impl TaggedStructure<'_> for MappedMemoryRange<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MAPPED_MEMORY_RANGE;
 }
 impl<'a> MappedMemoryRange<'a> {
@@ -2068,7 +1892,7 @@ impl ::core::default::Default for WriteDescriptorSet<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WriteDescriptorSet<'a> {
+unsafe impl TaggedStructure<'_> for WriteDescriptorSet<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WRITE_DESCRIPTOR_SET;
 }
 impl<'a> WriteDescriptorSet<'a> {
@@ -2115,50 +1939,6 @@ impl<'a> WriteDescriptorSet<'a> {
         self.p_texel_buffer_view = texel_buffer_view.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -2196,7 +1976,7 @@ impl ::core::default::Default for CopyDescriptorSet<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyDescriptorSet<'a> {
+unsafe impl TaggedStructure<'_> for CopyDescriptorSet<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_DESCRIPTOR_SET;
 }
 impl<'a> CopyDescriptorSet<'a> {
@@ -2260,13 +2040,19 @@ impl ::core::default::Default for BufferUsageFlags2CreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferUsageFlags2CreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for BufferUsageFlags2CreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR;
 }
-unsafe impl Extends<BufferViewCreateInfo<'_>> for BufferUsageFlags2CreateInfoKHR<'_> {}
-unsafe impl Extends<BufferCreateInfo<'_>> for BufferUsageFlags2CreateInfoKHR<'_> {}
-unsafe impl Extends<PhysicalDeviceExternalBufferInfo<'_>> for BufferUsageFlags2CreateInfoKHR<'_> {}
-unsafe impl Extends<DescriptorBufferBindingInfoEXT<'_>> for BufferUsageFlags2CreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, BufferViewCreateInfo<'a>> for BufferUsageFlags2CreateInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for BufferUsageFlags2CreateInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceExternalBufferInfo<'a>>
+    for BufferUsageFlags2CreateInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DescriptorBufferBindingInfoEXT<'a>>
+    for BufferUsageFlags2CreateInfoKHR<'a>
+{
+}
 impl<'a> BufferUsageFlags2CreateInfoKHR<'a> {
     #[inline]
     pub fn usage(mut self, usage: BufferUsageFlags2KHR) -> Self {
@@ -2308,7 +2094,7 @@ impl ::core::default::Default for BufferCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for BufferCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_CREATE_INFO;
 }
 impl<'a> BufferCreateInfo<'a> {
@@ -2337,50 +2123,6 @@ impl<'a> BufferCreateInfo<'a> {
         self.queue_family_index_count = queue_family_indices.len() as _;
         self.p_queue_family_indices = queue_family_indices.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -2415,7 +2157,7 @@ impl ::core::default::Default for BufferViewCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferViewCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for BufferViewCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_VIEW_CREATE_INFO;
 }
 impl<'a> BufferViewCreateInfo<'a> {
@@ -2443,50 +2185,6 @@ impl<'a> BufferViewCreateInfo<'a> {
     pub fn range(mut self, range: DeviceSize) -> Self {
         self.range = range;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -2614,7 +2312,7 @@ impl ::core::default::Default for MemoryBarrier<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryBarrier<'a> {
+unsafe impl TaggedStructure<'_> for MemoryBarrier<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_BARRIER;
 }
 impl<'a> MemoryBarrier<'a> {
@@ -2665,7 +2363,7 @@ impl ::core::default::Default for BufferMemoryBarrier<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferMemoryBarrier<'a> {
+unsafe impl TaggedStructure<'_> for BufferMemoryBarrier<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_MEMORY_BARRIER;
 }
 impl<'a> BufferMemoryBarrier<'a> {
@@ -2703,50 +2401,6 @@ impl<'a> BufferMemoryBarrier<'a> {
     pub fn size(mut self, size: DeviceSize) -> Self {
         self.size = size;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -2787,7 +2441,7 @@ impl ::core::default::Default for ImageMemoryBarrier<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageMemoryBarrier<'a> {
+unsafe impl TaggedStructure<'_> for ImageMemoryBarrier<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_MEMORY_BARRIER;
 }
 impl<'a> ImageMemoryBarrier<'a> {
@@ -2830,50 +2484,6 @@ impl<'a> ImageMemoryBarrier<'a> {
     pub fn subresource_range(mut self, subresource_range: ImageSubresourceRange) -> Self {
         self.subresource_range = subresource_range;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -2924,7 +2534,7 @@ impl ::core::default::Default for ImageCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ImageCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_CREATE_INFO;
 }
 impl<'a> ImageCreateInfo<'a> {
@@ -2988,50 +2598,6 @@ impl<'a> ImageCreateInfo<'a> {
     pub fn initial_layout(mut self, initial_layout: ImageLayout) -> Self {
         self.initial_layout = initial_layout;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -3107,7 +2673,7 @@ impl ::core::default::Default for ImageViewCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_CREATE_INFO;
 }
 impl<'a> ImageViewCreateInfo<'a> {
@@ -3140,50 +2706,6 @@ impl<'a> ImageViewCreateInfo<'a> {
     pub fn subresource_range(mut self, subresource_range: ImageSubresourceRange) -> Self {
         self.subresource_range = subresource_range;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -3450,7 +2972,7 @@ impl ::core::default::Default for BindSparseInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindSparseInfo<'a> {
+unsafe impl TaggedStructure<'_> for BindSparseInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_SPARSE_INFO;
 }
 impl<'a> BindSparseInfo<'a> {
@@ -3486,50 +3008,6 @@ impl<'a> BindSparseInfo<'a> {
         self.signal_semaphore_count = signal_semaphores.len() as _;
         self.p_signal_semaphores = signal_semaphores.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -3799,10 +3277,10 @@ impl ::core::default::Default for ShaderModuleCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ShaderModuleCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ShaderModuleCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SHADER_MODULE_CREATE_INFO;
 }
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>> for ShaderModuleCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>> for ShaderModuleCreateInfo<'a> {}
 impl<'a> ShaderModuleCreateInfo<'a> {
     #[inline]
     pub fn flags(mut self, flags: ShaderModuleCreateFlags) -> Self {
@@ -3814,50 +3292,6 @@ impl<'a> ShaderModuleCreateInfo<'a> {
         self.code_size = code.len() * 4;
         self.p_code = code.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -3944,7 +3378,7 @@ impl ::core::default::Default for DescriptorSetLayoutCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetLayoutCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetLayoutCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
 }
 impl<'a> DescriptorSetLayoutCreateInfo<'a> {
@@ -3958,50 +3392,6 @@ impl<'a> DescriptorSetLayoutCreateInfo<'a> {
         self.binding_count = bindings.len() as _;
         self.p_bindings = bindings.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -4055,7 +3445,7 @@ impl ::core::default::Default for DescriptorPoolCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorPoolCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorPoolCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_POOL_CREATE_INFO;
 }
 impl<'a> DescriptorPoolCreateInfo<'a> {
@@ -4074,50 +3464,6 @@ impl<'a> DescriptorPoolCreateInfo<'a> {
         self.pool_size_count = pool_sizes.len() as _;
         self.p_pool_sizes = pool_sizes.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -4148,7 +3494,7 @@ impl ::core::default::Default for DescriptorSetAllocateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_SET_ALLOCATE_INFO;
 }
 impl<'a> DescriptorSetAllocateInfo<'a> {
@@ -4162,50 +3508,6 @@ impl<'a> DescriptorSetAllocateInfo<'a> {
         self.descriptor_set_count = set_layouts.len() as _;
         self.p_set_layouts = set_layouts.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -4307,7 +3609,7 @@ impl ::core::default::Default for PipelineShaderStageCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineShaderStageCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineShaderStageCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO;
 }
 impl<'a> PipelineShaderStageCreateInfo<'a> {
@@ -4344,50 +3646,6 @@ impl<'a> PipelineShaderStageCreateInfo<'a> {
         self.p_specialization_info = specialization_info;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -4421,7 +3679,7 @@ impl ::core::default::Default for ComputePipelineCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ComputePipelineCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ComputePipelineCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMPUTE_PIPELINE_CREATE_INFO;
 }
 impl<'a> ComputePipelineCreateInfo<'a> {
@@ -4449,50 +3707,6 @@ impl<'a> ComputePipelineCreateInfo<'a> {
     pub fn base_pipeline_index(mut self, base_pipeline_index: i32) -> Self {
         self.base_pipeline_index = base_pipeline_index;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -4523,10 +3737,13 @@ impl ::core::default::Default for ComputePipelineIndirectBufferInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ComputePipelineIndirectBufferInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for ComputePipelineIndirectBufferInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV;
 }
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for ComputePipelineIndirectBufferInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>>
+    for ComputePipelineIndirectBufferInfoNV<'a>
+{
+}
 impl<'a> ComputePipelineIndirectBufferInfoNV<'a> {
     #[inline]
     pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
@@ -4571,13 +3788,25 @@ impl ::core::default::Default for PipelineCreateFlags2CreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCreateFlags2CreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCreateFlags2CreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR;
 }
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for PipelineCreateFlags2CreateInfoKHR<'_> {}
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineCreateFlags2CreateInfoKHR<'_> {}
-unsafe impl Extends<RayTracingPipelineCreateInfoNV<'_>> for PipelineCreateFlags2CreateInfoKHR<'_> {}
-unsafe impl Extends<RayTracingPipelineCreateInfoKHR<'_>> for PipelineCreateFlags2CreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>>
+    for PipelineCreateFlags2CreateInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineCreateFlags2CreateInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RayTracingPipelineCreateInfoNV<'a>>
+    for PipelineCreateFlags2CreateInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RayTracingPipelineCreateInfoKHR<'a>>
+    for PipelineCreateFlags2CreateInfoKHR<'a>
+{
+}
 impl<'a> PipelineCreateFlags2CreateInfoKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: PipelineCreateFlags2KHR) -> Self {
@@ -4677,7 +3906,7 @@ impl ::core::default::Default for PipelineVertexInputStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineVertexInputStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineVertexInputStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
 }
 impl<'a> PipelineVertexInputStateCreateInfo<'a> {
@@ -4703,50 +3932,6 @@ impl<'a> PipelineVertexInputStateCreateInfo<'a> {
         self.vertex_attribute_description_count = vertex_attribute_descriptions.len() as _;
         self.p_vertex_attribute_descriptions = vertex_attribute_descriptions.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -4777,7 +3962,7 @@ impl ::core::default::Default for PipelineInputAssemblyStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineInputAssemblyStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineInputAssemblyStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
 }
 impl<'a> PipelineInputAssemblyStateCreateInfo<'a> {
@@ -4823,7 +4008,7 @@ impl ::core::default::Default for PipelineTessellationStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineTessellationStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineTessellationStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_TESSELLATION_STATE_CREATE_INFO;
 }
 impl<'a> PipelineTessellationStateCreateInfo<'a> {
@@ -4836,50 +4021,6 @@ impl<'a> PipelineTessellationStateCreateInfo<'a> {
     pub fn patch_control_points(mut self, patch_control_points: u32) -> Self {
         self.patch_control_points = patch_control_points;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -4914,7 +4055,7 @@ impl ::core::default::Default for PipelineViewportStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_VIEWPORT_STATE_CREATE_INFO;
 }
 impl<'a> PipelineViewportStateCreateInfo<'a> {
@@ -4944,50 +4085,6 @@ impl<'a> PipelineViewportStateCreateInfo<'a> {
         self.scissor_count = scissors.len() as _;
         self.p_scissors = scissors.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -5034,7 +4131,7 @@ impl ::core::default::Default for PipelineRasterizationStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 }
 impl<'a> PipelineRasterizationStateCreateInfo<'a> {
@@ -5093,50 +4190,6 @@ impl<'a> PipelineRasterizationStateCreateInfo<'a> {
         self.line_width = line_width;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -5174,7 +4227,7 @@ impl ::core::default::Default for PipelineMultisampleStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineMultisampleStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineMultisampleStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
 }
 impl<'a> PipelineMultisampleStateCreateInfo<'a> {
@@ -5221,50 +4274,6 @@ impl<'a> PipelineMultisampleStateCreateInfo<'a> {
     pub fn alpha_to_one_enable(mut self, alpha_to_one_enable: bool) -> Self {
         self.alpha_to_one_enable = alpha_to_one_enable.into();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -5358,7 +4367,7 @@ impl ::core::default::Default for PipelineColorBlendStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineColorBlendStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineColorBlendStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
 }
 impl<'a> PipelineColorBlendStateCreateInfo<'a> {
@@ -5387,50 +4396,6 @@ impl<'a> PipelineColorBlendStateCreateInfo<'a> {
     pub fn blend_constants(mut self, blend_constants: [f32; 4]) -> Self {
         self.blend_constants = blend_constants;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -5461,7 +4426,7 @@ impl ::core::default::Default for PipelineDynamicStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineDynamicStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineDynamicStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_DYNAMIC_STATE_CREATE_INFO;
 }
 impl<'a> PipelineDynamicStateCreateInfo<'a> {
@@ -5570,7 +4535,7 @@ impl ::core::default::Default for PipelineDepthStencilStateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineDepthStencilStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineDepthStencilStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
 }
 impl<'a> PipelineDepthStencilStateCreateInfo<'a> {
@@ -5681,7 +4646,7 @@ impl ::core::default::Default for GraphicsPipelineCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GraphicsPipelineCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for GraphicsPipelineCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GRAPHICS_PIPELINE_CREATE_INFO;
 }
 impl<'a> GraphicsPipelineCreateInfo<'a> {
@@ -5790,50 +4755,6 @@ impl<'a> GraphicsPipelineCreateInfo<'a> {
         self.base_pipeline_index = base_pipeline_index;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -5863,7 +4784,7 @@ impl ::core::default::Default for PipelineCacheCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCacheCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCacheCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_CACHE_CREATE_INFO;
 }
 impl<'a> PipelineCacheCreateInfo<'a> {
@@ -5985,7 +4906,7 @@ impl ::core::default::Default for PipelineBinaryCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineBinaryCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineBinaryCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_BINARY_CREATE_INFO_KHR;
 }
 impl<'a> PipelineBinaryCreateInfoKHR<'a> {
@@ -6037,7 +4958,7 @@ impl ::core::default::Default for PipelineBinaryHandlesInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineBinaryHandlesInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineBinaryHandlesInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_BINARY_HANDLES_INFO_KHR;
 }
 impl<'a> PipelineBinaryHandlesInfoKHR<'a> {
@@ -6148,7 +5069,7 @@ impl ::core::default::Default for PipelineBinaryKeyKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineBinaryKeyKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineBinaryKeyKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_BINARY_KEY_KHR;
 }
 impl<'a> PipelineBinaryKeyKHR<'a> {
@@ -6189,12 +5110,12 @@ impl ::core::default::Default for PipelineBinaryInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineBinaryInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineBinaryInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_BINARY_INFO_KHR;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineBinaryInfoKHR<'_> {}
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for PipelineBinaryInfoKHR<'_> {}
-unsafe impl Extends<RayTracingPipelineCreateInfoKHR<'_>> for PipelineBinaryInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>> for PipelineBinaryInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>> for PipelineBinaryInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, RayTracingPipelineCreateInfoKHR<'a>> for PipelineBinaryInfoKHR<'a> {}
 impl<'a> PipelineBinaryInfoKHR<'a> {
     #[inline]
     pub fn pipeline_binaries(mut self, pipeline_binaries: &'a [PipelineBinaryKHR]) -> Self {
@@ -6227,7 +5148,7 @@ impl ::core::default::Default for ReleaseCapturedPipelineDataInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ReleaseCapturedPipelineDataInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ReleaseCapturedPipelineDataInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RELEASE_CAPTURED_PIPELINE_DATA_INFO_KHR;
 }
 impl<'a> ReleaseCapturedPipelineDataInfoKHR<'a> {
@@ -6261,7 +5182,7 @@ impl ::core::default::Default for PipelineBinaryDataInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineBinaryDataInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineBinaryDataInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_BINARY_DATA_INFO_KHR;
 }
 impl<'a> PipelineBinaryDataInfoKHR<'a> {
@@ -6293,7 +5214,7 @@ impl ::core::default::Default for PipelineCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_CREATE_INFO_KHR;
 }
 impl<'a> PipelineCreateInfoKHR<'a> {}
@@ -6329,19 +5250,28 @@ impl ::core::default::Default for PipelineLayoutCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineLayoutCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineLayoutCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_LAYOUT_CREATE_INFO;
 }
-unsafe impl Extends<BindDescriptorSetsInfoKHR<'_>> for PipelineLayoutCreateInfo<'_> {}
-unsafe impl Extends<PushConstantsInfoKHR<'_>> for PipelineLayoutCreateInfo<'_> {}
-unsafe impl Extends<PushDescriptorSetInfoKHR<'_>> for PipelineLayoutCreateInfo<'_> {}
-unsafe impl Extends<PushDescriptorSetWithTemplateInfoKHR<'_>> for PipelineLayoutCreateInfo<'_> {}
-unsafe impl Extends<SetDescriptorBufferOffsetsInfoEXT<'_>> for PipelineLayoutCreateInfo<'_> {}
-unsafe impl Extends<BindDescriptorBufferEmbeddedSamplersInfoEXT<'_>>
-    for PipelineLayoutCreateInfo<'_>
+unsafe impl<'a> Extends<'a, BindDescriptorSetsInfoKHR<'a>> for PipelineLayoutCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, PushConstantsInfoKHR<'a>> for PipelineLayoutCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, PushDescriptorSetInfoKHR<'a>> for PipelineLayoutCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, PushDescriptorSetWithTemplateInfoKHR<'a>>
+    for PipelineLayoutCreateInfo<'a>
 {
 }
-unsafe impl Extends<IndirectCommandsLayoutCreateInfoEXT<'_>> for PipelineLayoutCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, SetDescriptorBufferOffsetsInfoEXT<'a>>
+    for PipelineLayoutCreateInfo<'a>
+{
+}
+unsafe impl<'a> Extends<'a, BindDescriptorBufferEmbeddedSamplersInfoEXT<'a>>
+    for PipelineLayoutCreateInfo<'a>
+{
+}
+unsafe impl<'a> Extends<'a, IndirectCommandsLayoutCreateInfoEXT<'a>>
+    for PipelineLayoutCreateInfo<'a>
+{
+}
 impl<'a> PipelineLayoutCreateInfo<'a> {
     #[inline]
     pub fn flags(mut self, flags: PipelineLayoutCreateFlags) -> Self {
@@ -6415,7 +5345,7 @@ impl ::core::default::Default for SamplerCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for SamplerCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLER_CREATE_INFO;
 }
 impl<'a> SamplerCreateInfo<'a> {
@@ -6499,50 +5429,6 @@ impl<'a> SamplerCreateInfo<'a> {
         self.unnormalized_coordinates = unnormalized_coordinates.into();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -6570,7 +5456,7 @@ impl ::core::default::Default for CommandPoolCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandPoolCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for CommandPoolCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMMAND_POOL_CREATE_INFO;
 }
 impl<'a> CommandPoolCreateInfo<'a> {
@@ -6613,7 +5499,7 @@ impl ::core::default::Default for CommandBufferAllocateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMMAND_BUFFER_ALLOCATE_INFO;
 }
 impl<'a> CommandBufferAllocateInfo<'a> {
@@ -6667,7 +5553,7 @@ impl ::core::default::Default for CommandBufferInheritanceInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferInheritanceInfo<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferInheritanceInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMMAND_BUFFER_INHERITANCE_INFO;
 }
 impl<'a> CommandBufferInheritanceInfo<'a> {
@@ -6701,50 +5587,6 @@ impl<'a> CommandBufferInheritanceInfo<'a> {
         self.pipeline_statistics = pipeline_statistics;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -6772,7 +5614,7 @@ impl ::core::default::Default for CommandBufferBeginInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferBeginInfo<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferBeginInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMMAND_BUFFER_BEGIN_INFO;
 }
 impl<'a> CommandBufferBeginInfo<'a> {
@@ -6788,50 +5630,6 @@ impl<'a> CommandBufferBeginInfo<'a> {
     ) -> Self {
         self.p_inheritance_info = inheritance_info;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -6879,7 +5677,7 @@ impl ::core::default::Default for RenderPassBeginInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassBeginInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassBeginInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_BEGIN_INFO;
 }
 impl<'a> RenderPassBeginInfo<'a> {
@@ -6903,50 +5701,6 @@ impl<'a> RenderPassBeginInfo<'a> {
         self.clear_value_count = clear_values.len() as _;
         self.p_clear_values = clear_values.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -7286,7 +6040,7 @@ impl ::core::default::Default for RenderPassCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_CREATE_INFO;
 }
 impl<'a> RenderPassCreateInfo<'a> {
@@ -7313,50 +6067,6 @@ impl<'a> RenderPassCreateInfo<'a> {
         self.p_dependencies = dependencies.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -7382,7 +6092,7 @@ impl ::core::default::Default for EventCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for EventCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for EventCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EVENT_CREATE_INFO;
 }
 impl<'a> EventCreateInfo<'a> {
@@ -7390,50 +6100,6 @@ impl<'a> EventCreateInfo<'a> {
     pub fn flags(mut self, flags: EventCreateFlags) -> Self {
         self.flags = flags;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -7460,7 +6126,7 @@ impl ::core::default::Default for FenceCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FenceCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for FenceCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FENCE_CREATE_INFO;
 }
 impl<'a> FenceCreateInfo<'a> {
@@ -7468,50 +6134,6 @@ impl<'a> FenceCreateInfo<'a> {
     pub fn flags(mut self, flags: FenceCreateFlags) -> Self {
         self.flags = flags;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -8853,7 +7475,7 @@ impl ::core::default::Default for SemaphoreCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_CREATE_INFO;
 }
 impl<'a> SemaphoreCreateInfo<'a> {
@@ -8861,50 +7483,6 @@ impl<'a> SemaphoreCreateInfo<'a> {
     pub fn flags(mut self, flags: SemaphoreCreateFlags) -> Self {
         self.flags = flags;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -8937,7 +7515,7 @@ impl ::core::default::Default for QueryPoolCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueryPoolCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for QueryPoolCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUERY_POOL_CREATE_INFO;
 }
 impl<'a> QueryPoolCreateInfo<'a> {
@@ -8960,50 +7538,6 @@ impl<'a> QueryPoolCreateInfo<'a> {
     pub fn pipeline_statistics(mut self, pipeline_statistics: QueryPipelineStatisticFlags) -> Self {
         self.pipeline_statistics = pipeline_statistics;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -9042,7 +7576,7 @@ impl ::core::default::Default for FramebufferCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FramebufferCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for FramebufferCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FRAMEBUFFER_CREATE_INFO;
 }
 impl<'a> FramebufferCreateInfo<'a> {
@@ -9081,50 +7615,6 @@ impl<'a> FramebufferCreateInfo<'a> {
     pub fn layers(mut self, layers: u32) -> Self {
         self.layers = layers;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -9310,7 +7800,7 @@ impl ::core::default::Default for SubmitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubmitInfo<'a> {
+unsafe impl TaggedStructure<'_> for SubmitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBMIT_INFO;
 }
 impl<'a> SubmitInfo<'a> {
@@ -9337,50 +7827,6 @@ impl<'a> SubmitInfo<'a> {
         self.signal_semaphore_count = signal_semaphores.len() as _;
         self.p_signal_semaphores = signal_semaphores.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -9549,7 +7995,7 @@ impl ::core::default::Default for DisplayModeCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayModeCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayModeCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_MODE_CREATE_INFO_KHR;
 }
 impl<'a> DisplayModeCreateInfoKHR<'a> {
@@ -9665,7 +8111,7 @@ impl ::core::default::Default for DisplaySurfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplaySurfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplaySurfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_SURFACE_CREATE_INFO_KHR;
 }
 impl<'a> DisplaySurfaceCreateInfoKHR<'a> {
@@ -9738,10 +8184,10 @@ impl ::core::default::Default for DisplayPresentInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayPresentInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayPresentInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_PRESENT_INFO_KHR;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for DisplayPresentInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for DisplayPresentInfoKHR<'a> {}
 impl<'a> DisplayPresentInfoKHR<'a> {
     #[inline]
     pub fn src_rect(mut self, src_rect: Rect2D) -> Self {
@@ -9857,7 +8303,7 @@ impl ::core::default::Default for AndroidSurfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AndroidSurfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AndroidSurfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ANDROID_SURFACE_CREATE_INFO_KHR;
 }
 impl<'a> AndroidSurfaceCreateInfoKHR<'a> {
@@ -9898,7 +8344,7 @@ impl ::core::default::Default for ViSurfaceCreateInfoNN<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ViSurfaceCreateInfoNN<'a> {
+unsafe impl TaggedStructure<'_> for ViSurfaceCreateInfoNN<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VI_SURFACE_CREATE_INFO_NN;
 }
 impl<'a> ViSurfaceCreateInfoNN<'a> {
@@ -9941,7 +8387,7 @@ impl ::core::default::Default for WaylandSurfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WaylandSurfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for WaylandSurfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WAYLAND_SURFACE_CREATE_INFO_KHR;
 }
 impl<'a> WaylandSurfaceCreateInfoKHR<'a> {
@@ -9989,7 +8435,7 @@ impl ::core::default::Default for Win32SurfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for Win32SurfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for Win32SurfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WIN32_SURFACE_CREATE_INFO_KHR;
 }
 impl<'a> Win32SurfaceCreateInfoKHR<'a> {
@@ -10037,7 +8483,7 @@ impl ::core::default::Default for XlibSurfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for XlibSurfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for XlibSurfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::XLIB_SURFACE_CREATE_INFO_KHR;
 }
 impl<'a> XlibSurfaceCreateInfoKHR<'a> {
@@ -10085,7 +8531,7 @@ impl ::core::default::Default for XcbSurfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for XcbSurfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for XcbSurfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::XCB_SURFACE_CREATE_INFO_KHR;
 }
 impl<'a> XcbSurfaceCreateInfoKHR<'a> {
@@ -10133,7 +8579,7 @@ impl ::core::default::Default for DirectFBSurfaceCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DirectFBSurfaceCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DirectFBSurfaceCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DIRECTFB_SURFACE_CREATE_INFO_EXT;
 }
 impl<'a> DirectFBSurfaceCreateInfoEXT<'a> {
@@ -10179,7 +8625,7 @@ impl ::core::default::Default for ImagePipeSurfaceCreateInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImagePipeSurfaceCreateInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for ImagePipeSurfaceCreateInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA;
 }
 impl<'a> ImagePipeSurfaceCreateInfoFUCHSIA<'a> {
@@ -10220,7 +8666,7 @@ impl ::core::default::Default for StreamDescriptorSurfaceCreateInfoGGP<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for StreamDescriptorSurfaceCreateInfoGGP<'a> {
+unsafe impl TaggedStructure<'_> for StreamDescriptorSurfaceCreateInfoGGP<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP;
 }
 impl<'a> StreamDescriptorSurfaceCreateInfoGGP<'a> {
@@ -10263,7 +8709,7 @@ impl ::core::default::Default for ScreenSurfaceCreateInfoQNX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ScreenSurfaceCreateInfoQNX<'a> {
+unsafe impl TaggedStructure<'_> for ScreenSurfaceCreateInfoQNX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SCREEN_SURFACE_CREATE_INFO_QNX;
 }
 impl<'a> ScreenSurfaceCreateInfoQNX<'a> {
@@ -10358,7 +8804,7 @@ impl ::core::default::Default for SwapchainCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_CREATE_INFO_KHR;
 }
 impl<'a> SwapchainCreateInfoKHR<'a> {
@@ -10438,50 +8884,6 @@ impl<'a> SwapchainCreateInfoKHR<'a> {
         self.old_swapchain = old_swapchain;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -10517,7 +8919,7 @@ impl ::core::default::Default for PresentInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PresentInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PresentInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PRESENT_INFO_KHR;
 }
 impl<'a> PresentInfoKHR<'a> {
@@ -10544,50 +8946,6 @@ impl<'a> PresentInfoKHR<'a> {
         self.swapchain_count = results.len() as _;
         self.p_results = results.as_mut_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -10629,10 +8987,10 @@ impl ::core::default::Default for DebugReportCallbackCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugReportCallbackCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugReportCallbackCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for DebugReportCallbackCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for DebugReportCallbackCreateInfoEXT<'a> {}
 impl<'a> DebugReportCallbackCreateInfoEXT<'a> {
     #[inline]
     pub fn flags(mut self, flags: DebugReportFlagsEXT) -> Self {
@@ -10676,10 +9034,10 @@ impl ::core::default::Default for ValidationFlagsEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ValidationFlagsEXT<'a> {
+unsafe impl TaggedStructure<'_> for ValidationFlagsEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VALIDATION_FLAGS_EXT;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for ValidationFlagsEXT<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for ValidationFlagsEXT<'a> {}
 impl<'a> ValidationFlagsEXT<'a> {
     #[inline]
     pub fn disabled_validation_checks(
@@ -10721,12 +9079,12 @@ impl ::core::default::Default for ValidationFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ValidationFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for ValidationFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VALIDATION_FEATURES_EXT;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for ValidationFeaturesEXT<'_> {}
-unsafe impl Extends<ShaderModuleCreateInfo<'_>> for ValidationFeaturesEXT<'_> {}
-unsafe impl Extends<ShaderCreateInfoEXT<'_>> for ValidationFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for ValidationFeaturesEXT<'a> {}
+unsafe impl<'a> Extends<'a, ShaderModuleCreateInfo<'a>> for ValidationFeaturesEXT<'a> {}
+unsafe impl<'a> Extends<'a, ShaderCreateInfoEXT<'a>> for ValidationFeaturesEXT<'a> {}
 impl<'a> ValidationFeaturesEXT<'a> {
     #[inline]
     pub fn enabled_validation_features(
@@ -10773,10 +9131,10 @@ impl ::core::default::Default for LayerSettingsCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for LayerSettingsCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for LayerSettingsCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::LAYER_SETTINGS_CREATE_INFO_EXT;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for LayerSettingsCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for LayerSettingsCreateInfoEXT<'a> {}
 impl<'a> LayerSettingsCreateInfoEXT<'a> {
     #[inline]
     pub fn settings(mut self, settings: &'a [LayerSettingEXT<'a>]) -> Self {
@@ -10876,12 +9234,12 @@ impl ::core::default::Default for PipelineRasterizationStateRasterizationOrderAM
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationStateRasterizationOrderAMD<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationStateRasterizationOrderAMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD;
 }
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for PipelineRasterizationStateRasterizationOrderAMD<'_>
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for PipelineRasterizationStateRasterizationOrderAMD<'a>
 {
 }
 impl<'a> PipelineRasterizationStateRasterizationOrderAMD<'a> {
@@ -10919,7 +9277,7 @@ impl ::core::default::Default for DebugMarkerObjectNameInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugMarkerObjectNameInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugMarkerObjectNameInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
 }
 impl<'a> DebugMarkerObjectNameInfoEXT<'a> {
@@ -10979,7 +9337,7 @@ impl ::core::default::Default for DebugMarkerObjectTagInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugMarkerObjectTagInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugMarkerObjectTagInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_MARKER_OBJECT_TAG_INFO_EXT;
 }
 impl<'a> DebugMarkerObjectTagInfoEXT<'a> {
@@ -11031,7 +9389,7 @@ impl ::core::default::Default for DebugMarkerMarkerInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugMarkerMarkerInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugMarkerMarkerInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_MARKER_MARKER_INFO_EXT;
 }
 impl<'a> DebugMarkerMarkerInfoEXT<'a> {
@@ -11078,10 +9436,10 @@ impl ::core::default::Default for DedicatedAllocationImageCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DedicatedAllocationImageCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for DedicatedAllocationImageCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for DedicatedAllocationImageCreateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for DedicatedAllocationImageCreateInfoNV<'a> {}
 impl<'a> DedicatedAllocationImageCreateInfoNV<'a> {
     #[inline]
     pub fn dedicated_allocation(mut self, dedicated_allocation: bool) -> Self {
@@ -11113,10 +9471,10 @@ impl ::core::default::Default for DedicatedAllocationBufferCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DedicatedAllocationBufferCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for DedicatedAllocationBufferCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV;
 }
-unsafe impl Extends<BufferCreateInfo<'_>> for DedicatedAllocationBufferCreateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for DedicatedAllocationBufferCreateInfoNV<'a> {}
 impl<'a> DedicatedAllocationBufferCreateInfoNV<'a> {
     #[inline]
     pub fn dedicated_allocation(mut self, dedicated_allocation: bool) -> Self {
@@ -11150,11 +9508,14 @@ impl ::core::default::Default for DedicatedAllocationMemoryAllocateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DedicatedAllocationMemoryAllocateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for DedicatedAllocationMemoryAllocateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for DedicatedAllocationMemoryAllocateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>>
+    for DedicatedAllocationMemoryAllocateInfoNV<'a>
+{
+}
 impl<'a> DedicatedAllocationMemoryAllocateInfoNV<'a> {
     #[inline]
     pub fn image(mut self, image: Image) -> Self {
@@ -11236,10 +9597,10 @@ impl ::core::default::Default for ExternalMemoryImageCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalMemoryImageCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for ExternalMemoryImageCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ExternalMemoryImageCreateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ExternalMemoryImageCreateInfoNV<'a> {}
 impl<'a> ExternalMemoryImageCreateInfoNV<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlagsNV) -> Self {
@@ -11271,10 +9632,10 @@ impl ::core::default::Default for ExportMemoryAllocateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMemoryAllocateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for ExportMemoryAllocateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_MEMORY_ALLOCATE_INFO_NV;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ExportMemoryAllocateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ExportMemoryAllocateInfoNV<'a> {}
 impl<'a> ExportMemoryAllocateInfoNV<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlagsNV) -> Self {
@@ -11308,10 +9669,10 @@ impl ::core::default::Default for ImportMemoryWin32HandleInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMemoryWin32HandleInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for ImportMemoryWin32HandleInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_MEMORY_WIN32_HANDLE_INFO_NV;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMemoryWin32HandleInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMemoryWin32HandleInfoNV<'a> {}
 impl<'a> ImportMemoryWin32HandleInfoNV<'a> {
     #[inline]
     pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlagsNV) -> Self {
@@ -11350,10 +9711,10 @@ impl ::core::default::Default for ExportMemoryWin32HandleInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMemoryWin32HandleInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for ExportMemoryWin32HandleInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_MEMORY_WIN32_HANDLE_INFO_NV;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ExportMemoryWin32HandleInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ExportMemoryWin32HandleInfoNV<'a> {}
 impl<'a> ExportMemoryWin32HandleInfoNV<'a> {
     #[inline]
     pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
@@ -11402,11 +9763,11 @@ impl ::core::default::Default for Win32KeyedMutexAcquireReleaseInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for Win32KeyedMutexAcquireReleaseInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for Win32KeyedMutexAcquireReleaseInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV;
 }
-unsafe impl Extends<SubmitInfo<'_>> for Win32KeyedMutexAcquireReleaseInfoNV<'_> {}
-unsafe impl Extends<SubmitInfo2<'_>> for Win32KeyedMutexAcquireReleaseInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for Win32KeyedMutexAcquireReleaseInfoNV<'a> {}
+unsafe impl<'a> Extends<'a, SubmitInfo2<'a>> for Win32KeyedMutexAcquireReleaseInfoNV<'a> {}
 impl<'a> Win32KeyedMutexAcquireReleaseInfoNV<'a> {
     #[inline]
     pub fn acquire_syncs(mut self, acquire_syncs: &'a [DeviceMemory]) -> Self {
@@ -11463,15 +9824,18 @@ impl ::core::default::Default for PhysicalDeviceDeviceGeneratedCommandsFeaturesN
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsFeaturesNV<'a> {
     #[inline]
     pub fn device_generated_commands(mut self, device_generated_commands: bool) -> Self {
@@ -11507,16 +9871,16 @@ impl ::core::default::Default for PhysicalDeviceDeviceGeneratedCommandsComputeFe
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV<'a> {
@@ -11567,10 +9931,10 @@ impl ::core::default::Default for DevicePrivateDataCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DevicePrivateDataCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DevicePrivateDataCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_PRIVATE_DATA_CREATE_INFO;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for DevicePrivateDataCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for DevicePrivateDataCreateInfo<'a> {}
 impl<'a> DevicePrivateDataCreateInfo<'a> {
     #[inline]
     pub fn private_data_slot_request_count(mut self, private_data_slot_request_count: u32) -> Self {
@@ -11602,7 +9966,7 @@ impl ::core::default::Default for PrivateDataSlotCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PrivateDataSlotCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PrivateDataSlotCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PRIVATE_DATA_SLOT_CREATE_INFO;
 }
 impl<'a> PrivateDataSlotCreateInfo<'a> {
@@ -11636,11 +10000,11 @@ impl ::core::default::Default for PhysicalDevicePrivateDataFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePrivateDataFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePrivateDataFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevicePrivateDataFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePrivateDataFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDevicePrivateDataFeatures<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevicePrivateDataFeatures<'a> {}
 impl<'a> PhysicalDevicePrivateDataFeatures<'a> {
     #[inline]
     pub fn private_data(mut self, private_data: bool) -> Self {
@@ -11688,12 +10052,12 @@ impl ::core::default::Default for PhysicalDeviceDeviceGeneratedCommandsPropertie
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDeviceGeneratedCommandsPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDeviceGeneratedCommandsPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDeviceGeneratedCommandsPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsPropertiesNV<'a> {
@@ -11791,10 +10155,13 @@ impl ::core::default::Default for PhysicalDeviceMultiDrawPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiDrawPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiDrawPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMultiDrawPropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMultiDrawPropertiesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceMultiDrawPropertiesEXT<'a> {
     #[inline]
     pub fn max_multi_draw_count(mut self, max_multi_draw_count: u32) -> Self {
@@ -11832,7 +10199,7 @@ impl ::core::default::Default for GraphicsShaderGroupCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GraphicsShaderGroupCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for GraphicsShaderGroupCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GRAPHICS_SHADER_GROUP_CREATE_INFO_NV;
 }
 impl<'a> GraphicsShaderGroupCreateInfoNV<'a> {
@@ -11889,12 +10256,12 @@ impl ::core::default::Default for GraphicsPipelineShaderGroupsCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GraphicsPipelineShaderGroupsCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for GraphicsPipelineShaderGroupsCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>>
-    for GraphicsPipelineShaderGroupsCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for GraphicsPipelineShaderGroupsCreateInfoNV<'a>
 {
 }
 impl<'a> GraphicsPipelineShaderGroupsCreateInfoNV<'a> {
@@ -12064,7 +10431,7 @@ impl ::core::default::Default for IndirectCommandsLayoutTokenNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectCommandsLayoutTokenNV<'a> {
+unsafe impl TaggedStructure<'_> for IndirectCommandsLayoutTokenNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_COMMANDS_LAYOUT_TOKEN_NV;
 }
 impl<'a> IndirectCommandsLayoutTokenNV<'a> {
@@ -12171,7 +10538,7 @@ impl ::core::default::Default for IndirectCommandsLayoutCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectCommandsLayoutCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for IndirectCommandsLayoutCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NV;
 }
 impl<'a> IndirectCommandsLayoutCreateInfoNV<'a> {
@@ -12246,7 +10613,7 @@ impl ::core::default::Default for GeneratedCommandsInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeneratedCommandsInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for GeneratedCommandsInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GENERATED_COMMANDS_INFO_NV;
 }
 impl<'a> GeneratedCommandsInfoNV<'a> {
@@ -12345,7 +10712,7 @@ impl ::core::default::Default for GeneratedCommandsMemoryRequirementsInfoNV<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeneratedCommandsMemoryRequirementsInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for GeneratedCommandsMemoryRequirementsInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV;
 }
@@ -12400,7 +10767,7 @@ impl ::core::default::Default for PipelineIndirectDeviceAddressInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineIndirectDeviceAddressInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineIndirectDeviceAddressInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV;
 }
 impl<'a> PipelineIndirectDeviceAddressInfoNV<'a> {
@@ -12454,59 +10821,15 @@ impl ::core::default::Default for PhysicalDeviceFeatures2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFeatures2<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFeatures2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_FEATURES_2;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFeatures2<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceFeatures2<'a> {}
 impl<'a> PhysicalDeviceFeatures2<'a> {
     #[inline]
     pub fn features(mut self, features: PhysicalDeviceFeatures) -> Self {
         self.features = features;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -12533,7 +10856,7 @@ impl ::core::default::Default for PhysicalDeviceProperties2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceProperties2<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceProperties2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_PROPERTIES_2;
 }
 impl<'a> PhysicalDeviceProperties2<'a> {
@@ -12541,50 +10864,6 @@ impl<'a> PhysicalDeviceProperties2<'a> {
     pub fn properties(mut self, properties: PhysicalDeviceProperties) -> Self {
         self.properties = properties;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -12611,7 +10890,7 @@ impl ::core::default::Default for FormatProperties2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FormatProperties2<'a> {
+unsafe impl TaggedStructure<'_> for FormatProperties2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FORMAT_PROPERTIES_2;
 }
 impl<'a> FormatProperties2<'a> {
@@ -12619,50 +10898,6 @@ impl<'a> FormatProperties2<'a> {
     pub fn format_properties(mut self, format_properties: FormatProperties) -> Self {
         self.format_properties = format_properties;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -12689,7 +10924,7 @@ impl ::core::default::Default for ImageFormatProperties2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageFormatProperties2<'a> {
+unsafe impl TaggedStructure<'_> for ImageFormatProperties2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_FORMAT_PROPERTIES_2;
 }
 impl<'a> ImageFormatProperties2<'a> {
@@ -12700,50 +10935,6 @@ impl<'a> ImageFormatProperties2<'a> {
     ) -> Self {
         self.image_format_properties = image_format_properties;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -12778,7 +10969,7 @@ impl ::core::default::Default for PhysicalDeviceImageFormatInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageFormatInfo2<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageFormatInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
 }
 impl<'a> PhysicalDeviceImageFormatInfo2<'a> {
@@ -12807,50 +10998,6 @@ impl<'a> PhysicalDeviceImageFormatInfo2<'a> {
         self.flags = flags;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -12876,7 +11023,7 @@ impl ::core::default::Default for QueueFamilyProperties2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueueFamilyProperties2<'a> {
+unsafe impl TaggedStructure<'_> for QueueFamilyProperties2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUEUE_FAMILY_PROPERTIES_2;
 }
 impl<'a> QueueFamilyProperties2<'a> {
@@ -12887,50 +11034,6 @@ impl<'a> QueueFamilyProperties2<'a> {
     ) -> Self {
         self.queue_family_properties = queue_family_properties;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -12957,7 +11060,7 @@ impl ::core::default::Default for PhysicalDeviceMemoryProperties2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMemoryProperties2<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMemoryProperties2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
 }
 impl<'a> PhysicalDeviceMemoryProperties2<'a> {
@@ -12965,50 +11068,6 @@ impl<'a> PhysicalDeviceMemoryProperties2<'a> {
     pub fn memory_properties(mut self, memory_properties: PhysicalDeviceMemoryProperties) -> Self {
         self.memory_properties = memory_properties;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -13035,7 +11094,7 @@ impl ::core::default::Default for SparseImageFormatProperties2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SparseImageFormatProperties2<'a> {
+unsafe impl TaggedStructure<'_> for SparseImageFormatProperties2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SPARSE_IMAGE_FORMAT_PROPERTIES_2;
 }
 impl<'a> SparseImageFormatProperties2<'a> {
@@ -13077,7 +11136,7 @@ impl ::core::default::Default for PhysicalDeviceSparseImageFormatInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSparseImageFormatInfo2<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSparseImageFormatInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2;
 }
 impl<'a> PhysicalDeviceSparseImageFormatInfo2<'a> {
@@ -13131,12 +11190,12 @@ impl ::core::default::Default for PhysicalDevicePushDescriptorPropertiesKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePushDescriptorPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePushDescriptorPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDevicePushDescriptorPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePushDescriptorPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDevicePushDescriptorPropertiesKHR<'a> {
@@ -13221,10 +11280,10 @@ impl ::core::default::Default for PhysicalDeviceDriverProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDriverProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDriverProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_DRIVER_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceDriverProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>> for PhysicalDeviceDriverProperties<'a> {}
 impl<'a> PhysicalDeviceDriverProperties<'a> {
     #[inline]
     pub fn driver_id(mut self, driver_id: DriverId) -> Self {
@@ -13285,10 +11344,10 @@ impl ::core::default::Default for PresentRegionsKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PresentRegionsKHR<'a> {
+unsafe impl TaggedStructure<'_> for PresentRegionsKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PRESENT_REGIONS_KHR;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for PresentRegionsKHR<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for PresentRegionsKHR<'a> {}
 impl<'a> PresentRegionsKHR<'a> {
     #[inline]
     pub fn regions(mut self, regions: &'a [PresentRegionKHR<'a>]) -> Self {
@@ -13380,11 +11439,14 @@ impl ::core::default::Default for PhysicalDeviceVariablePointersFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVariablePointersFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVariablePointersFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceVariablePointersFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVariablePointersFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceVariablePointersFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceVariablePointersFeatures<'a> {}
 impl<'a> PhysicalDeviceVariablePointersFeatures<'a> {
     #[inline]
     pub fn variable_pointers_storage_buffer(
@@ -13460,11 +11522,11 @@ impl ::core::default::Default for PhysicalDeviceExternalImageFormatInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalImageFormatInfo<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalImageFormatInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
 }
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>>
-    for PhysicalDeviceExternalImageFormatInfo<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>>
+    for PhysicalDeviceExternalImageFormatInfo<'a>
 {
 }
 impl<'a> PhysicalDeviceExternalImageFormatInfo<'a> {
@@ -13498,10 +11560,10 @@ impl ::core::default::Default for ExternalImageFormatProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalImageFormatProperties<'a> {
+unsafe impl TaggedStructure<'_> for ExternalImageFormatProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_IMAGE_FORMAT_PROPERTIES;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>> for ExternalImageFormatProperties<'_> {}
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>> for ExternalImageFormatProperties<'a> {}
 impl<'a> ExternalImageFormatProperties<'a> {
     #[inline]
     pub fn external_memory_properties(
@@ -13540,7 +11602,7 @@ impl ::core::default::Default for PhysicalDeviceExternalBufferInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalBufferInfo<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalBufferInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO;
 }
 impl<'a> PhysicalDeviceExternalBufferInfo<'a> {
@@ -13558,50 +11620,6 @@ impl<'a> PhysicalDeviceExternalBufferInfo<'a> {
     pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.handle_type = handle_type;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -13628,7 +11646,7 @@ impl ::core::default::Default for ExternalBufferProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalBufferProperties<'a> {
+unsafe impl TaggedStructure<'_> for ExternalBufferProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_BUFFER_PROPERTIES;
 }
 impl<'a> ExternalBufferProperties<'a> {
@@ -13673,10 +11691,10 @@ impl ::core::default::Default for PhysicalDeviceIDProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceIDProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceIDProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_ID_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceIDProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>> for PhysicalDeviceIDProperties<'a> {}
 impl<'a> PhysicalDeviceIDProperties<'a> {
     #[inline]
     pub fn device_uuid(mut self, device_uuid: [u8; UUID_SIZE]) -> Self {
@@ -13728,10 +11746,10 @@ impl ::core::default::Default for ExternalMemoryImageCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalMemoryImageCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ExternalMemoryImageCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ExternalMemoryImageCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ExternalMemoryImageCreateInfo<'a> {}
 impl<'a> ExternalMemoryImageCreateInfo<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlags) -> Self {
@@ -13763,10 +11781,10 @@ impl ::core::default::Default for ExternalMemoryBufferCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalMemoryBufferCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ExternalMemoryBufferCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_MEMORY_BUFFER_CREATE_INFO;
 }
-unsafe impl Extends<BufferCreateInfo<'_>> for ExternalMemoryBufferCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for ExternalMemoryBufferCreateInfo<'a> {}
 impl<'a> ExternalMemoryBufferCreateInfo<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlags) -> Self {
@@ -13798,10 +11816,10 @@ impl ::core::default::Default for ExportMemoryAllocateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMemoryAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ExportMemoryAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_MEMORY_ALLOCATE_INFO;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ExportMemoryAllocateInfo<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ExportMemoryAllocateInfo<'a> {}
 impl<'a> ExportMemoryAllocateInfo<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlags) -> Self {
@@ -13837,10 +11855,10 @@ impl ::core::default::Default for ImportMemoryWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMemoryWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImportMemoryWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMemoryWin32HandleInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMemoryWin32HandleInfoKHR<'a> {}
 impl<'a> ImportMemoryWin32HandleInfoKHR<'a> {
     #[inline]
     pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
@@ -13886,10 +11904,10 @@ impl ::core::default::Default for ExportMemoryWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMemoryWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ExportMemoryWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ExportMemoryWin32HandleInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ExportMemoryWin32HandleInfoKHR<'a> {}
 impl<'a> ExportMemoryWin32HandleInfoKHR<'a> {
     #[inline]
     pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
@@ -13933,10 +11951,10 @@ impl ::core::default::Default for ImportMemoryZirconHandleInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMemoryZirconHandleInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for ImportMemoryZirconHandleInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMemoryZirconHandleInfoFUCHSIA<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMemoryZirconHandleInfoFUCHSIA<'a> {}
 impl<'a> ImportMemoryZirconHandleInfoFUCHSIA<'a> {
     #[inline]
     pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
@@ -13973,7 +11991,7 @@ impl ::core::default::Default for MemoryZirconHandlePropertiesFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryZirconHandlePropertiesFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for MemoryZirconHandlePropertiesFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_ZIRCON_HANDLE_PROPERTIES_FUCHSIA;
 }
 impl<'a> MemoryZirconHandlePropertiesFUCHSIA<'a> {
@@ -14009,7 +12027,7 @@ impl ::core::default::Default for MemoryGetZirconHandleInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryGetZirconHandleInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for MemoryGetZirconHandleInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_GET_ZIRCON_HANDLE_INFO_FUCHSIA;
 }
 impl<'a> MemoryGetZirconHandleInfoFUCHSIA<'a> {
@@ -14048,7 +12066,7 @@ impl ::core::default::Default for MemoryWin32HandlePropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryWin32HandlePropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for MemoryWin32HandlePropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_WIN32_HANDLE_PROPERTIES_KHR;
 }
 impl<'a> MemoryWin32HandlePropertiesKHR<'a> {
@@ -14084,7 +12102,7 @@ impl ::core::default::Default for MemoryGetWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryGetWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for MemoryGetWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_GET_WIN32_HANDLE_INFO_KHR;
 }
 impl<'a> MemoryGetWin32HandleInfoKHR<'a> {
@@ -14125,10 +12143,10 @@ impl ::core::default::Default for ImportMemoryFdInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMemoryFdInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImportMemoryFdInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_MEMORY_FD_INFO_KHR;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMemoryFdInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMemoryFdInfoKHR<'a> {}
 impl<'a> ImportMemoryFdInfoKHR<'a> {
     #[inline]
     pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
@@ -14165,7 +12183,7 @@ impl ::core::default::Default for MemoryFdPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryFdPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for MemoryFdPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_FD_PROPERTIES_KHR;
 }
 impl<'a> MemoryFdPropertiesKHR<'a> {
@@ -14201,7 +12219,7 @@ impl ::core::default::Default for MemoryGetFdInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryGetFdInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for MemoryGetFdInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_GET_FD_INFO_KHR;
 }
 impl<'a> MemoryGetFdInfoKHR<'a> {
@@ -14252,11 +12270,11 @@ impl ::core::default::Default for Win32KeyedMutexAcquireReleaseInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for Win32KeyedMutexAcquireReleaseInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for Win32KeyedMutexAcquireReleaseInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR;
 }
-unsafe impl Extends<SubmitInfo<'_>> for Win32KeyedMutexAcquireReleaseInfoKHR<'_> {}
-unsafe impl Extends<SubmitInfo2<'_>> for Win32KeyedMutexAcquireReleaseInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for Win32KeyedMutexAcquireReleaseInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, SubmitInfo2<'a>> for Win32KeyedMutexAcquireReleaseInfoKHR<'a> {}
 impl<'a> Win32KeyedMutexAcquireReleaseInfoKHR<'a> {
     #[inline]
     pub fn acquire_syncs(mut self, acquire_syncs: &'a [DeviceMemory]) -> Self {
@@ -14313,7 +12331,7 @@ impl ::core::default::Default for PhysicalDeviceExternalSemaphoreInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalSemaphoreInfo<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalSemaphoreInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO;
 }
 impl<'a> PhysicalDeviceExternalSemaphoreInfo<'a> {
@@ -14321,50 +12339,6 @@ impl<'a> PhysicalDeviceExternalSemaphoreInfo<'a> {
     pub fn handle_type(mut self, handle_type: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.handle_type = handle_type;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -14395,7 +12369,7 @@ impl ::core::default::Default for ExternalSemaphoreProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalSemaphoreProperties<'a> {
+unsafe impl TaggedStructure<'_> for ExternalSemaphoreProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_SEMAPHORE_PROPERTIES;
 }
 impl<'a> ExternalSemaphoreProperties<'a> {
@@ -14448,10 +12422,10 @@ impl ::core::default::Default for ExportSemaphoreCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportSemaphoreCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ExportSemaphoreCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_SEMAPHORE_CREATE_INFO;
 }
-unsafe impl Extends<SemaphoreCreateInfo<'_>> for ExportSemaphoreCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, SemaphoreCreateInfo<'a>> for ExportSemaphoreCreateInfo<'a> {}
 impl<'a> ExportSemaphoreCreateInfo<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalSemaphoreHandleTypeFlags) -> Self {
@@ -14491,7 +12465,7 @@ impl ::core::default::Default for ImportSemaphoreWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportSemaphoreWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImportSemaphoreWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR;
 }
 impl<'a> ImportSemaphoreWin32HandleInfoKHR<'a> {
@@ -14549,10 +12523,10 @@ impl ::core::default::Default for ExportSemaphoreWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportSemaphoreWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ExportSemaphoreWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR;
 }
-unsafe impl Extends<SemaphoreCreateInfo<'_>> for ExportSemaphoreWin32HandleInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, SemaphoreCreateInfo<'a>> for ExportSemaphoreWin32HandleInfoKHR<'a> {}
 impl<'a> ExportSemaphoreWin32HandleInfoKHR<'a> {
     #[inline]
     pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
@@ -14600,10 +12574,10 @@ impl ::core::default::Default for D3D12FenceSubmitInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for D3D12FenceSubmitInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for D3D12FenceSubmitInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::D3D12_FENCE_SUBMIT_INFO_KHR;
 }
-unsafe impl Extends<SubmitInfo<'_>> for D3D12FenceSubmitInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for D3D12FenceSubmitInfoKHR<'a> {}
 impl<'a> D3D12FenceSubmitInfoKHR<'a> {
     #[inline]
     pub fn wait_semaphore_values(mut self, wait_semaphore_values: &'a [u64]) -> Self {
@@ -14644,7 +12618,7 @@ impl ::core::default::Default for SemaphoreGetWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreGetWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreGetWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR;
 }
 impl<'a> SemaphoreGetWin32HandleInfoKHR<'a> {
@@ -14689,7 +12663,7 @@ impl ::core::default::Default for ImportSemaphoreFdInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportSemaphoreFdInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImportSemaphoreFdInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_SEMAPHORE_FD_INFO_KHR;
 }
 impl<'a> ImportSemaphoreFdInfoKHR<'a> {
@@ -14740,7 +12714,7 @@ impl ::core::default::Default for SemaphoreGetFdInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreGetFdInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreGetFdInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_GET_FD_INFO_KHR;
 }
 impl<'a> SemaphoreGetFdInfoKHR<'a> {
@@ -14785,7 +12759,7 @@ impl ::core::default::Default for ImportSemaphoreZirconHandleInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportSemaphoreZirconHandleInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for ImportSemaphoreZirconHandleInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::IMPORT_SEMAPHORE_ZIRCON_HANDLE_INFO_FUCHSIA;
 }
@@ -14837,7 +12811,7 @@ impl ::core::default::Default for SemaphoreGetZirconHandleInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreGetZirconHandleInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreGetZirconHandleInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_GET_ZIRCON_HANDLE_INFO_FUCHSIA;
 }
 impl<'a> SemaphoreGetZirconHandleInfoFUCHSIA<'a> {
@@ -14876,7 +12850,7 @@ impl ::core::default::Default for PhysicalDeviceExternalFenceInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalFenceInfo<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalFenceInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO;
 }
 impl<'a> PhysicalDeviceExternalFenceInfo<'a> {
@@ -14914,7 +12888,7 @@ impl ::core::default::Default for ExternalFenceProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalFenceProperties<'a> {
+unsafe impl TaggedStructure<'_> for ExternalFenceProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_FENCE_PROPERTIES;
 }
 impl<'a> ExternalFenceProperties<'a> {
@@ -14967,10 +12941,10 @@ impl ::core::default::Default for ExportFenceCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportFenceCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ExportFenceCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_FENCE_CREATE_INFO;
 }
-unsafe impl Extends<FenceCreateInfo<'_>> for ExportFenceCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, FenceCreateInfo<'a>> for ExportFenceCreateInfo<'a> {}
 impl<'a> ExportFenceCreateInfo<'a> {
     #[inline]
     pub fn handle_types(mut self, handle_types: ExternalFenceHandleTypeFlags) -> Self {
@@ -15010,7 +12984,7 @@ impl ::core::default::Default for ImportFenceWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportFenceWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImportFenceWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_FENCE_WIN32_HANDLE_INFO_KHR;
 }
 impl<'a> ImportFenceWin32HandleInfoKHR<'a> {
@@ -15068,10 +13042,10 @@ impl ::core::default::Default for ExportFenceWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportFenceWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ExportFenceWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_FENCE_WIN32_HANDLE_INFO_KHR;
 }
-unsafe impl Extends<FenceCreateInfo<'_>> for ExportFenceWin32HandleInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, FenceCreateInfo<'a>> for ExportFenceWin32HandleInfoKHR<'a> {}
 impl<'a> ExportFenceWin32HandleInfoKHR<'a> {
     #[inline]
     pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
@@ -15115,7 +13089,7 @@ impl ::core::default::Default for FenceGetWin32HandleInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FenceGetWin32HandleInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for FenceGetWin32HandleInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FENCE_GET_WIN32_HANDLE_INFO_KHR;
 }
 impl<'a> FenceGetWin32HandleInfoKHR<'a> {
@@ -15160,7 +13134,7 @@ impl ::core::default::Default for ImportFenceFdInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportFenceFdInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImportFenceFdInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_FENCE_FD_INFO_KHR;
 }
 impl<'a> ImportFenceFdInfoKHR<'a> {
@@ -15211,7 +13185,7 @@ impl ::core::default::Default for FenceGetFdInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FenceGetFdInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for FenceGetFdInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FENCE_GET_FD_INFO_KHR;
 }
 impl<'a> FenceGetFdInfoKHR<'a> {
@@ -15254,11 +13228,11 @@ impl ::core::default::Default for PhysicalDeviceMultiviewFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiviewFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiviewFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MULTIVIEW_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMultiviewFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMultiviewFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceMultiviewFeatures<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMultiviewFeatures<'a> {}
 impl<'a> PhysicalDeviceMultiviewFeatures<'a> {
     #[inline]
     pub fn multiview(mut self, multiview: bool) -> Self {
@@ -15302,10 +13276,13 @@ impl ::core::default::Default for PhysicalDeviceMultiviewProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiviewProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiviewProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMultiviewProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMultiviewProperties<'a>
+{
+}
 impl<'a> PhysicalDeviceMultiviewProperties<'a> {
     #[inline]
     pub fn max_multiview_view_count(mut self, max_multiview_view_count: u32) -> Self {
@@ -15352,10 +13329,10 @@ impl ::core::default::Default for RenderPassMultiviewCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassMultiviewCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassMultiviewCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_MULTIVIEW_CREATE_INFO;
 }
-unsafe impl Extends<RenderPassCreateInfo<'_>> for RenderPassMultiviewCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassCreateInfo<'a>> for RenderPassMultiviewCreateInfo<'a> {}
 impl<'a> RenderPassMultiviewCreateInfo<'a> {
     #[inline]
     pub fn view_masks(mut self, view_masks: &'a [u32]) -> Self {
@@ -15420,7 +13397,7 @@ impl ::core::default::Default for SurfaceCapabilities2EXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceCapabilities2EXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceCapabilities2EXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_CAPABILITIES_2_EXT;
 }
 impl<'a> SurfaceCapabilities2EXT<'a> {
@@ -15510,7 +13487,7 @@ impl ::core::default::Default for DisplayPowerInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayPowerInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DisplayPowerInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_POWER_INFO_EXT;
 }
 impl<'a> DisplayPowerInfoEXT<'a> {
@@ -15544,7 +13521,7 @@ impl ::core::default::Default for DeviceEventInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceEventInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DeviceEventInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_EVENT_INFO_EXT;
 }
 impl<'a> DeviceEventInfoEXT<'a> {
@@ -15578,7 +13555,7 @@ impl ::core::default::Default for DisplayEventInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayEventInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DisplayEventInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_EVENT_INFO_EXT;
 }
 impl<'a> DisplayEventInfoEXT<'a> {
@@ -15612,10 +13589,10 @@ impl ::core::default::Default for SwapchainCounterCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainCounterCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainCounterCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_COUNTER_CREATE_INFO_EXT;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SwapchainCounterCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for SwapchainCounterCreateInfoEXT<'a> {}
 impl<'a> SwapchainCounterCreateInfoEXT<'a> {
     #[inline]
     pub fn surface_counters(mut self, surface_counters: SurfaceCounterFlagsEXT) -> Self {
@@ -15662,7 +13639,7 @@ impl ::core::default::Default for PhysicalDeviceGroupProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceGroupProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceGroupProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_GROUP_PROPERTIES;
 }
 impl<'a> PhysicalDeviceGroupProperties<'a> {
@@ -15708,10 +13685,10 @@ impl ::core::default::Default for MemoryAllocateFlagsInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryAllocateFlagsInfo<'a> {
+unsafe impl TaggedStructure<'_> for MemoryAllocateFlagsInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_ALLOCATE_FLAGS_INFO;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for MemoryAllocateFlagsInfo<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for MemoryAllocateFlagsInfo<'a> {}
 impl<'a> MemoryAllocateFlagsInfo<'a> {
     #[inline]
     pub fn flags(mut self, flags: MemoryAllocateFlags) -> Self {
@@ -15752,7 +13729,7 @@ impl ::core::default::Default for BindBufferMemoryInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindBufferMemoryInfo<'a> {
+unsafe impl TaggedStructure<'_> for BindBufferMemoryInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_BUFFER_MEMORY_INFO;
 }
 impl<'a> BindBufferMemoryInfo<'a> {
@@ -15770,50 +13747,6 @@ impl<'a> BindBufferMemoryInfo<'a> {
     pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.memory_offset = memory_offset;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -15842,10 +13775,10 @@ impl ::core::default::Default for BindBufferMemoryDeviceGroupInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindBufferMemoryDeviceGroupInfo<'a> {
+unsafe impl TaggedStructure<'_> for BindBufferMemoryDeviceGroupInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO;
 }
-unsafe impl Extends<BindBufferMemoryInfo<'_>> for BindBufferMemoryDeviceGroupInfo<'_> {}
+unsafe impl<'a> Extends<'a, BindBufferMemoryInfo<'a>> for BindBufferMemoryDeviceGroupInfo<'a> {}
 impl<'a> BindBufferMemoryDeviceGroupInfo<'a> {
     #[inline]
     pub fn device_indices(mut self, device_indices: &'a [u32]) -> Self {
@@ -15882,7 +13815,7 @@ impl ::core::default::Default for BindImageMemoryInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindImageMemoryInfo<'a> {
+unsafe impl TaggedStructure<'_> for BindImageMemoryInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_IMAGE_MEMORY_INFO;
 }
 impl<'a> BindImageMemoryInfo<'a> {
@@ -15900,50 +13833,6 @@ impl<'a> BindImageMemoryInfo<'a> {
     pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.memory_offset = memory_offset;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -15976,10 +13865,10 @@ impl ::core::default::Default for BindImageMemoryDeviceGroupInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindImageMemoryDeviceGroupInfo<'a> {
+unsafe impl TaggedStructure<'_> for BindImageMemoryDeviceGroupInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO;
 }
-unsafe impl Extends<BindImageMemoryInfo<'_>> for BindImageMemoryDeviceGroupInfo<'_> {}
+unsafe impl<'a> Extends<'a, BindImageMemoryInfo<'a>> for BindImageMemoryDeviceGroupInfo<'a> {}
 impl<'a> BindImageMemoryDeviceGroupInfo<'a> {
     #[inline]
     pub fn device_indices(mut self, device_indices: &'a [u32]) -> Self {
@@ -16025,11 +13914,11 @@ impl ::core::default::Default for DeviceGroupRenderPassBeginInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupRenderPassBeginInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupRenderPassBeginInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_RENDER_PASS_BEGIN_INFO;
 }
-unsafe impl Extends<RenderPassBeginInfo<'_>> for DeviceGroupRenderPassBeginInfo<'_> {}
-unsafe impl Extends<RenderingInfo<'_>> for DeviceGroupRenderPassBeginInfo<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassBeginInfo<'a>> for DeviceGroupRenderPassBeginInfo<'a> {}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>> for DeviceGroupRenderPassBeginInfo<'a> {}
 impl<'a> DeviceGroupRenderPassBeginInfo<'a> {
     #[inline]
     pub fn device_mask(mut self, device_mask: u32) -> Self {
@@ -16067,10 +13956,10 @@ impl ::core::default::Default for DeviceGroupCommandBufferBeginInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupCommandBufferBeginInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupCommandBufferBeginInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO;
 }
-unsafe impl Extends<CommandBufferBeginInfo<'_>> for DeviceGroupCommandBufferBeginInfo<'_> {}
+unsafe impl<'a> Extends<'a, CommandBufferBeginInfo<'a>> for DeviceGroupCommandBufferBeginInfo<'a> {}
 impl<'a> DeviceGroupCommandBufferBeginInfo<'a> {
     #[inline]
     pub fn device_mask(mut self, device_mask: u32) -> Self {
@@ -16112,10 +14001,10 @@ impl ::core::default::Default for DeviceGroupSubmitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupSubmitInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupSubmitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_SUBMIT_INFO;
 }
-unsafe impl Extends<SubmitInfo<'_>> for DeviceGroupSubmitInfo<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for DeviceGroupSubmitInfo<'a> {}
 impl<'a> DeviceGroupSubmitInfo<'a> {
     #[inline]
     pub fn wait_semaphore_device_indices(
@@ -16168,10 +14057,10 @@ impl ::core::default::Default for DeviceGroupBindSparseInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupBindSparseInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupBindSparseInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_BIND_SPARSE_INFO;
 }
-unsafe impl Extends<BindSparseInfo<'_>> for DeviceGroupBindSparseInfo<'_> {}
+unsafe impl<'a> Extends<'a, BindSparseInfo<'a>> for DeviceGroupBindSparseInfo<'a> {}
 impl<'a> DeviceGroupBindSparseInfo<'a> {
     #[inline]
     pub fn resource_device_index(mut self, resource_device_index: u32) -> Self {
@@ -16210,7 +14099,7 @@ impl ::core::default::Default for DeviceGroupPresentCapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupPresentCapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupPresentCapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_PRESENT_CAPABILITIES_KHR;
 }
 impl<'a> DeviceGroupPresentCapabilitiesKHR<'a> {
@@ -16249,10 +14138,10 @@ impl ::core::default::Default for ImageSwapchainCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageSwapchainCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for ImageSwapchainCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_SWAPCHAIN_CREATE_INFO_KHR;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageSwapchainCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImageSwapchainCreateInfoKHR<'a> {}
 impl<'a> ImageSwapchainCreateInfoKHR<'a> {
     #[inline]
     pub fn swapchain(mut self, swapchain: SwapchainKHR) -> Self {
@@ -16286,10 +14175,10 @@ impl ::core::default::Default for BindImageMemorySwapchainInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindImageMemorySwapchainInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for BindImageMemorySwapchainInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR;
 }
-unsafe impl Extends<BindImageMemoryInfo<'_>> for BindImageMemorySwapchainInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, BindImageMemoryInfo<'a>> for BindImageMemorySwapchainInfoKHR<'a> {}
 impl<'a> BindImageMemorySwapchainInfoKHR<'a> {
     #[inline]
     pub fn swapchain(mut self, swapchain: SwapchainKHR) -> Self {
@@ -16334,7 +14223,7 @@ impl ::core::default::Default for AcquireNextImageInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AcquireNextImageInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AcquireNextImageInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACQUIRE_NEXT_IMAGE_INFO_KHR;
 }
 impl<'a> AcquireNextImageInfoKHR<'a> {
@@ -16392,10 +14281,10 @@ impl ::core::default::Default for DeviceGroupPresentInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupPresentInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupPresentInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_PRESENT_INFO_KHR;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for DeviceGroupPresentInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for DeviceGroupPresentInfoKHR<'a> {}
 impl<'a> DeviceGroupPresentInfoKHR<'a> {
     #[inline]
     pub fn device_masks(mut self, device_masks: &'a [u32]) -> Self {
@@ -16435,10 +14324,10 @@ impl ::core::default::Default for DeviceGroupDeviceCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupDeviceCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupDeviceCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_DEVICE_CREATE_INFO;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for DeviceGroupDeviceCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for DeviceGroupDeviceCreateInfo<'a> {}
 impl<'a> DeviceGroupDeviceCreateInfo<'a> {
     #[inline]
     pub fn physical_devices(mut self, physical_devices: &'a [PhysicalDevice]) -> Self {
@@ -16471,10 +14360,10 @@ impl ::core::default::Default for DeviceGroupSwapchainCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceGroupSwapchainCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DeviceGroupSwapchainCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for DeviceGroupSwapchainCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for DeviceGroupSwapchainCreateInfoKHR<'a> {}
 impl<'a> DeviceGroupSwapchainCreateInfoKHR<'a> {
     #[inline]
     pub fn modes(mut self, modes: DeviceGroupPresentModeFlagsKHR) -> Self {
@@ -16565,7 +14454,7 @@ impl ::core::default::Default for DescriptorUpdateTemplateCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorUpdateTemplateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorUpdateTemplateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO;
 }
 impl<'a> DescriptorUpdateTemplateCreateInfo<'a> {
@@ -16654,11 +14543,14 @@ impl ::core::default::Default for PhysicalDevicePresentIdFeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePresentIdFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePresentIdFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevicePresentIdFeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePresentIdFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePresentIdFeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevicePresentIdFeaturesKHR<'a> {}
 impl<'a> PhysicalDevicePresentIdFeaturesKHR<'a> {
     #[inline]
     pub fn present_id(mut self, present_id: bool) -> Self {
@@ -16692,10 +14584,10 @@ impl ::core::default::Default for PresentIdKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PresentIdKHR<'a> {
+unsafe impl TaggedStructure<'_> for PresentIdKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PRESENT_ID_KHR;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for PresentIdKHR<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for PresentIdKHR<'a> {}
 impl<'a> PresentIdKHR<'a> {
     #[inline]
     pub fn present_ids(mut self, present_ids: &'a [u64]) -> Self {
@@ -16728,11 +14620,14 @@ impl ::core::default::Default for PhysicalDevicePresentWaitFeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePresentWaitFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePresentWaitFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevicePresentWaitFeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePresentWaitFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePresentWaitFeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevicePresentWaitFeaturesKHR<'a> {}
 impl<'a> PhysicalDevicePresentWaitFeaturesKHR<'a> {
     #[inline]
     pub fn present_wait(mut self, present_wait: bool) -> Self {
@@ -16778,7 +14673,7 @@ impl ::core::default::Default for HdrMetadataEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for HdrMetadataEXT<'a> {
+unsafe impl TaggedStructure<'_> for HdrMetadataEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::HDR_METADATA_EXT;
 }
 impl<'a> HdrMetadataEXT<'a> {
@@ -16847,11 +14742,14 @@ impl ::core::default::Default for DisplayNativeHdrSurfaceCapabilitiesAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayNativeHdrSurfaceCapabilitiesAMD<'a> {
+unsafe impl TaggedStructure<'_> for DisplayNativeHdrSurfaceCapabilitiesAMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for DisplayNativeHdrSurfaceCapabilitiesAMD<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>>
+    for DisplayNativeHdrSurfaceCapabilitiesAMD<'a>
+{
+}
 impl<'a> DisplayNativeHdrSurfaceCapabilitiesAMD<'a> {
     #[inline]
     pub fn local_dimming_support(mut self, local_dimming_support: bool) -> Self {
@@ -16883,11 +14781,14 @@ impl ::core::default::Default for SwapchainDisplayNativeHdrCreateInfoAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainDisplayNativeHdrCreateInfoAMD<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainDisplayNativeHdrCreateInfoAMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SwapchainDisplayNativeHdrCreateInfoAMD<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>>
+    for SwapchainDisplayNativeHdrCreateInfoAMD<'a>
+{
+}
 impl<'a> SwapchainDisplayNativeHdrCreateInfoAMD<'a> {
     #[inline]
     pub fn local_dimming_enable(mut self, local_dimming_enable: bool) -> Self {
@@ -16975,10 +14876,10 @@ impl ::core::default::Default for PresentTimesInfoGOOGLE<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PresentTimesInfoGOOGLE<'a> {
+unsafe impl TaggedStructure<'_> for PresentTimesInfoGOOGLE<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PRESENT_TIMES_INFO_GOOGLE;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for PresentTimesInfoGOOGLE<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for PresentTimesInfoGOOGLE<'a> {}
 impl<'a> PresentTimesInfoGOOGLE<'a> {
     #[inline]
     pub fn times(mut self, times: &'a [PresentTimeGOOGLE]) -> Self {
@@ -17034,7 +14935,7 @@ impl ::core::default::Default for IOSSurfaceCreateInfoMVK<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IOSSurfaceCreateInfoMVK<'a> {
+unsafe impl TaggedStructure<'_> for IOSSurfaceCreateInfoMVK<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IOS_SURFACE_CREATE_INFO_MVK;
 }
 impl<'a> IOSSurfaceCreateInfoMVK<'a> {
@@ -17075,7 +14976,7 @@ impl ::core::default::Default for MacOSSurfaceCreateInfoMVK<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MacOSSurfaceCreateInfoMVK<'a> {
+unsafe impl TaggedStructure<'_> for MacOSSurfaceCreateInfoMVK<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MACOS_SURFACE_CREATE_INFO_MVK;
 }
 impl<'a> MacOSSurfaceCreateInfoMVK<'a> {
@@ -17116,7 +15017,7 @@ impl ::core::default::Default for MetalSurfaceCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MetalSurfaceCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MetalSurfaceCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::METAL_SURFACE_CREATE_INFO_EXT;
 }
 impl<'a> MetalSurfaceCreateInfoEXT<'a> {
@@ -17180,12 +15081,12 @@ impl ::core::default::Default for PipelineViewportWScalingStateCreateInfoNV<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportWScalingStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportWScalingStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportWScalingStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportWScalingStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineViewportWScalingStateCreateInfoNV<'a> {
@@ -17262,12 +15163,12 @@ impl ::core::default::Default for PipelineViewportSwizzleStateCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportSwizzleStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportSwizzleStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportSwizzleStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportSwizzleStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineViewportSwizzleStateCreateInfoNV<'a> {
@@ -17307,12 +15208,12 @@ impl ::core::default::Default for PhysicalDeviceDiscardRectanglePropertiesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDiscardRectanglePropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDiscardRectanglePropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDiscardRectanglePropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDiscardRectanglePropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceDiscardRectanglePropertiesEXT<'a> {
@@ -17352,12 +15253,12 @@ impl ::core::default::Default for PipelineDiscardRectangleStateCreateInfoEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineDiscardRectangleStateCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineDiscardRectangleStateCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>>
-    for PipelineDiscardRectangleStateCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineDiscardRectangleStateCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineDiscardRectangleStateCreateInfoEXT<'a> {
@@ -17405,12 +15306,12 @@ impl ::core::default::Default for PhysicalDeviceMultiviewPerViewAttributesProper
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX<'a>
 {
 }
 impl<'a> PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX<'a> {
@@ -17476,11 +15377,14 @@ impl ::core::default::Default for RenderPassInputAttachmentAspectCreateInfo<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassInputAttachmentAspectCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassInputAttachmentAspectCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO;
 }
-unsafe impl Extends<RenderPassCreateInfo<'_>> for RenderPassInputAttachmentAspectCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassCreateInfo<'a>>
+    for RenderPassInputAttachmentAspectCreateInfo<'a>
+{
+}
 impl<'a> RenderPassInputAttachmentAspectCreateInfo<'a> {
     #[inline]
     pub fn aspect_references(
@@ -17516,7 +15420,7 @@ impl ::core::default::Default for PhysicalDeviceSurfaceInfo2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSurfaceInfo2KHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSurfaceInfo2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
 }
 impl<'a> PhysicalDeviceSurfaceInfo2KHR<'a> {
@@ -17524,50 +15428,6 @@ impl<'a> PhysicalDeviceSurfaceInfo2KHR<'a> {
     pub fn surface(mut self, surface: SurfaceKHR) -> Self {
         self.surface = surface;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -17594,7 +15454,7 @@ impl ::core::default::Default for SurfaceCapabilities2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceCapabilities2KHR<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceCapabilities2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_CAPABILITIES_2_KHR;
 }
 impl<'a> SurfaceCapabilities2KHR<'a> {
@@ -17602,50 +15462,6 @@ impl<'a> SurfaceCapabilities2KHR<'a> {
     pub fn surface_capabilities(mut self, surface_capabilities: SurfaceCapabilitiesKHR) -> Self {
         self.surface_capabilities = surface_capabilities;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -17672,7 +15488,7 @@ impl ::core::default::Default for SurfaceFormat2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceFormat2KHR<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceFormat2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_FORMAT_2_KHR;
 }
 impl<'a> SurfaceFormat2KHR<'a> {
@@ -17680,50 +15496,6 @@ impl<'a> SurfaceFormat2KHR<'a> {
     pub fn surface_format(mut self, surface_format: SurfaceFormatKHR) -> Self {
         self.surface_format = surface_format;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -17750,7 +15522,7 @@ impl ::core::default::Default for DisplayProperties2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayProperties2KHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayProperties2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_PROPERTIES_2_KHR;
 }
 impl<'a> DisplayProperties2KHR<'a> {
@@ -17784,7 +15556,7 @@ impl ::core::default::Default for DisplayPlaneProperties2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayPlaneProperties2KHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayPlaneProperties2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_PLANE_PROPERTIES_2_KHR;
 }
 impl<'a> DisplayPlaneProperties2KHR<'a> {
@@ -17821,7 +15593,7 @@ impl ::core::default::Default for DisplayModeProperties2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayModeProperties2KHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayModeProperties2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_MODE_PROPERTIES_2_KHR;
 }
 impl<'a> DisplayModeProperties2KHR<'a> {
@@ -17860,7 +15632,7 @@ impl ::core::default::Default for DisplayPlaneInfo2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayPlaneInfo2KHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayPlaneInfo2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_PLANE_INFO_2_KHR;
 }
 impl<'a> DisplayPlaneInfo2KHR<'a> {
@@ -17899,7 +15671,7 @@ impl ::core::default::Default for DisplayPlaneCapabilities2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DisplayPlaneCapabilities2KHR<'a> {
+unsafe impl TaggedStructure<'_> for DisplayPlaneCapabilities2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DISPLAY_PLANE_CAPABILITIES_2_KHR;
 }
 impl<'a> DisplayPlaneCapabilities2KHR<'a> {
@@ -17933,10 +15705,13 @@ impl ::core::default::Default for SharedPresentSurfaceCapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SharedPresentSurfaceCapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for SharedPresentSurfaceCapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SHARED_PRESENT_SURFACE_CAPABILITIES_KHR;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for SharedPresentSurfaceCapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>>
+    for SharedPresentSurfaceCapabilitiesKHR<'a>
+{
+}
 impl<'a> SharedPresentSurfaceCapabilitiesKHR<'a> {
     #[inline]
     pub fn shared_present_supported_usage_flags(
@@ -17977,11 +15752,14 @@ impl ::core::default::Default for PhysicalDevice16BitStorageFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevice16BitStorageFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevice16BitStorageFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevice16BitStorageFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevice16BitStorageFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevice16BitStorageFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevice16BitStorageFeatures<'a> {}
 impl<'a> PhysicalDevice16BitStorageFeatures<'a> {
     #[inline]
     pub fn storage_buffer16_bit_access(mut self, storage_buffer16_bit_access: bool) -> Self {
@@ -18038,10 +15816,13 @@ impl ::core::default::Default for PhysicalDeviceSubgroupProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSubgroupProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSubgroupProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceSubgroupProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceSubgroupProperties<'a>
+{
+}
 impl<'a> PhysicalDeviceSubgroupProperties<'a> {
     #[inline]
     pub fn subgroup_size(mut self, subgroup_size: u32) -> Self {
@@ -18088,16 +15869,16 @@ impl ::core::default::Default for PhysicalDeviceShaderSubgroupExtendedTypesFeatu
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderSubgroupExtendedTypesFeatures<'a> {
@@ -18131,7 +15912,7 @@ impl ::core::default::Default for BufferMemoryRequirementsInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferMemoryRequirementsInfo2<'a> {
+unsafe impl TaggedStructure<'_> for BufferMemoryRequirementsInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_MEMORY_REQUIREMENTS_INFO_2;
 }
 impl<'a> BufferMemoryRequirementsInfo2<'a> {
@@ -18165,7 +15946,7 @@ impl ::core::default::Default for DeviceBufferMemoryRequirements<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceBufferMemoryRequirements<'a> {
+unsafe impl TaggedStructure<'_> for DeviceBufferMemoryRequirements<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_BUFFER_MEMORY_REQUIREMENTS;
 }
 impl<'a> DeviceBufferMemoryRequirements<'a> {
@@ -18199,7 +15980,7 @@ impl ::core::default::Default for ImageMemoryRequirementsInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageMemoryRequirementsInfo2<'a> {
+unsafe impl TaggedStructure<'_> for ImageMemoryRequirementsInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_MEMORY_REQUIREMENTS_INFO_2;
 }
 impl<'a> ImageMemoryRequirementsInfo2<'a> {
@@ -18207,50 +15988,6 @@ impl<'a> ImageMemoryRequirementsInfo2<'a> {
     pub fn image(mut self, image: Image) -> Self {
         self.image = image;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -18277,7 +16014,7 @@ impl ::core::default::Default for ImageSparseMemoryRequirementsInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageSparseMemoryRequirementsInfo2<'a> {
+unsafe impl TaggedStructure<'_> for ImageSparseMemoryRequirementsInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2;
 }
 impl<'a> ImageSparseMemoryRequirementsInfo2<'a> {
@@ -18313,7 +16050,7 @@ impl ::core::default::Default for DeviceImageMemoryRequirements<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceImageMemoryRequirements<'a> {
+unsafe impl TaggedStructure<'_> for DeviceImageMemoryRequirements<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_IMAGE_MEMORY_REQUIREMENTS;
 }
 impl<'a> DeviceImageMemoryRequirements<'a> {
@@ -18352,7 +16089,7 @@ impl ::core::default::Default for MemoryRequirements2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryRequirements2<'a> {
+unsafe impl TaggedStructure<'_> for MemoryRequirements2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_REQUIREMENTS_2;
 }
 impl<'a> MemoryRequirements2<'a> {
@@ -18360,50 +16097,6 @@ impl<'a> MemoryRequirements2<'a> {
     pub fn memory_requirements(mut self, memory_requirements: MemoryRequirements) -> Self {
         self.memory_requirements = memory_requirements;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -18430,7 +16123,7 @@ impl ::core::default::Default for SparseImageMemoryRequirements2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SparseImageMemoryRequirements2<'a> {
+unsafe impl TaggedStructure<'_> for SparseImageMemoryRequirements2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SPARSE_IMAGE_MEMORY_REQUIREMENTS_2;
 }
 impl<'a> SparseImageMemoryRequirements2<'a> {
@@ -18467,10 +16160,13 @@ impl ::core::default::Default for PhysicalDevicePointClippingProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePointClippingProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePointClippingProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDevicePointClippingProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePointClippingProperties<'a>
+{
+}
 impl<'a> PhysicalDevicePointClippingProperties<'a> {
     #[inline]
     pub fn point_clipping_behavior(
@@ -18507,10 +16203,10 @@ impl ::core::default::Default for MemoryDedicatedRequirements<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryDedicatedRequirements<'a> {
+unsafe impl TaggedStructure<'_> for MemoryDedicatedRequirements<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_DEDICATED_REQUIREMENTS;
 }
-unsafe impl Extends<MemoryRequirements2<'_>> for MemoryDedicatedRequirements<'_> {}
+unsafe impl<'a> Extends<'a, MemoryRequirements2<'a>> for MemoryDedicatedRequirements<'a> {}
 impl<'a> MemoryDedicatedRequirements<'a> {
     #[inline]
     pub fn prefers_dedicated_allocation(mut self, prefers_dedicated_allocation: bool) -> Self {
@@ -18549,10 +16245,10 @@ impl ::core::default::Default for MemoryDedicatedAllocateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryDedicatedAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for MemoryDedicatedAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_DEDICATED_ALLOCATE_INFO;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for MemoryDedicatedAllocateInfo<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for MemoryDedicatedAllocateInfo<'a> {}
 impl<'a> MemoryDedicatedAllocateInfo<'a> {
     #[inline]
     pub fn image(mut self, image: Image) -> Self {
@@ -18589,10 +16285,10 @@ impl ::core::default::Default for ImageViewUsageCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewUsageCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewUsageCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_USAGE_CREATE_INFO;
 }
-unsafe impl Extends<ImageViewCreateInfo<'_>> for ImageViewUsageCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for ImageViewUsageCreateInfo<'a> {}
 impl<'a> ImageViewUsageCreateInfo<'a> {
     #[inline]
     pub fn usage(mut self, usage: ImageUsageFlags) -> Self {
@@ -18626,10 +16322,10 @@ impl ::core::default::Default for ImageViewSlicedCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewSlicedCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewSlicedCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_SLICED_CREATE_INFO_EXT;
 }
-unsafe impl Extends<ImageViewCreateInfo<'_>> for ImageViewSlicedCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for ImageViewSlicedCreateInfoEXT<'a> {}
 impl<'a> ImageViewSlicedCreateInfoEXT<'a> {
     #[inline]
     pub fn slice_offset(mut self, slice_offset: u32) -> Self {
@@ -18666,12 +16362,12 @@ impl ::core::default::Default for PipelineTessellationDomainOriginStateCreateInf
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineTessellationDomainOriginStateCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineTessellationDomainOriginStateCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO;
 }
-unsafe impl Extends<PipelineTessellationStateCreateInfo<'_>>
-    for PipelineTessellationDomainOriginStateCreateInfo<'_>
+unsafe impl<'a> Extends<'a, PipelineTessellationStateCreateInfo<'a>>
+    for PipelineTessellationDomainOriginStateCreateInfo<'a>
 {
 }
 impl<'a> PipelineTessellationDomainOriginStateCreateInfo<'a> {
@@ -18705,11 +16401,11 @@ impl ::core::default::Default for SamplerYcbcrConversionInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerYcbcrConversionInfo<'a> {
+unsafe impl TaggedStructure<'_> for SamplerYcbcrConversionInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLER_YCBCR_CONVERSION_INFO;
 }
-unsafe impl Extends<SamplerCreateInfo<'_>> for SamplerYcbcrConversionInfo<'_> {}
-unsafe impl Extends<ImageViewCreateInfo<'_>> for SamplerYcbcrConversionInfo<'_> {}
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>> for SamplerYcbcrConversionInfo<'a> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for SamplerYcbcrConversionInfo<'a> {}
 impl<'a> SamplerYcbcrConversionInfo<'a> {
     #[inline]
     pub fn conversion(mut self, conversion: SamplerYcbcrConversion) -> Self {
@@ -18755,7 +16451,7 @@ impl ::core::default::Default for SamplerYcbcrConversionCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerYcbcrConversionCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for SamplerYcbcrConversionCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
 }
 impl<'a> SamplerYcbcrConversionCreateInfo<'a> {
@@ -18799,50 +16495,6 @@ impl<'a> SamplerYcbcrConversionCreateInfo<'a> {
         self.force_explicit_reconstruction = force_explicit_reconstruction.into();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -18868,10 +16520,10 @@ impl ::core::default::Default for BindImagePlaneMemoryInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindImagePlaneMemoryInfo<'a> {
+unsafe impl TaggedStructure<'_> for BindImagePlaneMemoryInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_IMAGE_PLANE_MEMORY_INFO;
 }
-unsafe impl Extends<BindImageMemoryInfo<'_>> for BindImagePlaneMemoryInfo<'_> {}
+unsafe impl<'a> Extends<'a, BindImageMemoryInfo<'a>> for BindImagePlaneMemoryInfo<'a> {}
 impl<'a> BindImagePlaneMemoryInfo<'a> {
     #[inline]
     pub fn plane_aspect(mut self, plane_aspect: ImageAspectFlags) -> Self {
@@ -18903,10 +16555,13 @@ impl ::core::default::Default for ImagePlaneMemoryRequirementsInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImagePlaneMemoryRequirementsInfo<'a> {
+unsafe impl TaggedStructure<'_> for ImagePlaneMemoryRequirementsInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO;
 }
-unsafe impl Extends<ImageMemoryRequirementsInfo2<'_>> for ImagePlaneMemoryRequirementsInfo<'_> {}
+unsafe impl<'a> Extends<'a, ImageMemoryRequirementsInfo2<'a>>
+    for ImagePlaneMemoryRequirementsInfo<'a>
+{
+}
 impl<'a> ImagePlaneMemoryRequirementsInfo<'a> {
     #[inline]
     pub fn plane_aspect(mut self, plane_aspect: ImageAspectFlags) -> Self {
@@ -18938,15 +16593,18 @@ impl ::core::default::Default for PhysicalDeviceSamplerYcbcrConversionFeatures<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSamplerYcbcrConversionFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSamplerYcbcrConversionFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceSamplerYcbcrConversionFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSamplerYcbcrConversionFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSamplerYcbcrConversionFeatures<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSamplerYcbcrConversionFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceSamplerYcbcrConversionFeatures<'a> {
     #[inline]
     pub fn sampler_ycbcr_conversion(mut self, sampler_ycbcr_conversion: bool) -> Self {
@@ -18978,12 +16636,12 @@ impl ::core::default::Default for SamplerYcbcrConversionImageFormatProperties<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerYcbcrConversionImageFormatProperties<'a> {
+unsafe impl TaggedStructure<'_> for SamplerYcbcrConversionImageFormatProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>>
-    for SamplerYcbcrConversionImageFormatProperties<'_>
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>>
+    for SamplerYcbcrConversionImageFormatProperties<'a>
 {
 }
 impl<'a> SamplerYcbcrConversionImageFormatProperties<'a> {
@@ -19020,10 +16678,13 @@ impl ::core::default::Default for TextureLODGatherFormatPropertiesAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for TextureLODGatherFormatPropertiesAMD<'a> {
+unsafe impl TaggedStructure<'_> for TextureLODGatherFormatPropertiesAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>> for TextureLODGatherFormatPropertiesAMD<'_> {}
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>>
+    for TextureLODGatherFormatPropertiesAMD<'a>
+{
+}
 impl<'a> TextureLODGatherFormatPropertiesAMD<'a> {
     #[inline]
     pub fn supports_texture_gather_lod_bias_amd(
@@ -19062,7 +16723,7 @@ impl ::core::default::Default for ConditionalRenderingBeginInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ConditionalRenderingBeginInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ConditionalRenderingBeginInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CONDITIONAL_RENDERING_BEGIN_INFO_EXT;
 }
 impl<'a> ConditionalRenderingBeginInfoEXT<'a> {
@@ -19106,10 +16767,10 @@ impl ::core::default::Default for ProtectedSubmitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ProtectedSubmitInfo<'a> {
+unsafe impl TaggedStructure<'_> for ProtectedSubmitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PROTECTED_SUBMIT_INFO;
 }
-unsafe impl Extends<SubmitInfo<'_>> for ProtectedSubmitInfo<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for ProtectedSubmitInfo<'a> {}
 impl<'a> ProtectedSubmitInfo<'a> {
     #[inline]
     pub fn protected_submit(mut self, protected_submit: bool) -> Self {
@@ -19141,11 +16802,14 @@ impl ::core::default::Default for PhysicalDeviceProtectedMemoryFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceProtectedMemoryFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceProtectedMemoryFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceProtectedMemoryFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceProtectedMemoryFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceProtectedMemoryFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceProtectedMemoryFeatures<'a> {}
 impl<'a> PhysicalDeviceProtectedMemoryFeatures<'a> {
     #[inline]
     pub fn protected_memory(mut self, protected_memory: bool) -> Self {
@@ -19177,11 +16841,14 @@ impl ::core::default::Default for PhysicalDeviceProtectedMemoryProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceProtectedMemoryProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceProtectedMemoryProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceProtectedMemoryProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceProtectedMemoryProperties<'a>
+{
+}
 impl<'a> PhysicalDeviceProtectedMemoryProperties<'a> {
     #[inline]
     pub fn protected_no_fault(mut self, protected_no_fault: bool) -> Self {
@@ -19217,7 +16884,7 @@ impl ::core::default::Default for DeviceQueueInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceQueueInfo2<'a> {
+unsafe impl TaggedStructure<'_> for DeviceQueueInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_QUEUE_INFO_2;
 }
 impl<'a> DeviceQueueInfo2<'a> {
@@ -19265,12 +16932,12 @@ impl ::core::default::Default for PipelineCoverageToColorStateCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCoverageToColorStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCoverageToColorStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineMultisampleStateCreateInfo<'_>>
-    for PipelineCoverageToColorStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineMultisampleStateCreateInfo<'a>>
+    for PipelineCoverageToColorStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineCoverageToColorStateCreateInfoNV<'a> {
@@ -19316,12 +16983,12 @@ impl ::core::default::Default for PhysicalDeviceSamplerFilterMinmaxProperties<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSamplerFilterMinmaxProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSamplerFilterMinmaxProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceSamplerFilterMinmaxProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceSamplerFilterMinmaxProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceSamplerFilterMinmaxProperties<'a> {
@@ -19393,11 +17060,11 @@ impl ::core::default::Default for SampleLocationsInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SampleLocationsInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SampleLocationsInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLE_LOCATIONS_INFO_EXT;
 }
-unsafe impl Extends<ImageMemoryBarrier<'_>> for SampleLocationsInfoEXT<'_> {}
-unsafe impl Extends<ImageMemoryBarrier2<'_>> for SampleLocationsInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageMemoryBarrier<'a>> for SampleLocationsInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageMemoryBarrier2<'a>> for SampleLocationsInfoEXT<'a> {}
 impl<'a> SampleLocationsInfoEXT<'a> {
     #[inline]
     pub fn sample_locations_per_pixel(
@@ -19499,11 +17166,11 @@ impl ::core::default::Default for RenderPassSampleLocationsBeginInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassSampleLocationsBeginInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassSampleLocationsBeginInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT;
 }
-unsafe impl Extends<RenderPassBeginInfo<'_>> for RenderPassSampleLocationsBeginInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassBeginInfo<'a>> for RenderPassSampleLocationsBeginInfoEXT<'a> {}
 impl<'a> RenderPassSampleLocationsBeginInfoEXT<'a> {
     #[inline]
     pub fn attachment_initial_sample_locations(
@@ -19551,12 +17218,12 @@ impl ::core::default::Default for PipelineSampleLocationsStateCreateInfoEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineSampleLocationsStateCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineSampleLocationsStateCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineMultisampleStateCreateInfo<'_>>
-    for PipelineSampleLocationsStateCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineMultisampleStateCreateInfo<'a>>
+    for PipelineSampleLocationsStateCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineSampleLocationsStateCreateInfoEXT<'a> {
@@ -19606,12 +17273,12 @@ impl ::core::default::Default for PhysicalDeviceSampleLocationsPropertiesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSampleLocationsPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSampleLocationsPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceSampleLocationsPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceSampleLocationsPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceSampleLocationsPropertiesEXT<'a> {
@@ -19674,7 +17341,7 @@ impl ::core::default::Default for MultisamplePropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MultisamplePropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for MultisamplePropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MULTISAMPLE_PROPERTIES_EXT;
 }
 impl<'a> MultisamplePropertiesEXT<'a> {
@@ -19711,10 +17378,10 @@ impl ::core::default::Default for SamplerReductionModeCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerReductionModeCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for SamplerReductionModeCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLER_REDUCTION_MODE_CREATE_INFO;
 }
-unsafe impl Extends<SamplerCreateInfo<'_>> for SamplerReductionModeCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>> for SamplerReductionModeCreateInfo<'a> {}
 impl<'a> SamplerReductionModeCreateInfo<'a> {
     #[inline]
     pub fn reduction_mode(mut self, reduction_mode: SamplerReductionMode) -> Self {
@@ -19746,15 +17413,18 @@ impl ::core::default::Default for PhysicalDeviceBlendOperationAdvancedFeaturesEX
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceBlendOperationAdvancedFeaturesEXT<'a> {
     #[inline]
     pub fn advanced_blend_coherent_operations(
@@ -19789,11 +17459,14 @@ impl ::core::default::Default for PhysicalDeviceMultiDrawFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiDrawFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiDrawFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMultiDrawFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMultiDrawFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMultiDrawFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMultiDrawFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceMultiDrawFeaturesEXT<'a> {
     #[inline]
     pub fn multi_draw(mut self, multi_draw: bool) -> Self {
@@ -19835,12 +17508,12 @@ impl ::core::default::Default for PhysicalDeviceBlendOperationAdvancedProperties
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceBlendOperationAdvancedPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceBlendOperationAdvancedPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceBlendOperationAdvancedPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceBlendOperationAdvancedPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceBlendOperationAdvancedPropertiesEXT<'a> {
@@ -19920,12 +17593,12 @@ impl ::core::default::Default for PipelineColorBlendAdvancedStateCreateInfoEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineColorBlendAdvancedStateCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineColorBlendAdvancedStateCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineColorBlendStateCreateInfo<'_>>
-    for PipelineColorBlendAdvancedStateCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineColorBlendStateCreateInfo<'a>>
+    for PipelineColorBlendAdvancedStateCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineColorBlendAdvancedStateCreateInfoEXT<'a> {
@@ -19971,12 +17644,15 @@ impl ::core::default::Default for PhysicalDeviceInlineUniformBlockFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceInlineUniformBlockFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceInlineUniformBlockFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceInlineUniformBlockFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceInlineUniformBlockFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceInlineUniformBlockFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceInlineUniformBlockFeatures<'a> {}
 impl<'a> PhysicalDeviceInlineUniformBlockFeatures<'a> {
     #[inline]
     pub fn inline_uniform_block(mut self, inline_uniform_block: bool) -> Self {
@@ -20025,12 +17701,12 @@ impl ::core::default::Default for PhysicalDeviceInlineUniformBlockProperties<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceInlineUniformBlockProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceInlineUniformBlockProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceInlineUniformBlockProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceInlineUniformBlockProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceInlineUniformBlockProperties<'a> {
@@ -20101,10 +17777,10 @@ impl ::core::default::Default for WriteDescriptorSetInlineUniformBlock<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WriteDescriptorSetInlineUniformBlock<'a> {
+unsafe impl TaggedStructure<'_> for WriteDescriptorSetInlineUniformBlock<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
 }
-unsafe impl Extends<WriteDescriptorSet<'_>> for WriteDescriptorSetInlineUniformBlock<'_> {}
+unsafe impl<'a> Extends<'a, WriteDescriptorSet<'a>> for WriteDescriptorSetInlineUniformBlock<'a> {}
 impl<'a> WriteDescriptorSetInlineUniformBlock<'a> {
     #[inline]
     pub fn data(mut self, data: &'a [u8]) -> Self {
@@ -20137,12 +17813,12 @@ impl ::core::default::Default for DescriptorPoolInlineUniformBlockCreateInfo<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorPoolInlineUniformBlockCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorPoolInlineUniformBlockCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO;
 }
-unsafe impl Extends<DescriptorPoolCreateInfo<'_>>
-    for DescriptorPoolInlineUniformBlockCreateInfo<'_>
+unsafe impl<'a> Extends<'a, DescriptorPoolCreateInfo<'a>>
+    for DescriptorPoolInlineUniformBlockCreateInfo<'a>
 {
 }
 impl<'a> DescriptorPoolInlineUniformBlockCreateInfo<'a> {
@@ -20187,12 +17863,12 @@ impl ::core::default::Default for PipelineCoverageModulationStateCreateInfoNV<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCoverageModulationStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCoverageModulationStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineMultisampleStateCreateInfo<'_>>
-    for PipelineCoverageModulationStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineMultisampleStateCreateInfo<'a>>
+    for PipelineCoverageModulationStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineCoverageModulationStateCreateInfoNV<'a> {
@@ -20250,12 +17926,12 @@ impl ::core::default::Default for ImageFormatListCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageFormatListCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ImageFormatListCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_FORMAT_LIST_CREATE_INFO;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageFormatListCreateInfo<'_> {}
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for ImageFormatListCreateInfo<'_> {}
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>> for ImageFormatListCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImageFormatListCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for ImageFormatListCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>> for ImageFormatListCreateInfo<'a> {}
 impl<'a> ImageFormatListCreateInfo<'a> {
     #[inline]
     pub fn view_formats(mut self, view_formats: &'a [Format]) -> Self {
@@ -20292,7 +17968,7 @@ impl ::core::default::Default for ValidationCacheCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ValidationCacheCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ValidationCacheCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VALIDATION_CACHE_CREATE_INFO_EXT;
 }
 impl<'a> ValidationCacheCreateInfoEXT<'a> {
@@ -20332,13 +18008,16 @@ impl ::core::default::Default for ShaderModuleValidationCacheCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ShaderModuleValidationCacheCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ShaderModuleValidationCacheCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<ShaderModuleCreateInfo<'_>> for ShaderModuleValidationCacheCreateInfoEXT<'_> {}
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>>
-    for ShaderModuleValidationCacheCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, ShaderModuleCreateInfo<'a>>
+    for ShaderModuleValidationCacheCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>>
+    for ShaderModuleValidationCacheCreateInfoEXT<'a>
 {
 }
 impl<'a> ShaderModuleValidationCacheCreateInfoEXT<'a> {
@@ -20374,10 +18053,13 @@ impl ::core::default::Default for PhysicalDeviceMaintenance3Properties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance3Properties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance3Properties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMaintenance3Properties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMaintenance3Properties<'a>
+{
+}
 impl<'a> PhysicalDeviceMaintenance3Properties<'a> {
     #[inline]
     pub fn max_per_set_descriptors(mut self, max_per_set_descriptors: u32) -> Self {
@@ -20414,11 +18096,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance4Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance4Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance4Features<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMaintenance4Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMaintenance4Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMaintenance4Features<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMaintenance4Features<'a> {}
 impl<'a> PhysicalDeviceMaintenance4Features<'a> {
     #[inline]
     pub fn maintenance4(mut self, maintenance4: bool) -> Self {
@@ -20450,10 +18135,13 @@ impl ::core::default::Default for PhysicalDeviceMaintenance4Properties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance4Properties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance4Properties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMaintenance4Properties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMaintenance4Properties<'a>
+{
+}
 impl<'a> PhysicalDeviceMaintenance4Properties<'a> {
     #[inline]
     pub fn max_buffer_size(mut self, max_buffer_size: DeviceSize) -> Self {
@@ -20485,11 +18173,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance5FeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance5FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance5FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMaintenance5FeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMaintenance5FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMaintenance5FeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMaintenance5FeaturesKHR<'a> {}
 impl<'a> PhysicalDeviceMaintenance5FeaturesKHR<'a> {
     #[inline]
     pub fn maintenance5(mut self, maintenance5: bool) -> Self {
@@ -20531,11 +18222,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance5PropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance5PropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance5PropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMaintenance5PropertiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMaintenance5PropertiesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceMaintenance5PropertiesKHR<'a> {
     #[inline]
     pub fn early_fragment_multisample_coverage_after_sample_counting(
@@ -20611,11 +18305,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance6FeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance6FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance6FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMaintenance6FeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMaintenance6FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMaintenance6FeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMaintenance6FeaturesKHR<'a> {}
 impl<'a> PhysicalDeviceMaintenance6FeaturesKHR<'a> {
     #[inline]
     pub fn maintenance6(mut self, maintenance6: bool) -> Self {
@@ -20651,11 +18348,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance6PropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance6PropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance6PropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMaintenance6PropertiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMaintenance6PropertiesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceMaintenance6PropertiesKHR<'a> {
     #[inline]
     pub fn block_texel_view_compatible_multiple_layers(
@@ -20709,11 +18409,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance7FeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance7FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance7FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMaintenance7FeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMaintenance7FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMaintenance7FeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMaintenance7FeaturesKHR<'a> {}
 impl<'a> PhysicalDeviceMaintenance7FeaturesKHR<'a> {
     #[inline]
     pub fn maintenance7(mut self, maintenance7: bool) -> Self {
@@ -20759,11 +18462,14 @@ impl ::core::default::Default for PhysicalDeviceMaintenance7PropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMaintenance7PropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMaintenance7PropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMaintenance7PropertiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMaintenance7PropertiesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceMaintenance7PropertiesKHR<'a> {
     #[inline]
     pub fn robust_fragment_shading_rate_attachment_access(
@@ -20863,12 +18569,12 @@ impl ::core::default::Default for PhysicalDeviceLayeredApiPropertiesListKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLayeredApiPropertiesListKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLayeredApiPropertiesListKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LAYERED_API_PROPERTIES_LIST_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceLayeredApiPropertiesListKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceLayeredApiPropertiesListKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceLayeredApiPropertiesListKHR<'a> {
@@ -20924,7 +18630,7 @@ impl ::core::default::Default for PhysicalDeviceLayeredApiPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLayeredApiPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLayeredApiPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_LAYERED_API_PROPERTIES_KHR;
 }
 impl<'a> PhysicalDeviceLayeredApiPropertiesKHR<'a> {
@@ -20954,50 +18660,6 @@ impl<'a> PhysicalDeviceLayeredApiPropertiesKHR<'a> {
     pub fn device_name_as_c_str(&self) -> core::result::Result<&CStr, FromBytesUntilNulError> {
         wrap_c_str_slice_until_nul(&self.device_name)
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -21023,12 +18685,12 @@ impl ::core::default::Default for PhysicalDeviceLayeredApiVulkanPropertiesKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLayeredApiVulkanPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLayeredApiVulkanPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LAYERED_API_VULKAN_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceLayeredApiPropertiesKHR<'_>>
-    for PhysicalDeviceLayeredApiVulkanPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceLayeredApiPropertiesKHR<'a>>
+    for PhysicalDeviceLayeredApiVulkanPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceLayeredApiVulkanPropertiesKHR<'a> {
@@ -21070,7 +18732,7 @@ impl ::core::default::Default for RenderingAreaInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingAreaInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RenderingAreaInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDERING_AREA_INFO_KHR;
 }
 impl<'a> RenderingAreaInfoKHR<'a> {
@@ -21120,7 +18782,7 @@ impl ::core::default::Default for DescriptorSetLayoutSupport<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetLayoutSupport<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetLayoutSupport<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_SET_LAYOUT_SUPPORT;
 }
 impl<'a> DescriptorSetLayoutSupport<'a> {
@@ -21128,50 +18790,6 @@ impl<'a> DescriptorSetLayoutSupport<'a> {
     pub fn supported(mut self, supported: bool) -> Self {
         self.supported = supported.into();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -21198,15 +18816,18 @@ impl ::core::default::Default for PhysicalDeviceShaderDrawParametersFeatures<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderDrawParametersFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderDrawParametersFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderDrawParametersFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderDrawParametersFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderDrawParametersFeatures<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderDrawParametersFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderDrawParametersFeatures<'a> {
     #[inline]
     pub fn shader_draw_parameters(mut self, shader_draw_parameters: bool) -> Self {
@@ -21240,12 +18861,15 @@ impl ::core::default::Default for PhysicalDeviceShaderFloat16Int8Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderFloat16Int8Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderFloat16Int8Features<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderFloat16Int8Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderFloat16Int8Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderFloat16Int8Features<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderFloat16Int8Features<'a> {}
 impl<'a> PhysicalDeviceShaderFloat16Int8Features<'a> {
     #[inline]
     pub fn shader_float16(mut self, shader_float16: bool) -> Self {
@@ -21314,10 +18938,13 @@ impl ::core::default::Default for PhysicalDeviceFloatControlsProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFloatControlsProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFloatControlsProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceFloatControlsProperties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFloatControlsProperties<'a>
+{
+}
 impl<'a> PhysicalDeviceFloatControlsProperties<'a> {
     #[inline]
     pub fn denorm_behavior_independence(
@@ -21474,11 +19101,14 @@ impl ::core::default::Default for PhysicalDeviceHostQueryResetFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceHostQueryResetFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceHostQueryResetFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceHostQueryResetFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceHostQueryResetFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceHostQueryResetFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceHostQueryResetFeatures<'a> {}
 impl<'a> PhysicalDeviceHostQueryResetFeatures<'a> {
     #[inline]
     pub fn host_query_reset(mut self, host_query_reset: bool) -> Self {
@@ -21539,7 +19169,7 @@ impl ::core::default::Default for NativeBufferANDROID<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for NativeBufferANDROID<'a> {
+unsafe impl TaggedStructure<'_> for NativeBufferANDROID<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::NATIVE_BUFFER_ANDROID;
 }
 impl<'a> NativeBufferANDROID<'a> {
@@ -21593,7 +19223,7 @@ impl ::core::default::Default for SwapchainImageCreateInfoANDROID<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainImageCreateInfoANDROID<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainImageCreateInfoANDROID<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_IMAGE_CREATE_INFO_ANDROID;
 }
 impl<'a> SwapchainImageCreateInfoANDROID<'a> {
@@ -21627,7 +19257,7 @@ impl ::core::default::Default for PhysicalDevicePresentationPropertiesANDROID<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePresentationPropertiesANDROID<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePresentationPropertiesANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_ANDROID;
 }
@@ -21766,11 +19396,14 @@ impl ::core::default::Default for DeviceQueueGlobalPriorityCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceQueueGlobalPriorityCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DeviceQueueGlobalPriorityCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR;
 }
-unsafe impl Extends<DeviceQueueCreateInfo<'_>> for DeviceQueueGlobalPriorityCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceQueueCreateInfo<'a>>
+    for DeviceQueueGlobalPriorityCreateInfoKHR<'a>
+{
+}
 impl<'a> DeviceQueueGlobalPriorityCreateInfoKHR<'a> {
     #[inline]
     pub fn global_priority(mut self, global_priority: QueueGlobalPriorityKHR) -> Self {
@@ -21802,15 +19435,18 @@ impl ::core::default::Default for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceGlobalPriorityQueryFeaturesKHR<'a> {
     #[inline]
     pub fn global_priority_query(mut self, global_priority_query: bool) -> Self {
@@ -21854,11 +19490,14 @@ impl ::core::default::Default for QueueFamilyGlobalPriorityPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueueFamilyGlobalPriorityPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for QueueFamilyGlobalPriorityPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR;
 }
-unsafe impl Extends<QueueFamilyProperties2<'_>> for QueueFamilyGlobalPriorityPropertiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, QueueFamilyProperties2<'a>>
+    for QueueFamilyGlobalPriorityPropertiesKHR<'a>
+{
+}
 impl<'a> QueueFamilyGlobalPriorityPropertiesKHR<'a> {
     #[inline]
     pub fn priorities(mut self, priorities: &'_ [QueueGlobalPriorityKHR]) -> Self {
@@ -21899,10 +19538,10 @@ impl ::core::default::Default for DebugUtilsObjectNameInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugUtilsObjectNameInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugUtilsObjectNameInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
 }
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>> for DebugUtilsObjectNameInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>> for DebugUtilsObjectNameInfoEXT<'a> {}
 impl<'a> DebugUtilsObjectNameInfoEXT<'a> {
     #[inline]
     pub fn object_handle<T: Handle>(mut self, object_handle: T) -> Self {
@@ -21956,7 +19595,7 @@ impl ::core::default::Default for DebugUtilsObjectTagInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugUtilsObjectTagInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugUtilsObjectTagInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_UTILS_OBJECT_TAG_INFO_EXT;
 }
 impl<'a> DebugUtilsObjectTagInfoEXT<'a> {
@@ -22004,7 +19643,7 @@ impl ::core::default::Default for DebugUtilsLabelEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugUtilsLabelEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugUtilsLabelEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_UTILS_LABEL_EXT;
 }
 impl<'a> DebugUtilsLabelEXT<'a> {
@@ -22075,10 +19714,10 @@ impl ::core::default::Default for DebugUtilsMessengerCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugUtilsMessengerCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugUtilsMessengerCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for DebugUtilsMessengerCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for DebugUtilsMessengerCreateInfoEXT<'a> {}
 impl<'a> DebugUtilsMessengerCreateInfoEXT<'a> {
     #[inline]
     pub fn flags(mut self, flags: DebugUtilsMessengerCreateFlagsEXT) -> Self {
@@ -22151,7 +19790,7 @@ impl ::core::default::Default for DebugUtilsMessengerCallbackDataEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DebugUtilsMessengerCallbackDataEXT<'a> {
+unsafe impl TaggedStructure<'_> for DebugUtilsMessengerCallbackDataEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
 }
 impl<'a> DebugUtilsMessengerCallbackDataEXT<'a> {
@@ -22209,50 +19848,6 @@ impl<'a> DebugUtilsMessengerCallbackDataEXT<'a> {
         self.p_objects = objects.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -22278,15 +19873,18 @@ impl ::core::default::Default for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDeviceMemoryReportFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDeviceMemoryReportFeaturesEXT<'a> {
     #[inline]
     pub fn device_memory_report(mut self, device_memory_report: bool) -> Self {
@@ -22336,11 +19934,11 @@ impl ::core::default::Default for DeviceDeviceMemoryReportCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceDeviceMemoryReportCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DeviceDeviceMemoryReportCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for DeviceDeviceMemoryReportCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for DeviceDeviceMemoryReportCreateInfoEXT<'a> {}
 impl<'a> DeviceDeviceMemoryReportCreateInfoEXT<'a> {
     #[inline]
     pub fn flags(mut self, flags: DeviceMemoryReportFlagsEXT) -> Self {
@@ -22397,7 +19995,7 @@ impl ::core::default::Default for DeviceMemoryReportCallbackDataEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceMemoryReportCallbackDataEXT<'a> {
+unsafe impl TaggedStructure<'_> for DeviceMemoryReportCallbackDataEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_MEMORY_REPORT_CALLBACK_DATA_EXT;
 }
 impl<'a> DeviceMemoryReportCallbackDataEXT<'a> {
@@ -22459,10 +20057,10 @@ impl ::core::default::Default for ImportMemoryHostPointerInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMemoryHostPointerInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImportMemoryHostPointerInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_MEMORY_HOST_POINTER_INFO_EXT;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMemoryHostPointerInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMemoryHostPointerInfoEXT<'a> {}
 impl<'a> ImportMemoryHostPointerInfoEXT<'a> {
     #[inline]
     pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
@@ -22499,7 +20097,7 @@ impl ::core::default::Default for MemoryHostPointerPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryHostPointerPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for MemoryHostPointerPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_HOST_POINTER_PROPERTIES_EXT;
 }
 impl<'a> MemoryHostPointerPropertiesEXT<'a> {
@@ -22533,12 +20131,12 @@ impl ::core::default::Default for PhysicalDeviceExternalMemoryHostPropertiesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalMemoryHostPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalMemoryHostPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceExternalMemoryHostPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceExternalMemoryHostPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceExternalMemoryHostPropertiesEXT<'a> {
@@ -22591,12 +20189,12 @@ impl ::core::default::Default for PhysicalDeviceConservativeRasterizationPropert
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceConservativeRasterizationPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceConservativeRasterizationPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceConservativeRasterizationPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceConservativeRasterizationPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceConservativeRasterizationPropertiesEXT<'a> {
@@ -22692,7 +20290,7 @@ impl ::core::default::Default for CalibratedTimestampInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CalibratedTimestampInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for CalibratedTimestampInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CALIBRATED_TIMESTAMP_INFO_KHR;
 }
 impl<'a> CalibratedTimestampInfoKHR<'a> {
@@ -22752,10 +20350,13 @@ impl ::core::default::Default for PhysicalDeviceShaderCorePropertiesAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderCorePropertiesAMD<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderCorePropertiesAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceShaderCorePropertiesAMD<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderCorePropertiesAMD<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderCorePropertiesAMD<'a> {
     #[inline]
     pub fn shader_engine_count(mut self, shader_engine_count: u32) -> Self {
@@ -22854,11 +20455,14 @@ impl ::core::default::Default for PhysicalDeviceShaderCoreProperties2AMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderCoreProperties2AMD<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderCoreProperties2AMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceShaderCoreProperties2AMD<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderCoreProperties2AMD<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderCoreProperties2AMD<'a> {
     #[inline]
     pub fn shader_core_features(
@@ -22902,12 +20506,12 @@ impl ::core::default::Default for PipelineRasterizationConservativeStateCreateIn
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationConservativeStateCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationConservativeStateCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for PipelineRasterizationConservativeStateCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for PipelineRasterizationConservativeStateCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineRasterizationConservativeStateCreateInfoEXT<'a> {
@@ -22995,12 +20599,15 @@ impl ::core::default::Default for PhysicalDeviceDescriptorIndexingFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorIndexingFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorIndexingFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDescriptorIndexingFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDescriptorIndexingFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDescriptorIndexingFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceDescriptorIndexingFeatures<'a> {}
 impl<'a> PhysicalDeviceDescriptorIndexingFeatures<'a> {
     #[inline]
     pub fn shader_input_attachment_array_dynamic_indexing(
@@ -23246,12 +20853,12 @@ impl ::core::default::Default for PhysicalDeviceDescriptorIndexingProperties<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorIndexingProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorIndexingProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDescriptorIndexingProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDescriptorIndexingProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceDescriptorIndexingProperties<'a> {
@@ -23483,12 +21090,12 @@ impl ::core::default::Default for DescriptorSetLayoutBindingFlagsCreateInfo<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetLayoutBindingFlagsCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetLayoutBindingFlagsCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
 }
-unsafe impl Extends<DescriptorSetLayoutCreateInfo<'_>>
-    for DescriptorSetLayoutBindingFlagsCreateInfo<'_>
+unsafe impl<'a> Extends<'a, DescriptorSetLayoutCreateInfo<'a>>
+    for DescriptorSetLayoutBindingFlagsCreateInfo<'a>
 {
 }
 impl<'a> DescriptorSetLayoutBindingFlagsCreateInfo<'a> {
@@ -23525,12 +21132,12 @@ impl ::core::default::Default for DescriptorSetVariableDescriptorCountAllocateIn
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetVariableDescriptorCountAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetVariableDescriptorCountAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
 }
-unsafe impl Extends<DescriptorSetAllocateInfo<'_>>
-    for DescriptorSetVariableDescriptorCountAllocateInfo<'_>
+unsafe impl<'a> Extends<'a, DescriptorSetAllocateInfo<'a>>
+    for DescriptorSetVariableDescriptorCountAllocateInfo<'a>
 {
 }
 impl<'a> DescriptorSetVariableDescriptorCountAllocateInfo<'a> {
@@ -23565,12 +21172,12 @@ impl ::core::default::Default for DescriptorSetVariableDescriptorCountLayoutSupp
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetVariableDescriptorCountLayoutSupport<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetVariableDescriptorCountLayoutSupport<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT;
 }
-unsafe impl Extends<DescriptorSetLayoutSupport<'_>>
-    for DescriptorSetVariableDescriptorCountLayoutSupport<'_>
+unsafe impl<'a> Extends<'a, DescriptorSetLayoutSupport<'a>>
+    for DescriptorSetVariableDescriptorCountLayoutSupport<'a>
 {
 }
 impl<'a> DescriptorSetVariableDescriptorCountLayoutSupport<'a> {
@@ -23620,7 +21227,7 @@ impl ::core::default::Default for AttachmentDescription2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AttachmentDescription2<'a> {
+unsafe impl TaggedStructure<'_> for AttachmentDescription2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ATTACHMENT_DESCRIPTION_2;
 }
 impl<'a> AttachmentDescription2<'a> {
@@ -23669,50 +21276,6 @@ impl<'a> AttachmentDescription2<'a> {
         self.final_layout = final_layout;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -23742,7 +21305,7 @@ impl ::core::default::Default for AttachmentReference2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AttachmentReference2<'a> {
+unsafe impl TaggedStructure<'_> for AttachmentReference2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ATTACHMENT_REFERENCE_2;
 }
 impl<'a> AttachmentReference2<'a> {
@@ -23760,50 +21323,6 @@ impl<'a> AttachmentReference2<'a> {
     pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.aspect_mask = aspect_mask;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -23850,7 +21369,7 @@ impl ::core::default::Default for SubpassDescription2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassDescription2<'a> {
+unsafe impl TaggedStructure<'_> for SubpassDescription2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBPASS_DESCRIPTION_2;
 }
 impl<'a> SubpassDescription2<'a> {
@@ -23904,50 +21423,6 @@ impl<'a> SubpassDescription2<'a> {
         self.p_preserve_attachments = preserve_attachments.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -23987,7 +21462,7 @@ impl ::core::default::Default for SubpassDependency2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassDependency2<'a> {
+unsafe impl TaggedStructure<'_> for SubpassDependency2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBPASS_DEPENDENCY_2;
 }
 impl<'a> SubpassDependency2<'a> {
@@ -24031,50 +21506,6 @@ impl<'a> SubpassDependency2<'a> {
         self.view_offset = view_offset;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -24116,7 +21547,7 @@ impl ::core::default::Default for RenderPassCreateInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassCreateInfo2<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassCreateInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_CREATE_INFO_2;
 }
 impl<'a> RenderPassCreateInfo2<'a> {
@@ -24149,50 +21580,6 @@ impl<'a> RenderPassCreateInfo2<'a> {
         self.p_correlated_view_masks = correlated_view_masks.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -24218,7 +21605,7 @@ impl ::core::default::Default for SubpassBeginInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassBeginInfo<'a> {
+unsafe impl TaggedStructure<'_> for SubpassBeginInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBPASS_BEGIN_INFO;
 }
 impl<'a> SubpassBeginInfo<'a> {
@@ -24250,55 +21637,10 @@ impl ::core::default::Default for SubpassEndInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassEndInfo<'a> {
+unsafe impl TaggedStructure<'_> for SubpassEndInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBPASS_END_INFO;
 }
-impl<'a> SubpassEndInfo<'a> {
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
-}
+impl<'a> SubpassEndInfo<'a> {}
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -24323,12 +21665,15 @@ impl ::core::default::Default for PhysicalDeviceTimelineSemaphoreFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTimelineSemaphoreFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTimelineSemaphoreFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceTimelineSemaphoreFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceTimelineSemaphoreFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceTimelineSemaphoreFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceTimelineSemaphoreFeatures<'a> {}
 impl<'a> PhysicalDeviceTimelineSemaphoreFeatures<'a> {
     #[inline]
     pub fn timeline_semaphore(mut self, timeline_semaphore: bool) -> Self {
@@ -24360,12 +21705,12 @@ impl ::core::default::Default for PhysicalDeviceTimelineSemaphoreProperties<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTimelineSemaphoreProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTimelineSemaphoreProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceTimelineSemaphoreProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceTimelineSemaphoreProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceTimelineSemaphoreProperties<'a> {
@@ -24404,11 +21749,14 @@ impl ::core::default::Default for SemaphoreTypeCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreTypeCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreTypeCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_TYPE_CREATE_INFO;
 }
-unsafe impl Extends<SemaphoreCreateInfo<'_>> for SemaphoreTypeCreateInfo<'_> {}
-unsafe impl Extends<PhysicalDeviceExternalSemaphoreInfo<'_>> for SemaphoreTypeCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, SemaphoreCreateInfo<'a>> for SemaphoreTypeCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceExternalSemaphoreInfo<'a>>
+    for SemaphoreTypeCreateInfo<'a>
+{
+}
 impl<'a> SemaphoreTypeCreateInfo<'a> {
     #[inline]
     pub fn semaphore_type(mut self, semaphore_type: SemaphoreType) -> Self {
@@ -24451,11 +21799,11 @@ impl ::core::default::Default for TimelineSemaphoreSubmitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for TimelineSemaphoreSubmitInfo<'a> {
+unsafe impl TaggedStructure<'_> for TimelineSemaphoreSubmitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::TIMELINE_SEMAPHORE_SUBMIT_INFO;
 }
-unsafe impl Extends<SubmitInfo<'_>> for TimelineSemaphoreSubmitInfo<'_> {}
-unsafe impl Extends<BindSparseInfo<'_>> for TimelineSemaphoreSubmitInfo<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for TimelineSemaphoreSubmitInfo<'a> {}
+unsafe impl<'a> Extends<'a, BindSparseInfo<'a>> for TimelineSemaphoreSubmitInfo<'a> {}
 impl<'a> TimelineSemaphoreSubmitInfo<'a> {
     #[inline]
     pub fn wait_semaphore_values(mut self, wait_semaphore_values: &'a [u64]) -> Self {
@@ -24500,7 +21848,7 @@ impl ::core::default::Default for SemaphoreWaitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreWaitInfo<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreWaitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_WAIT_INFO;
 }
 impl<'a> SemaphoreWaitInfo<'a> {
@@ -24548,7 +21896,7 @@ impl ::core::default::Default for SemaphoreSignalInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreSignalInfo<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreSignalInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_SIGNAL_INFO;
 }
 impl<'a> SemaphoreSignalInfo<'a> {
@@ -24610,12 +21958,12 @@ impl ::core::default::Default for PipelineVertexInputDivisorStateCreateInfoKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineVertexInputDivisorStateCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineVertexInputDivisorStateCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_KHR;
 }
-unsafe impl Extends<PipelineVertexInputStateCreateInfo<'_>>
-    for PipelineVertexInputDivisorStateCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, PipelineVertexInputStateCreateInfo<'a>>
+    for PipelineVertexInputDivisorStateCreateInfoKHR<'a>
 {
 }
 impl<'a> PipelineVertexInputDivisorStateCreateInfoKHR<'a> {
@@ -24653,12 +22001,12 @@ impl ::core::default::Default for PhysicalDeviceVertexAttributeDivisorProperties
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVertexAttributeDivisorPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVertexAttributeDivisorPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceVertexAttributeDivisorPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceVertexAttributeDivisorPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceVertexAttributeDivisorPropertiesEXT<'a> {
@@ -24694,12 +22042,12 @@ impl ::core::default::Default for PhysicalDeviceVertexAttributeDivisorProperties
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVertexAttributeDivisorPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVertexAttributeDivisorPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceVertexAttributeDivisorPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceVertexAttributeDivisorPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceVertexAttributeDivisorPropertiesKHR<'a> {
@@ -24747,11 +22095,14 @@ impl ::core::default::Default for PhysicalDevicePCIBusInfoPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePCIBusInfoPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePCIBusInfoPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDevicePCIBusInfoPropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePCIBusInfoPropertiesEXT<'a>
+{
+}
 impl<'a> PhysicalDevicePCIBusInfoPropertiesEXT<'a> {
     #[inline]
     pub fn pci_domain(mut self, pci_domain: u32) -> Self {
@@ -24798,11 +22149,11 @@ impl ::core::default::Default for ImportAndroidHardwareBufferInfoANDROID<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportAndroidHardwareBufferInfoANDROID<'a> {
+unsafe impl TaggedStructure<'_> for ImportAndroidHardwareBufferInfoANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportAndroidHardwareBufferInfoANDROID<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportAndroidHardwareBufferInfoANDROID<'a> {}
 impl<'a> ImportAndroidHardwareBufferInfoANDROID<'a> {
     #[inline]
     pub fn buffer(mut self, buffer: *mut AHardwareBuffer) -> Self {
@@ -24834,10 +22185,10 @@ impl ::core::default::Default for AndroidHardwareBufferUsageANDROID<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AndroidHardwareBufferUsageANDROID<'a> {
+unsafe impl TaggedStructure<'_> for AndroidHardwareBufferUsageANDROID<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ANDROID_HARDWARE_BUFFER_USAGE_ANDROID;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>> for AndroidHardwareBufferUsageANDROID<'_> {}
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>> for AndroidHardwareBufferUsageANDROID<'a> {}
 impl<'a> AndroidHardwareBufferUsageANDROID<'a> {
     #[inline]
     pub fn android_hardware_buffer_usage(mut self, android_hardware_buffer_usage: u64) -> Self {
@@ -24871,7 +22222,7 @@ impl ::core::default::Default for AndroidHardwareBufferPropertiesANDROID<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AndroidHardwareBufferPropertiesANDROID<'a> {
+unsafe impl TaggedStructure<'_> for AndroidHardwareBufferPropertiesANDROID<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
 }
 impl<'a> AndroidHardwareBufferPropertiesANDROID<'a> {
@@ -24884,50 +22235,6 @@ impl<'a> AndroidHardwareBufferPropertiesANDROID<'a> {
     pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.memory_type_bits = memory_type_bits;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -24954,7 +22261,7 @@ impl ::core::default::Default for MemoryGetAndroidHardwareBufferInfoANDROID<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryGetAndroidHardwareBufferInfoANDROID<'a> {
+unsafe impl TaggedStructure<'_> for MemoryGetAndroidHardwareBufferInfoANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
 }
@@ -25003,12 +22310,12 @@ impl ::core::default::Default for AndroidHardwareBufferFormatPropertiesANDROID<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AndroidHardwareBufferFormatPropertiesANDROID<'a> {
+unsafe impl TaggedStructure<'_> for AndroidHardwareBufferFormatPropertiesANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID;
 }
-unsafe impl Extends<AndroidHardwareBufferPropertiesANDROID<'_>>
-    for AndroidHardwareBufferFormatPropertiesANDROID<'_>
+unsafe impl<'a> Extends<'a, AndroidHardwareBufferPropertiesANDROID<'a>>
+    for AndroidHardwareBufferFormatPropertiesANDROID<'a>
 {
 }
 impl<'a> AndroidHardwareBufferFormatPropertiesANDROID<'a> {
@@ -25083,12 +22390,12 @@ impl ::core::default::Default for CommandBufferInheritanceConditionalRenderingIn
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferInheritanceConditionalRenderingInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferInheritanceConditionalRenderingInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT;
 }
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>>
-    for CommandBufferInheritanceConditionalRenderingInfoEXT<'_>
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for CommandBufferInheritanceConditionalRenderingInfoEXT<'a>
 {
 }
 impl<'a> CommandBufferInheritanceConditionalRenderingInfoEXT<'a> {
@@ -25122,14 +22429,14 @@ impl ::core::default::Default for ExternalFormatANDROID<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalFormatANDROID<'a> {
+unsafe impl TaggedStructure<'_> for ExternalFormatANDROID<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_FORMAT_ANDROID;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ExternalFormatANDROID<'_> {}
-unsafe impl Extends<SamplerYcbcrConversionCreateInfo<'_>> for ExternalFormatANDROID<'_> {}
-unsafe impl Extends<AttachmentDescription2<'_>> for ExternalFormatANDROID<'_> {}
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for ExternalFormatANDROID<'_> {}
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>> for ExternalFormatANDROID<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ExternalFormatANDROID<'a> {}
+unsafe impl<'a> Extends<'a, SamplerYcbcrConversionCreateInfo<'a>> for ExternalFormatANDROID<'a> {}
+unsafe impl<'a> Extends<'a, AttachmentDescription2<'a>> for ExternalFormatANDROID<'a> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>> for ExternalFormatANDROID<'a> {}
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>> for ExternalFormatANDROID<'a> {}
 impl<'a> ExternalFormatANDROID<'a> {
     #[inline]
     pub fn external_format(mut self, external_format: u64) -> Self {
@@ -25165,11 +22472,11 @@ impl ::core::default::Default for PhysicalDevice8BitStorageFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevice8BitStorageFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevice8BitStorageFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevice8BitStorageFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevice8BitStorageFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDevice8BitStorageFeatures<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevice8BitStorageFeatures<'a> {}
 impl<'a> PhysicalDevice8BitStorageFeatures<'a> {
     #[inline]
     pub fn storage_buffer8_bit_access(mut self, storage_buffer8_bit_access: bool) -> Self {
@@ -25216,15 +22523,18 @@ impl ::core::default::Default for PhysicalDeviceConditionalRenderingFeaturesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceConditionalRenderingFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceConditionalRenderingFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceConditionalRenderingFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceConditionalRenderingFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceConditionalRenderingFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceConditionalRenderingFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceConditionalRenderingFeaturesEXT<'a> {
     #[inline]
     pub fn conditional_rendering(mut self, conditional_rendering: bool) -> Self {
@@ -25268,12 +22578,15 @@ impl ::core::default::Default for PhysicalDeviceVulkanMemoryModelFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkanMemoryModelFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkanMemoryModelFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceVulkanMemoryModelFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVulkanMemoryModelFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceVulkanMemoryModelFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceVulkanMemoryModelFeatures<'a> {}
 impl<'a> PhysicalDeviceVulkanMemoryModelFeatures<'a> {
     #[inline]
     pub fn vulkan_memory_model(mut self, vulkan_memory_model: bool) -> Self {
@@ -25324,12 +22637,15 @@ impl ::core::default::Default for PhysicalDeviceShaderAtomicInt64Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderAtomicInt64Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderAtomicInt64Features<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderAtomicInt64Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderAtomicInt64Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderAtomicInt64Features<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderAtomicInt64Features<'a> {}
 impl<'a> PhysicalDeviceShaderAtomicInt64Features<'a> {
     #[inline]
     pub fn shader_buffer_int64_atomics(mut self, shader_buffer_int64_atomics: bool) -> Self {
@@ -25388,15 +22704,18 @@ impl ::core::default::Default for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderAtomicFloatFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderAtomicFloatFeaturesEXT<'a> {
     #[inline]
     pub fn shader_buffer_float32_atomics(mut self, shader_buffer_float32_atomics: bool) -> Self {
@@ -25523,15 +22842,18 @@ impl ::core::default::Default for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderAtomicFloat2FeaturesEXT<'a> {
     #[inline]
     pub fn shader_buffer_float16_atomics(mut self, shader_buffer_float16_atomics: bool) -> Self {
@@ -25650,15 +22972,18 @@ impl ::core::default::Default for PhysicalDeviceVertexAttributeDivisorFeaturesKH
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceVertexAttributeDivisorFeaturesKHR<'a> {
     #[inline]
     pub fn vertex_attribute_instance_rate_divisor(
@@ -25702,10 +23027,10 @@ impl ::core::default::Default for QueueFamilyCheckpointPropertiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueueFamilyCheckpointPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for QueueFamilyCheckpointPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV;
 }
-unsafe impl Extends<QueueFamilyProperties2<'_>> for QueueFamilyCheckpointPropertiesNV<'_> {}
+unsafe impl<'a> Extends<'a, QueueFamilyProperties2<'a>> for QueueFamilyCheckpointPropertiesNV<'a> {}
 impl<'a> QueueFamilyCheckpointPropertiesNV<'a> {
     #[inline]
     pub fn checkpoint_execution_stage_mask(
@@ -25742,7 +23067,7 @@ impl ::core::default::Default for CheckpointDataNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CheckpointDataNV<'a> {
+unsafe impl TaggedStructure<'_> for CheckpointDataNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CHECKPOINT_DATA_NV;
 }
 impl<'a> CheckpointDataNV<'a> {
@@ -25787,12 +23112,12 @@ impl ::core::default::Default for PhysicalDeviceDepthStencilResolveProperties<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDepthStencilResolveProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDepthStencilResolveProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDepthStencilResolveProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDepthStencilResolveProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceDepthStencilResolveProperties<'a> {
@@ -25851,10 +23176,10 @@ impl ::core::default::Default for SubpassDescriptionDepthStencilResolve<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassDescriptionDepthStencilResolve<'a> {
+unsafe impl TaggedStructure<'_> for SubpassDescriptionDepthStencilResolve<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE;
 }
-unsafe impl Extends<SubpassDescription2<'_>> for SubpassDescriptionDepthStencilResolve<'_> {}
+unsafe impl<'a> Extends<'a, SubpassDescription2<'a>> for SubpassDescriptionDepthStencilResolve<'a> {}
 impl<'a> SubpassDescriptionDepthStencilResolve<'a> {
     #[inline]
     pub fn depth_resolve_mode(mut self, depth_resolve_mode: ResolveModeFlags) -> Self {
@@ -25899,10 +23224,10 @@ impl ::core::default::Default for ImageViewASTCDecodeModeEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewASTCDecodeModeEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewASTCDecodeModeEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_ASTC_DECODE_MODE_EXT;
 }
-unsafe impl Extends<ImageViewCreateInfo<'_>> for ImageViewASTCDecodeModeEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for ImageViewASTCDecodeModeEXT<'a> {}
 impl<'a> ImageViewASTCDecodeModeEXT<'a> {
     #[inline]
     pub fn decode_mode(mut self, decode_mode: Format) -> Self {
@@ -25934,11 +23259,14 @@ impl ::core::default::Default for PhysicalDeviceASTCDecodeFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceASTCDecodeFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceASTCDecodeFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceASTCDecodeFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceASTCDecodeFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceASTCDecodeFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceASTCDecodeFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceASTCDecodeFeaturesEXT<'a> {
     #[inline]
     pub fn decode_mode_shared_exponent(mut self, decode_mode_shared_exponent: bool) -> Self {
@@ -25972,15 +23300,18 @@ impl ::core::default::Default for PhysicalDeviceTransformFeedbackFeaturesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTransformFeedbackFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTransformFeedbackFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceTransformFeedbackFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceTransformFeedbackFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceTransformFeedbackFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceTransformFeedbackFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceTransformFeedbackFeaturesEXT<'a> {
     #[inline]
     pub fn transform_feedback(mut self, transform_feedback: bool) -> Self {
@@ -26035,12 +23366,12 @@ impl ::core::default::Default for PhysicalDeviceTransformFeedbackPropertiesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTransformFeedbackPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTransformFeedbackPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceTransformFeedbackPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceTransformFeedbackPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceTransformFeedbackPropertiesEXT<'a> {
@@ -26141,12 +23472,12 @@ impl ::core::default::Default for PipelineRasterizationStateStreamCreateInfoEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationStateStreamCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationStateStreamCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for PipelineRasterizationStateStreamCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for PipelineRasterizationStateStreamCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineRasterizationStateStreamCreateInfoEXT<'a> {
@@ -26185,16 +23516,16 @@ impl ::core::default::Default for PhysicalDeviceRepresentativeFragmentTestFeatur
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceRepresentativeFragmentTestFeaturesNV<'a> {
@@ -26228,12 +23559,12 @@ impl ::core::default::Default for PipelineRepresentativeFragmentTestStateCreateI
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRepresentativeFragmentTestStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRepresentativeFragmentTestStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>>
-    for PipelineRepresentativeFragmentTestStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineRepresentativeFragmentTestStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineRepresentativeFragmentTestStateCreateInfoNV<'a> {
@@ -26270,12 +23601,15 @@ impl ::core::default::Default for PhysicalDeviceExclusiveScissorFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExclusiveScissorFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExclusiveScissorFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceExclusiveScissorFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceExclusiveScissorFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExclusiveScissorFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceExclusiveScissorFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceExclusiveScissorFeaturesNV<'a> {
     #[inline]
     pub fn exclusive_scissor(mut self, exclusive_scissor: bool) -> Self {
@@ -26309,12 +23643,12 @@ impl ::core::default::Default for PipelineViewportExclusiveScissorStateCreateInf
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportExclusiveScissorStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportExclusiveScissorStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportExclusiveScissorStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportExclusiveScissorStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineViewportExclusiveScissorStateCreateInfoNV<'a> {
@@ -26349,15 +23683,18 @@ impl ::core::default::Default for PhysicalDeviceCornerSampledImageFeaturesNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCornerSampledImageFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCornerSampledImageFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceCornerSampledImageFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCornerSampledImageFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCornerSampledImageFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCornerSampledImageFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceCornerSampledImageFeaturesNV<'a> {
     #[inline]
     pub fn corner_sampled_image(mut self, corner_sampled_image: bool) -> Self {
@@ -26391,16 +23728,16 @@ impl ::core::default::Default for PhysicalDeviceComputeShaderDerivativesFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceComputeShaderDerivativesFeaturesKHR<'a> {
@@ -26442,12 +23779,12 @@ impl ::core::default::Default for PhysicalDeviceComputeShaderDerivativesProperti
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceComputeShaderDerivativesPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceComputeShaderDerivativesPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceComputeShaderDerivativesPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceComputeShaderDerivativesPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceComputeShaderDerivativesPropertiesKHR<'a> {
@@ -26484,15 +23821,18 @@ impl ::core::default::Default for PhysicalDeviceShaderImageFootprintFeaturesNV<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderImageFootprintFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderImageFootprintFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderImageFootprintFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderImageFootprintFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderImageFootprintFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderImageFootprintFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderImageFootprintFeaturesNV<'a> {
     #[inline]
     pub fn image_footprint(mut self, image_footprint: bool) -> Self {
@@ -26524,16 +23864,16 @@ impl ::core::default::Default for PhysicalDeviceDedicatedAllocationImageAliasing
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV<'a> {
@@ -26570,15 +23910,18 @@ impl ::core::default::Default for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCopyMemoryIndirectFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceCopyMemoryIndirectFeaturesNV<'a> {
     #[inline]
     pub fn indirect_copy(mut self, indirect_copy: bool) -> Self {
@@ -26610,12 +23953,12 @@ impl ::core::default::Default for PhysicalDeviceCopyMemoryIndirectPropertiesNV<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCopyMemoryIndirectPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCopyMemoryIndirectPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceCopyMemoryIndirectPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceCopyMemoryIndirectPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceCopyMemoryIndirectPropertiesNV<'a> {
@@ -26649,15 +23992,18 @@ impl ::core::default::Default for PhysicalDeviceMemoryDecompressionFeaturesNV<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMemoryDecompressionFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMemoryDecompressionFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceMemoryDecompressionFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMemoryDecompressionFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMemoryDecompressionFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceMemoryDecompressionFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceMemoryDecompressionFeaturesNV<'a> {
     #[inline]
     pub fn memory_decompression(mut self, memory_decompression: bool) -> Self {
@@ -26691,12 +24037,12 @@ impl ::core::default::Default for PhysicalDeviceMemoryDecompressionPropertiesNV<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMemoryDecompressionPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMemoryDecompressionPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceMemoryDecompressionPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMemoryDecompressionPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceMemoryDecompressionPropertiesNV<'a> {
@@ -26778,12 +24124,12 @@ impl ::core::default::Default for PipelineViewportShadingRateImageStateCreateInf
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportShadingRateImageStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportShadingRateImageStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportShadingRateImageStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportShadingRateImageStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineViewportShadingRateImageStateCreateInfoNV<'a> {
@@ -26828,12 +24174,15 @@ impl ::core::default::Default for PhysicalDeviceShadingRateImageFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShadingRateImageFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShadingRateImageFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShadingRateImageFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShadingRateImageFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShadingRateImageFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShadingRateImageFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceShadingRateImageFeaturesNV<'a> {
     #[inline]
     pub fn shading_rate_image(mut self, shading_rate_image: bool) -> Self {
@@ -26877,12 +24226,12 @@ impl ::core::default::Default for PhysicalDeviceShadingRateImagePropertiesNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShadingRateImagePropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShadingRateImagePropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShadingRateImagePropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShadingRateImagePropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceShadingRateImagePropertiesNV<'a> {
@@ -26926,15 +24275,18 @@ impl ::core::default::Default for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceInvocationMaskFeaturesHUAWEI<'a>
+{
+}
 impl<'a> PhysicalDeviceInvocationMaskFeaturesHUAWEI<'a> {
     #[inline]
     pub fn invocation_mask(mut self, invocation_mask: bool) -> Self {
@@ -27041,12 +24393,12 @@ impl ::core::default::Default for PipelineViewportCoarseSampleOrderStateCreateIn
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportCoarseSampleOrderStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportCoarseSampleOrderStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportCoarseSampleOrderStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportCoarseSampleOrderStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineViewportCoarseSampleOrderStateCreateInfoNV<'a> {
@@ -27091,11 +24443,14 @@ impl ::core::default::Default for PhysicalDeviceMeshShaderFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMeshShaderFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMeshShaderFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMeshShaderFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMeshShaderFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMeshShaderFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMeshShaderFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceMeshShaderFeaturesNV<'a> {
     #[inline]
     pub fn task_shader(mut self, task_shader: bool) -> Self {
@@ -27156,10 +24511,13 @@ impl ::core::default::Default for PhysicalDeviceMeshShaderPropertiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMeshShaderPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMeshShaderPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMeshShaderPropertiesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMeshShaderPropertiesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceMeshShaderPropertiesNV<'a> {
     #[inline]
     pub fn max_draw_mesh_tasks_count(mut self, max_draw_mesh_tasks_count: u32) -> Self {
@@ -27286,11 +24644,14 @@ impl ::core::default::Default for PhysicalDeviceMeshShaderFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMeshShaderFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMeshShaderFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMeshShaderFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMeshShaderFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMeshShaderFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMeshShaderFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceMeshShaderFeaturesEXT<'a> {
     #[inline]
     pub fn task_shader(mut self, task_shader: bool) -> Self {
@@ -27400,10 +24761,13 @@ impl ::core::default::Default for PhysicalDeviceMeshShaderPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMeshShaderPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMeshShaderPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceMeshShaderPropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMeshShaderPropertiesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceMeshShaderPropertiesEXT<'a> {
     #[inline]
     pub fn max_task_work_group_total_count(mut self, max_task_work_group_total_count: u32) -> Self {
@@ -27636,7 +25000,7 @@ impl ::core::default::Default for RayTracingShaderGroupCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RayTracingShaderGroupCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for RayTracingShaderGroupCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV;
 }
 impl<'a> RayTracingShaderGroupCreateInfoNV<'a> {
@@ -27700,7 +25064,7 @@ impl ::core::default::Default for RayTracingShaderGroupCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RayTracingShaderGroupCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RayTracingShaderGroupCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
 }
 impl<'a> RayTracingShaderGroupCreateInfoKHR<'a> {
@@ -27778,7 +25142,7 @@ impl ::core::default::Default for RayTracingPipelineCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RayTracingPipelineCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for RayTracingPipelineCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RAY_TRACING_PIPELINE_CREATE_INFO_NV;
 }
 impl<'a> RayTracingPipelineCreateInfoNV<'a> {
@@ -27818,50 +25182,6 @@ impl<'a> RayTracingPipelineCreateInfoNV<'a> {
     pub fn base_pipeline_index(mut self, base_pipeline_index: i32) -> Self {
         self.base_pipeline_index = base_pipeline_index;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -27910,7 +25230,7 @@ impl ::core::default::Default for RayTracingPipelineCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RayTracingPipelineCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RayTracingPipelineCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RAY_TRACING_PIPELINE_CREATE_INFO_KHR;
 }
 impl<'a> RayTracingPipelineCreateInfoKHR<'a> {
@@ -27972,50 +25292,6 @@ impl<'a> RayTracingPipelineCreateInfoKHR<'a> {
         self.base_pipeline_index = base_pipeline_index;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -28061,7 +25337,7 @@ impl ::core::default::Default for GeometryTrianglesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeometryTrianglesNV<'a> {
+unsafe impl TaggedStructure<'_> for GeometryTrianglesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GEOMETRY_TRIANGLES_NV;
 }
 impl<'a> GeometryTrianglesNV<'a> {
@@ -28151,7 +25427,7 @@ impl ::core::default::Default for GeometryAABBNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeometryAABBNV<'a> {
+unsafe impl TaggedStructure<'_> for GeometryAABBNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GEOMETRY_AABB_NV;
 }
 impl<'a> GeometryAABBNV<'a> {
@@ -28226,7 +25502,7 @@ impl ::core::default::Default for GeometryNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeometryNV<'a> {
+unsafe impl TaggedStructure<'_> for GeometryNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GEOMETRY_NV;
 }
 impl<'a> GeometryNV<'a> {
@@ -28278,7 +25554,7 @@ impl ::core::default::Default for AccelerationStructureInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACCELERATION_STRUCTURE_INFO_NV;
 }
 impl<'a> AccelerationStructureInfoNV<'a> {
@@ -28330,7 +25606,7 @@ impl ::core::default::Default for AccelerationStructureCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACCELERATION_STRUCTURE_CREATE_INFO_NV;
 }
 impl<'a> AccelerationStructureCreateInfoNV<'a> {
@@ -28343,50 +25619,6 @@ impl<'a> AccelerationStructureCreateInfoNV<'a> {
     pub fn info(mut self, info: AccelerationStructureInfoNV<'a>) -> Self {
         self.info = info;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -28421,7 +25653,7 @@ impl ::core::default::Default for BindAccelerationStructureMemoryInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindAccelerationStructureMemoryInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for BindAccelerationStructureMemoryInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_NV;
 }
 impl<'a> BindAccelerationStructureMemoryInfoNV<'a> {
@@ -28476,11 +25708,14 @@ impl ::core::default::Default for WriteDescriptorSetAccelerationStructureKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WriteDescriptorSetAccelerationStructureKHR<'a> {
+unsafe impl TaggedStructure<'_> for WriteDescriptorSetAccelerationStructureKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
 }
-unsafe impl Extends<WriteDescriptorSet<'_>> for WriteDescriptorSetAccelerationStructureKHR<'_> {}
+unsafe impl<'a> Extends<'a, WriteDescriptorSet<'a>>
+    for WriteDescriptorSetAccelerationStructureKHR<'a>
+{
+}
 impl<'a> WriteDescriptorSetAccelerationStructureKHR<'a> {
     #[inline]
     pub fn acceleration_structures(
@@ -28518,11 +25753,14 @@ impl ::core::default::Default for WriteDescriptorSetAccelerationStructureNV<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WriteDescriptorSetAccelerationStructureNV<'a> {
+unsafe impl TaggedStructure<'_> for WriteDescriptorSetAccelerationStructureNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV;
 }
-unsafe impl Extends<WriteDescriptorSet<'_>> for WriteDescriptorSetAccelerationStructureNV<'_> {}
+unsafe impl<'a> Extends<'a, WriteDescriptorSet<'a>>
+    for WriteDescriptorSetAccelerationStructureNV<'a>
+{
+}
 impl<'a> WriteDescriptorSetAccelerationStructureNV<'a> {
     #[inline]
     pub fn acceleration_structures(
@@ -28560,7 +25798,7 @@ impl ::core::default::Default for AccelerationStructureMemoryRequirementsInfoNV<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureMemoryRequirementsInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureMemoryRequirementsInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV;
 }
@@ -28611,15 +25849,18 @@ impl ::core::default::Default for PhysicalDeviceAccelerationStructureFeaturesKHR
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceAccelerationStructureFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceAccelerationStructureFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceAccelerationStructureFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceAccelerationStructureFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceAccelerationStructureFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceAccelerationStructureFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceAccelerationStructureFeaturesKHR<'a> {
     #[inline]
     pub fn acceleration_structure(mut self, acceleration_structure: bool) -> Self {
@@ -28692,15 +25933,18 @@ impl ::core::default::Default for PhysicalDeviceRayTracingPipelineFeaturesKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingPipelineFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingPipelineFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRayTracingPipelineFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRayTracingPipelineFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRayTracingPipelineFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRayTracingPipelineFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceRayTracingPipelineFeaturesKHR<'a> {
     #[inline]
     pub fn ray_tracing_pipeline(mut self, ray_tracing_pipeline: bool) -> Self {
@@ -28767,11 +26011,11 @@ impl ::core::default::Default for PhysicalDeviceRayQueryFeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayQueryFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayQueryFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceRayQueryFeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRayQueryFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceRayQueryFeaturesKHR<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceRayQueryFeaturesKHR<'a> {}
 impl<'a> PhysicalDeviceRayQueryFeaturesKHR<'a> {
     #[inline]
     pub fn ray_query(mut self, ray_query: bool) -> Self {
@@ -28817,12 +26061,12 @@ impl ::core::default::Default for PhysicalDeviceAccelerationStructurePropertiesK
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceAccelerationStructurePropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceAccelerationStructurePropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceAccelerationStructurePropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceAccelerationStructurePropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceAccelerationStructurePropertiesKHR<'a> {
@@ -28925,12 +26169,12 @@ impl ::core::default::Default for PhysicalDeviceRayTracingPipelinePropertiesKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingPipelinePropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingPipelinePropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceRayTracingPipelinePropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceRayTracingPipelinePropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceRayTracingPipelinePropertiesKHR<'a> {
@@ -29019,10 +26263,13 @@ impl ::core::default::Default for PhysicalDeviceRayTracingPropertiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceRayTracingPropertiesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceRayTracingPropertiesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceRayTracingPropertiesNV<'a> {
     #[inline]
     pub fn shader_group_handle_size(mut self, shader_group_handle_size: u32) -> Self {
@@ -29272,15 +26519,18 @@ impl ::core::default::Default for PhysicalDeviceRayTracingMaintenance1FeaturesKH
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceRayTracingMaintenance1FeaturesKHR<'a> {
     #[inline]
     pub fn ray_tracing_maintenance1(mut self, ray_tracing_maintenance1: bool) -> Self {
@@ -29323,10 +26573,10 @@ impl ::core::default::Default for DrmFormatModifierPropertiesListEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DrmFormatModifierPropertiesListEXT<'a> {
+unsafe impl TaggedStructure<'_> for DrmFormatModifierPropertiesListEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
 }
-unsafe impl Extends<FormatProperties2<'_>> for DrmFormatModifierPropertiesListEXT<'_> {}
+unsafe impl<'a> Extends<'a, FormatProperties2<'a>> for DrmFormatModifierPropertiesListEXT<'a> {}
 impl<'a> DrmFormatModifierPropertiesListEXT<'a> {
     #[inline]
     pub fn drm_format_modifier_properties(
@@ -29398,12 +26648,12 @@ impl ::core::default::Default for PhysicalDeviceImageDrmFormatModifierInfoEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageDrmFormatModifierInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageDrmFormatModifierInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT;
 }
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>>
-    for PhysicalDeviceImageDrmFormatModifierInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>>
+    for PhysicalDeviceImageDrmFormatModifierInfoEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceImageDrmFormatModifierInfoEXT<'a> {
@@ -29450,11 +26700,11 @@ impl ::core::default::Default for ImageDrmFormatModifierListCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageDrmFormatModifierListCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageDrmFormatModifierListCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageDrmFormatModifierListCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImageDrmFormatModifierListCreateInfoEXT<'a> {}
 impl<'a> ImageDrmFormatModifierListCreateInfoEXT<'a> {
     #[inline]
     pub fn drm_format_modifiers(mut self, drm_format_modifiers: &'a [u64]) -> Self {
@@ -29491,11 +26741,14 @@ impl ::core::default::Default for ImageDrmFormatModifierExplicitCreateInfoEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageDrmFormatModifierExplicitCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageDrmFormatModifierExplicitCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageDrmFormatModifierExplicitCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>>
+    for ImageDrmFormatModifierExplicitCreateInfoEXT<'a>
+{
+}
 impl<'a> ImageDrmFormatModifierExplicitCreateInfoEXT<'a> {
     #[inline]
     pub fn drm_format_modifier(mut self, drm_format_modifier: u64) -> Self {
@@ -29533,7 +26786,7 @@ impl ::core::default::Default for ImageDrmFormatModifierPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageDrmFormatModifierPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageDrmFormatModifierPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
 }
 impl<'a> ImageDrmFormatModifierPropertiesEXT<'a> {
@@ -29567,11 +26820,14 @@ impl ::core::default::Default for ImageStencilUsageCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageStencilUsageCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for ImageStencilUsageCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_STENCIL_USAGE_CREATE_INFO;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageStencilUsageCreateInfo<'_> {}
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>> for ImageStencilUsageCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImageStencilUsageCreateInfo<'a> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>>
+    for ImageStencilUsageCreateInfo<'a>
+{
+}
 impl<'a> ImageStencilUsageCreateInfo<'a> {
     #[inline]
     pub fn stencil_usage(mut self, stencil_usage: ImageUsageFlags) -> Self {
@@ -29603,11 +26859,11 @@ impl ::core::default::Default for DeviceMemoryOverallocationCreateInfoAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceMemoryOverallocationCreateInfoAMD<'a> {
+unsafe impl TaggedStructure<'_> for DeviceMemoryOverallocationCreateInfoAMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for DeviceMemoryOverallocationCreateInfoAMD<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for DeviceMemoryOverallocationCreateInfoAMD<'a> {}
 impl<'a> DeviceMemoryOverallocationCreateInfoAMD<'a> {
     #[inline]
     pub fn overallocation_behavior(
@@ -29646,15 +26902,18 @@ impl ::core::default::Default for PhysicalDeviceFragmentDensityMapFeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentDensityMapFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentDensityMapFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentDensityMapFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentDensityMapFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFragmentDensityMapFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentDensityMapFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceFragmentDensityMapFeaturesEXT<'a> {
     #[inline]
     pub fn fragment_density_map(mut self, fragment_density_map: bool) -> Self {
@@ -29700,15 +26959,18 @@ impl ::core::default::Default for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentDensityMap2FeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceFragmentDensityMap2FeaturesEXT<'a> {
     #[inline]
     pub fn fragment_density_map_deferred(mut self, fragment_density_map_deferred: bool) -> Self {
@@ -29740,16 +27002,16 @@ impl ::core::default::Default for PhysicalDeviceFragmentDensityMapOffsetFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM<'a> {
@@ -29787,12 +27049,12 @@ impl ::core::default::Default for PhysicalDeviceFragmentDensityMapPropertiesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentDensityMapPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentDensityMapPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceFragmentDensityMapPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFragmentDensityMapPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentDensityMapPropertiesEXT<'a> {
@@ -29848,12 +27110,12 @@ impl ::core::default::Default for PhysicalDeviceFragmentDensityMap2PropertiesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentDensityMap2PropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentDensityMap2PropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceFragmentDensityMap2PropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFragmentDensityMap2PropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentDensityMap2PropertiesEXT<'a> {
@@ -29909,12 +27171,12 @@ impl ::core::default::Default for PhysicalDeviceFragmentDensityMapOffsetProperti
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_PROPERTIES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM<'a> {
@@ -29951,12 +27213,18 @@ impl ::core::default::Default for RenderPassFragmentDensityMapCreateInfoEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassFragmentDensityMapCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassFragmentDensityMapCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT;
 }
-unsafe impl Extends<RenderPassCreateInfo<'_>> for RenderPassFragmentDensityMapCreateInfoEXT<'_> {}
-unsafe impl Extends<RenderPassCreateInfo2<'_>> for RenderPassFragmentDensityMapCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassCreateInfo<'a>>
+    for RenderPassFragmentDensityMapCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RenderPassCreateInfo2<'a>>
+    for RenderPassFragmentDensityMapCreateInfoEXT<'a>
+{
+}
 impl<'a> RenderPassFragmentDensityMapCreateInfoEXT<'a> {
     #[inline]
     pub fn fragment_density_map_attachment(
@@ -29993,11 +27261,11 @@ impl ::core::default::Default for SubpassFragmentDensityMapOffsetEndInfoQCOM<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassFragmentDensityMapOffsetEndInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for SubpassFragmentDensityMapOffsetEndInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SUBPASS_FRAGMENT_DENSITY_MAP_OFFSET_END_INFO_QCOM;
 }
-unsafe impl Extends<SubpassEndInfo<'_>> for SubpassFragmentDensityMapOffsetEndInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, SubpassEndInfo<'a>> for SubpassFragmentDensityMapOffsetEndInfoQCOM<'a> {}
 impl<'a> SubpassFragmentDensityMapOffsetEndInfoQCOM<'a> {
     #[inline]
     pub fn fragment_density_offsets(mut self, fragment_density_offsets: &'a [Offset2D]) -> Self {
@@ -30030,12 +27298,15 @@ impl ::core::default::Default for PhysicalDeviceScalarBlockLayoutFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceScalarBlockLayoutFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceScalarBlockLayoutFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceScalarBlockLayoutFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceScalarBlockLayoutFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceScalarBlockLayoutFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceScalarBlockLayoutFeatures<'a> {}
 impl<'a> PhysicalDeviceScalarBlockLayoutFeatures<'a> {
     #[inline]
     pub fn scalar_block_layout(mut self, scalar_block_layout: bool) -> Self {
@@ -30067,10 +27338,10 @@ impl ::core::default::Default for SurfaceProtectedCapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceProtectedCapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceProtectedCapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_PROTECTED_CAPABILITIES_KHR;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for SurfaceProtectedCapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>> for SurfaceProtectedCapabilitiesKHR<'a> {}
 impl<'a> SurfaceProtectedCapabilitiesKHR<'a> {
     #[inline]
     pub fn supports_protected(mut self, supports_protected: bool) -> Self {
@@ -30102,16 +27373,16 @@ impl ::core::default::Default for PhysicalDeviceUniformBufferStandardLayoutFeatu
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceUniformBufferStandardLayoutFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceUniformBufferStandardLayoutFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceUniformBufferStandardLayoutFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceUniformBufferStandardLayoutFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceUniformBufferStandardLayoutFeatures<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceUniformBufferStandardLayoutFeatures<'a>
 {
 }
 impl<'a> PhysicalDeviceUniformBufferStandardLayoutFeatures<'a> {
@@ -30145,12 +27416,15 @@ impl ::core::default::Default for PhysicalDeviceDepthClipEnableFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDepthClipEnableFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDepthClipEnableFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDepthClipEnableFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDepthClipEnableFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDepthClipEnableFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceDepthClipEnableFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceDepthClipEnableFeaturesEXT<'a> {
     #[inline]
     pub fn depth_clip_enable(mut self, depth_clip_enable: bool) -> Self {
@@ -30184,12 +27458,12 @@ impl ::core::default::Default for PipelineRasterizationDepthClipStateCreateInfoE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationDepthClipStateCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationDepthClipStateCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for PipelineRasterizationDepthClipStateCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for PipelineRasterizationDepthClipStateCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineRasterizationDepthClipStateCreateInfoEXT<'a> {
@@ -30230,12 +27504,12 @@ impl ::core::default::Default for PhysicalDeviceMemoryBudgetPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMemoryBudgetPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMemoryBudgetPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceMemoryProperties2<'_>>
-    for PhysicalDeviceMemoryBudgetPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceMemoryProperties2<'a>>
+    for PhysicalDeviceMemoryBudgetPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceMemoryBudgetPropertiesEXT<'a> {
@@ -30274,12 +27548,15 @@ impl ::core::default::Default for PhysicalDeviceMemoryPriorityFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMemoryPriorityFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMemoryPriorityFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMemoryPriorityFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMemoryPriorityFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMemoryPriorityFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMemoryPriorityFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceMemoryPriorityFeaturesEXT<'a> {
     #[inline]
     pub fn memory_priority(mut self, memory_priority: bool) -> Self {
@@ -30311,10 +27588,10 @@ impl ::core::default::Default for MemoryPriorityAllocateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryPriorityAllocateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MemoryPriorityAllocateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_PRIORITY_ALLOCATE_INFO_EXT;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for MemoryPriorityAllocateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for MemoryPriorityAllocateInfoEXT<'a> {}
 impl<'a> MemoryPriorityAllocateInfoEXT<'a> {
     #[inline]
     pub fn priority(mut self, priority: f32) -> Self {
@@ -30346,16 +27623,16 @@ impl ::core::default::Default for PhysicalDevicePageableDeviceLocalMemoryFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT<'a> {
@@ -30393,12 +27670,18 @@ impl ::core::default::Default for PhysicalDeviceBufferDeviceAddressFeatures<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceBufferDeviceAddressFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceBufferDeviceAddressFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceBufferDeviceAddressFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceBufferDeviceAddressFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceBufferDeviceAddressFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceBufferDeviceAddressFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceBufferDeviceAddressFeatures<'a> {
     #[inline]
     pub fn buffer_device_address(mut self, buffer_device_address: bool) -> Self {
@@ -30450,15 +27733,18 @@ impl ::core::default::Default for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceBufferDeviceAddressFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesEXT<'a> {
     #[inline]
     pub fn buffer_device_address(mut self, buffer_device_address: bool) -> Self {
@@ -30506,7 +27792,7 @@ impl ::core::default::Default for BufferDeviceAddressInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferDeviceAddressInfo<'a> {
+unsafe impl TaggedStructure<'_> for BufferDeviceAddressInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_DEVICE_ADDRESS_INFO;
 }
 impl<'a> BufferDeviceAddressInfo<'a> {
@@ -30540,10 +27826,10 @@ impl ::core::default::Default for BufferOpaqueCaptureAddressCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferOpaqueCaptureAddressCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for BufferOpaqueCaptureAddressCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO;
 }
-unsafe impl Extends<BufferCreateInfo<'_>> for BufferOpaqueCaptureAddressCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for BufferOpaqueCaptureAddressCreateInfo<'a> {}
 impl<'a> BufferOpaqueCaptureAddressCreateInfo<'a> {
     #[inline]
     pub fn opaque_capture_address(mut self, opaque_capture_address: u64) -> Self {
@@ -30575,10 +27861,10 @@ impl ::core::default::Default for BufferDeviceAddressCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferDeviceAddressCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for BufferDeviceAddressCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT;
 }
-unsafe impl Extends<BufferCreateInfo<'_>> for BufferDeviceAddressCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for BufferDeviceAddressCreateInfoEXT<'a> {}
 impl<'a> BufferDeviceAddressCreateInfoEXT<'a> {
     #[inline]
     pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
@@ -30610,12 +27896,12 @@ impl ::core::default::Default for PhysicalDeviceImageViewImageFormatInfoEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageViewImageFormatInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageViewImageFormatInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT;
 }
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>>
-    for PhysicalDeviceImageViewImageFormatInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>>
+    for PhysicalDeviceImageViewImageFormatInfoEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceImageViewImageFormatInfoEXT<'a> {
@@ -30651,12 +27937,12 @@ impl ::core::default::Default for FilterCubicImageViewImageFormatPropertiesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FilterCubicImageViewImageFormatPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for FilterCubicImageViewImageFormatPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>>
-    for FilterCubicImageViewImageFormatPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>>
+    for FilterCubicImageViewImageFormatPropertiesEXT<'a>
 {
 }
 impl<'a> FilterCubicImageViewImageFormatPropertiesEXT<'a> {
@@ -30695,15 +27981,18 @@ impl ::core::default::Default for PhysicalDeviceImagelessFramebufferFeatures<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImagelessFramebufferFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImagelessFramebufferFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceImagelessFramebufferFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImagelessFramebufferFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImagelessFramebufferFeatures<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImagelessFramebufferFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceImagelessFramebufferFeatures<'a> {
     #[inline]
     pub fn imageless_framebuffer(mut self, imageless_framebuffer: bool) -> Self {
@@ -30737,10 +28026,10 @@ impl ::core::default::Default for FramebufferAttachmentsCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FramebufferAttachmentsCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for FramebufferAttachmentsCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FRAMEBUFFER_ATTACHMENTS_CREATE_INFO;
 }
-unsafe impl Extends<FramebufferCreateInfo<'_>> for FramebufferAttachmentsCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, FramebufferCreateInfo<'a>> for FramebufferAttachmentsCreateInfo<'a> {}
 impl<'a> FramebufferAttachmentsCreateInfo<'a> {
     #[inline]
     pub fn attachment_image_infos(
@@ -30788,7 +28077,7 @@ impl ::core::default::Default for FramebufferAttachmentImageInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FramebufferAttachmentImageInfo<'a> {
+unsafe impl TaggedStructure<'_> for FramebufferAttachmentImageInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FRAMEBUFFER_ATTACHMENT_IMAGE_INFO;
 }
 impl<'a> FramebufferAttachmentImageInfo<'a> {
@@ -30850,10 +28139,10 @@ impl ::core::default::Default for RenderPassAttachmentBeginInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassAttachmentBeginInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassAttachmentBeginInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_ATTACHMENT_BEGIN_INFO;
 }
-unsafe impl Extends<RenderPassBeginInfo<'_>> for RenderPassAttachmentBeginInfo<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassBeginInfo<'a>> for RenderPassAttachmentBeginInfo<'a> {}
 impl<'a> RenderPassAttachmentBeginInfo<'a> {
     #[inline]
     pub fn attachments(mut self, attachments: &'a [ImageView]) -> Self {
@@ -30886,15 +28175,18 @@ impl ::core::default::Default for PhysicalDeviceTextureCompressionASTCHDRFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTextureCompressionASTCHDRFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTextureCompressionASTCHDRFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceTextureCompressionASTCHDRFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceTextureCompressionASTCHDRFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceTextureCompressionASTCHDRFeatures<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceTextureCompressionASTCHDRFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceTextureCompressionASTCHDRFeatures<'a> {
     #[inline]
     pub fn texture_compression_astc_hdr(mut self, texture_compression_astc_hdr: bool) -> Self {
@@ -30928,12 +28220,18 @@ impl ::core::default::Default for PhysicalDeviceCooperativeMatrixFeaturesNV<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCooperativeMatrixFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCooperativeMatrixFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceCooperativeMatrixFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCooperativeMatrixFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCooperativeMatrixFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCooperativeMatrixFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceCooperativeMatrixFeaturesNV<'a> {
     #[inline]
     pub fn cooperative_matrix(mut self, cooperative_matrix: bool) -> Self {
@@ -30974,12 +28272,12 @@ impl ::core::default::Default for PhysicalDeviceCooperativeMatrixPropertiesNV<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCooperativeMatrixPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCooperativeMatrixPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceCooperativeMatrixPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceCooperativeMatrixPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceCooperativeMatrixPropertiesNV<'a> {
@@ -31030,7 +28328,7 @@ impl ::core::default::Default for CooperativeMatrixPropertiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CooperativeMatrixPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for CooperativeMatrixPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COOPERATIVE_MATRIX_PROPERTIES_NV;
 }
 impl<'a> CooperativeMatrixPropertiesNV<'a> {
@@ -31099,12 +28397,18 @@ impl ::core::default::Default for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceYcbcrImageArraysFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceYcbcrImageArraysFeaturesEXT<'a> {
     #[inline]
     pub fn ycbcr_image_arrays(mut self, ycbcr_image_arrays: bool) -> Self {
@@ -31140,7 +28444,7 @@ impl ::core::default::Default for ImageViewHandleInfoNVX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewHandleInfoNVX<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewHandleInfoNVX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_HANDLE_INFO_NVX;
 }
 impl<'a> ImageViewHandleInfoNVX<'a> {
@@ -31186,7 +28490,7 @@ impl ::core::default::Default for ImageViewAddressPropertiesNVX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewAddressPropertiesNVX<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewAddressPropertiesNVX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_ADDRESS_PROPERTIES_NVX;
 }
 impl<'a> ImageViewAddressPropertiesNVX<'a> {
@@ -31225,10 +28529,10 @@ impl ::core::default::Default for PresentFrameTokenGGP<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PresentFrameTokenGGP<'a> {
+unsafe impl TaggedStructure<'_> for PresentFrameTokenGGP<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PRESENT_FRAME_TOKEN_GGP;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for PresentFrameTokenGGP<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for PresentFrameTokenGGP<'a> {}
 impl<'a> PresentFrameTokenGGP<'a> {
     #[inline]
     pub fn frame_token(mut self, frame_token: GgpFrameToken) -> Self {
@@ -31285,18 +28589,27 @@ impl ::core::default::Default for PipelineCreationFeedbackCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCreationFeedbackCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCreationFeedbackCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_CREATION_FEEDBACK_CREATE_INFO;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineCreationFeedbackCreateInfo<'_> {}
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for PipelineCreationFeedbackCreateInfo<'_> {}
-unsafe impl Extends<RayTracingPipelineCreateInfoNV<'_>> for PipelineCreationFeedbackCreateInfo<'_> {}
-unsafe impl Extends<RayTracingPipelineCreateInfoKHR<'_>>
-    for PipelineCreationFeedbackCreateInfo<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineCreationFeedbackCreateInfo<'a>
 {
 }
-unsafe impl Extends<ExecutionGraphPipelineCreateInfoAMDX<'_>>
-    for PipelineCreationFeedbackCreateInfo<'_>
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>>
+    for PipelineCreationFeedbackCreateInfo<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RayTracingPipelineCreateInfoNV<'a>>
+    for PipelineCreationFeedbackCreateInfo<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RayTracingPipelineCreateInfoKHR<'a>>
+    for PipelineCreationFeedbackCreateInfo<'a>
+{
+}
+unsafe impl<'a> Extends<'a, ExecutionGraphPipelineCreateInfoAMDX<'a>>
+    for PipelineCreationFeedbackCreateInfo<'a>
 {
 }
 impl<'a> PipelineCreationFeedbackCreateInfo<'a> {
@@ -31342,11 +28655,14 @@ impl ::core::default::Default for SurfaceFullScreenExclusiveInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceFullScreenExclusiveInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceFullScreenExclusiveInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT;
 }
-unsafe impl Extends<PhysicalDeviceSurfaceInfo2KHR<'_>> for SurfaceFullScreenExclusiveInfoEXT<'_> {}
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SurfaceFullScreenExclusiveInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceSurfaceInfo2KHR<'a>>
+    for SurfaceFullScreenExclusiveInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for SurfaceFullScreenExclusiveInfoEXT<'a> {}
 impl<'a> SurfaceFullScreenExclusiveInfoEXT<'a> {
     #[inline]
     pub fn full_screen_exclusive(mut self, full_screen_exclusive: FullScreenExclusiveEXT) -> Self {
@@ -31378,15 +28694,18 @@ impl ::core::default::Default for SurfaceFullScreenExclusiveWin32InfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceFullScreenExclusiveWin32InfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceFullScreenExclusiveWin32InfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT;
 }
-unsafe impl Extends<PhysicalDeviceSurfaceInfo2KHR<'_>>
-    for SurfaceFullScreenExclusiveWin32InfoEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceSurfaceInfo2KHR<'a>>
+    for SurfaceFullScreenExclusiveWin32InfoEXT<'a>
 {
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SurfaceFullScreenExclusiveWin32InfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>>
+    for SurfaceFullScreenExclusiveWin32InfoEXT<'a>
+{
+}
 impl<'a> SurfaceFullScreenExclusiveWin32InfoEXT<'a> {
     #[inline]
     pub fn hmonitor(mut self, hmonitor: HMONITOR) -> Self {
@@ -31418,11 +28737,14 @@ impl ::core::default::Default for SurfaceCapabilitiesFullScreenExclusiveEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceCapabilitiesFullScreenExclusiveEXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceCapabilitiesFullScreenExclusiveEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for SurfaceCapabilitiesFullScreenExclusiveEXT<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>>
+    for SurfaceCapabilitiesFullScreenExclusiveEXT<'a>
+{
+}
 impl<'a> SurfaceCapabilitiesFullScreenExclusiveEXT<'a> {
     #[inline]
     pub fn full_screen_exclusive_supported(
@@ -31457,12 +28779,15 @@ impl ::core::default::Default for PhysicalDevicePresentBarrierFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePresentBarrierFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePresentBarrierFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevicePresentBarrierFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePresentBarrierFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePresentBarrierFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevicePresentBarrierFeaturesNV<'a> {}
 impl<'a> PhysicalDevicePresentBarrierFeaturesNV<'a> {
     #[inline]
     pub fn present_barrier(mut self, present_barrier: bool) -> Self {
@@ -31494,10 +28819,13 @@ impl ::core::default::Default for SurfaceCapabilitiesPresentBarrierNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfaceCapabilitiesPresentBarrierNV<'a> {
+unsafe impl TaggedStructure<'_> for SurfaceCapabilitiesPresentBarrierNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_CAPABILITIES_PRESENT_BARRIER_NV;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for SurfaceCapabilitiesPresentBarrierNV<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>>
+    for SurfaceCapabilitiesPresentBarrierNV<'a>
+{
+}
 impl<'a> SurfaceCapabilitiesPresentBarrierNV<'a> {
     #[inline]
     pub fn present_barrier_supported(mut self, present_barrier_supported: bool) -> Self {
@@ -31529,10 +28857,13 @@ impl ::core::default::Default for SwapchainPresentBarrierCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainPresentBarrierCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainPresentBarrierCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_PRESENT_BARRIER_CREATE_INFO_NV;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SwapchainPresentBarrierCreateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>>
+    for SwapchainPresentBarrierCreateInfoNV<'a>
+{
+}
 impl<'a> SwapchainPresentBarrierCreateInfoNV<'a> {
     #[inline]
     pub fn present_barrier_enable(mut self, present_barrier_enable: bool) -> Self {
@@ -31566,12 +28897,18 @@ impl ::core::default::Default for PhysicalDevicePerformanceQueryFeaturesKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePerformanceQueryFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePerformanceQueryFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevicePerformanceQueryFeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePerformanceQueryFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePerformanceQueryFeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePerformanceQueryFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDevicePerformanceQueryFeaturesKHR<'a> {
     #[inline]
     pub fn performance_counter_query_pools(
@@ -31615,12 +28952,12 @@ impl ::core::default::Default for PhysicalDevicePerformanceQueryPropertiesKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePerformanceQueryPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePerformanceQueryPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDevicePerformanceQueryPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePerformanceQueryPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDevicePerformanceQueryPropertiesKHR<'a> {
@@ -31663,7 +29000,7 @@ impl ::core::default::Default for PerformanceCounterKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceCounterKHR<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceCounterKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PERFORMANCE_COUNTER_KHR;
 }
 impl<'a> PerformanceCounterKHR<'a> {
@@ -31730,7 +29067,7 @@ impl ::core::default::Default for PerformanceCounterDescriptionKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceCounterDescriptionKHR<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceCounterDescriptionKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PERFORMANCE_COUNTER_DESCRIPTION_KHR;
 }
 impl<'a> PerformanceCounterDescriptionKHR<'a> {
@@ -31798,10 +29135,10 @@ impl ::core::default::Default for QueryPoolPerformanceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueryPoolPerformanceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for QueryPoolPerformanceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR;
 }
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for QueryPoolPerformanceCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for QueryPoolPerformanceCreateInfoKHR<'a> {}
 impl<'a> QueryPoolPerformanceCreateInfoKHR<'a> {
     #[inline]
     pub fn queue_family_index(mut self, queue_family_index: u32) -> Self {
@@ -31858,7 +29195,7 @@ impl ::core::default::Default for AcquireProfilingLockInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AcquireProfilingLockInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AcquireProfilingLockInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACQUIRE_PROFILING_LOCK_INFO_KHR;
 }
 impl<'a> AcquireProfilingLockInfoKHR<'a> {
@@ -31897,11 +29234,11 @@ impl ::core::default::Default for PerformanceQuerySubmitInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceQuerySubmitInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceQuerySubmitInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PERFORMANCE_QUERY_SUBMIT_INFO_KHR;
 }
-unsafe impl Extends<SubmitInfo<'_>> for PerformanceQuerySubmitInfoKHR<'_> {}
-unsafe impl Extends<SubmitInfo2<'_>> for PerformanceQuerySubmitInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for PerformanceQuerySubmitInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, SubmitInfo2<'a>> for PerformanceQuerySubmitInfoKHR<'a> {}
 impl<'a> PerformanceQuerySubmitInfoKHR<'a> {
     #[inline]
     pub fn counter_pass_index(mut self, counter_pass_index: u32) -> Self {
@@ -31933,7 +29270,7 @@ impl ::core::default::Default for HeadlessSurfaceCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for HeadlessSurfaceCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for HeadlessSurfaceCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::HEADLESS_SURFACE_CREATE_INFO_EXT;
 }
 impl<'a> HeadlessSurfaceCreateInfoEXT<'a> {
@@ -31967,15 +29304,18 @@ impl ::core::default::Default for PhysicalDeviceCoverageReductionModeFeaturesNV<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCoverageReductionModeFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCoverageReductionModeFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceCoverageReductionModeFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCoverageReductionModeFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCoverageReductionModeFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCoverageReductionModeFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceCoverageReductionModeFeaturesNV<'a> {
     #[inline]
     pub fn coverage_reduction_mode(mut self, coverage_reduction_mode: bool) -> Self {
@@ -32009,12 +29349,12 @@ impl ::core::default::Default for PipelineCoverageReductionStateCreateInfoNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCoverageReductionStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCoverageReductionStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<PipelineMultisampleStateCreateInfo<'_>>
-    for PipelineCoverageReductionStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, PipelineMultisampleStateCreateInfo<'a>>
+    for PipelineCoverageReductionStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineCoverageReductionStateCreateInfoNV<'a> {
@@ -32062,7 +29402,7 @@ impl ::core::default::Default for FramebufferMixedSamplesCombinationNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FramebufferMixedSamplesCombinationNV<'a> {
+unsafe impl TaggedStructure<'_> for FramebufferMixedSamplesCombinationNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV;
 }
 impl<'a> FramebufferMixedSamplesCombinationNV<'a> {
@@ -32114,16 +29454,16 @@ impl ::core::default::Default for PhysicalDeviceShaderIntegerFunctions2FeaturesI
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL<'a> {
@@ -32202,7 +29542,7 @@ impl ::core::default::Default for InitializePerformanceApiInfoINTEL<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for InitializePerformanceApiInfoINTEL<'a> {
+unsafe impl TaggedStructure<'_> for InitializePerformanceApiInfoINTEL<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INITIALIZE_PERFORMANCE_API_INFO_INTEL;
 }
 impl<'a> InitializePerformanceApiInfoINTEL<'a> {
@@ -32236,11 +29576,14 @@ impl ::core::default::Default for QueryPoolPerformanceQueryCreateInfoINTEL<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueryPoolPerformanceQueryCreateInfoINTEL<'a> {
+unsafe impl TaggedStructure<'_> for QueryPoolPerformanceQueryCreateInfoINTEL<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL;
 }
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for QueryPoolPerformanceQueryCreateInfoINTEL<'_> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>>
+    for QueryPoolPerformanceQueryCreateInfoINTEL<'a>
+{
+}
 impl<'a> QueryPoolPerformanceQueryCreateInfoINTEL<'a> {
     #[inline]
     pub fn performance_counters_sampling(
@@ -32275,7 +29618,7 @@ impl ::core::default::Default for PerformanceMarkerInfoINTEL<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceMarkerInfoINTEL<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceMarkerInfoINTEL<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PERFORMANCE_MARKER_INFO_INTEL;
 }
 impl<'a> PerformanceMarkerInfoINTEL<'a> {
@@ -32309,7 +29652,7 @@ impl ::core::default::Default for PerformanceStreamMarkerInfoINTEL<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceStreamMarkerInfoINTEL<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceStreamMarkerInfoINTEL<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PERFORMANCE_STREAM_MARKER_INFO_INTEL;
 }
 impl<'a> PerformanceStreamMarkerInfoINTEL<'a> {
@@ -32347,7 +29690,7 @@ impl ::core::default::Default for PerformanceOverrideInfoINTEL<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceOverrideInfoINTEL<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceOverrideInfoINTEL<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PERFORMANCE_OVERRIDE_INFO_INTEL;
 }
 impl<'a> PerformanceOverrideInfoINTEL<'a> {
@@ -32391,7 +29734,7 @@ impl ::core::default::Default for PerformanceConfigurationAcquireInfoINTEL<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PerformanceConfigurationAcquireInfoINTEL<'a> {
+unsafe impl TaggedStructure<'_> for PerformanceConfigurationAcquireInfoINTEL<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL;
 }
@@ -32428,11 +29771,14 @@ impl ::core::default::Default for PhysicalDeviceShaderClockFeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderClockFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderClockFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderClockFeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderClockFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderClockFeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderClockFeaturesKHR<'a> {}
 impl<'a> PhysicalDeviceShaderClockFeaturesKHR<'a> {
     #[inline]
     pub fn shader_subgroup_clock(mut self, shader_subgroup_clock: bool) -> Self {
@@ -32469,12 +29815,15 @@ impl ::core::default::Default for PhysicalDeviceIndexTypeUint8FeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceIndexTypeUint8FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceIndexTypeUint8FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceIndexTypeUint8FeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceIndexTypeUint8FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceIndexTypeUint8FeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceIndexTypeUint8FeaturesKHR<'a> {}
 impl<'a> PhysicalDeviceIndexTypeUint8FeaturesKHR<'a> {
     #[inline]
     pub fn index_type_uint8(mut self, index_type_uint8: bool) -> Self {
@@ -32508,12 +29857,12 @@ impl ::core::default::Default for PhysicalDeviceShaderSMBuiltinsPropertiesNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderSMBuiltinsPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderSMBuiltinsPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShaderSMBuiltinsPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderSMBuiltinsPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderSMBuiltinsPropertiesNV<'a> {
@@ -32552,12 +29901,15 @@ impl ::core::default::Default for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderSMBuiltinsFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceShaderSMBuiltinsFeaturesNV<'a> {
     #[inline]
     pub fn shader_sm_builtins(mut self, shader_sm_builtins: bool) -> Self {
@@ -32593,15 +29945,18 @@ impl ::core::default::Default for PhysicalDeviceFragmentShaderInterlockFeaturesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceFragmentShaderInterlockFeaturesEXT<'a> {
     #[inline]
     pub fn fragment_shader_sample_interlock(
@@ -32652,16 +30007,16 @@ impl ::core::default::Default for PhysicalDeviceSeparateDepthStencilLayoutsFeatu
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'a>
 {
 }
 impl<'a> PhysicalDeviceSeparateDepthStencilLayoutsFeatures<'a> {
@@ -32695,10 +30050,10 @@ impl ::core::default::Default for AttachmentReferenceStencilLayout<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AttachmentReferenceStencilLayout<'a> {
+unsafe impl TaggedStructure<'_> for AttachmentReferenceStencilLayout<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ATTACHMENT_REFERENCE_STENCIL_LAYOUT;
 }
-unsafe impl Extends<AttachmentReference2<'_>> for AttachmentReferenceStencilLayout<'_> {}
+unsafe impl<'a> Extends<'a, AttachmentReference2<'a>> for AttachmentReferenceStencilLayout<'a> {}
 impl<'a> AttachmentReferenceStencilLayout<'a> {
     #[inline]
     pub fn stencil_layout(mut self, stencil_layout: ImageLayout) -> Self {
@@ -32732,16 +30087,16 @@ impl ::core::default::Default for PhysicalDevicePrimitiveTopologyListRestartFeat
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT<'a> {
@@ -32788,10 +30143,10 @@ impl ::core::default::Default for AttachmentDescriptionStencilLayout<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AttachmentDescriptionStencilLayout<'a> {
+unsafe impl TaggedStructure<'_> for AttachmentDescriptionStencilLayout<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT;
 }
-unsafe impl Extends<AttachmentDescription2<'_>> for AttachmentDescriptionStencilLayout<'_> {}
+unsafe impl<'a> Extends<'a, AttachmentDescription2<'a>> for AttachmentDescriptionStencilLayout<'a> {}
 impl<'a> AttachmentDescriptionStencilLayout<'a> {
     #[inline]
     pub fn stencil_initial_layout(mut self, stencil_initial_layout: ImageLayout) -> Self {
@@ -32828,16 +30183,16 @@ impl ::core::default::Default for PhysicalDevicePipelineExecutablePropertiesFeat
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDevicePipelineExecutablePropertiesFeaturesKHR<'a> {
@@ -32871,7 +30226,7 @@ impl ::core::default::Default for PipelineInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_INFO_KHR;
 }
 impl<'a> PipelineInfoKHR<'a> {
@@ -32923,7 +30278,7 @@ impl ::core::default::Default for PipelineExecutablePropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineExecutablePropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineExecutablePropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_EXECUTABLE_PROPERTIES_KHR;
 }
 impl<'a> PipelineExecutablePropertiesKHR<'a> {
@@ -32983,7 +30338,7 @@ impl ::core::default::Default for PipelineExecutableInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineExecutableInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineExecutableInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_EXECUTABLE_INFO_KHR;
 }
 impl<'a> PipelineExecutableInfoKHR<'a> {
@@ -33055,7 +30410,7 @@ impl ::core::default::Default for PipelineExecutableStatisticKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineExecutableStatisticKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineExecutableStatisticKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_EXECUTABLE_STATISTIC_KHR;
 }
 impl<'a> PipelineExecutableStatisticKHR<'a> {
@@ -33134,7 +30489,7 @@ impl ::core::default::Default for PipelineExecutableInternalRepresentationKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineExecutableInternalRepresentationKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineExecutableInternalRepresentationKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR;
 }
@@ -33194,16 +30549,16 @@ impl ::core::default::Default for PhysicalDeviceShaderDemoteToHelperInvocationFe
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderDemoteToHelperInvocationFeatures<'a> {
@@ -33240,15 +30595,18 @@ impl ::core::default::Default for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceTexelBufferAlignmentFeaturesEXT<'a> {
     #[inline]
     pub fn texel_buffer_alignment(mut self, texel_buffer_alignment: bool) -> Self {
@@ -33286,12 +30644,12 @@ impl ::core::default::Default for PhysicalDeviceTexelBufferAlignmentProperties<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTexelBufferAlignmentProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTexelBufferAlignmentProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceTexelBufferAlignmentProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceTexelBufferAlignmentProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceTexelBufferAlignmentProperties<'a> {
@@ -33358,12 +30716,18 @@ impl ::core::default::Default for PhysicalDeviceSubgroupSizeControlFeatures<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSubgroupSizeControlFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSubgroupSizeControlFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceSubgroupSizeControlFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSubgroupSizeControlFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSubgroupSizeControlFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSubgroupSizeControlFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceSubgroupSizeControlFeatures<'a> {
     #[inline]
     pub fn subgroup_size_control(mut self, subgroup_size_control: bool) -> Self {
@@ -33406,12 +30770,12 @@ impl ::core::default::Default for PhysicalDeviceSubgroupSizeControlProperties<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSubgroupSizeControlProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSubgroupSizeControlProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceSubgroupSizeControlProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceSubgroupSizeControlProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceSubgroupSizeControlProperties<'a> {
@@ -33463,16 +30827,16 @@ impl ::core::default::Default for PipelineShaderStageRequiredSubgroupSizeCreateI
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineShaderStageRequiredSubgroupSizeCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineShaderStageRequiredSubgroupSizeCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
 }
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>>
-    for PipelineShaderStageRequiredSubgroupSizeCreateInfo<'_>
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>>
+    for PipelineShaderStageRequiredSubgroupSizeCreateInfo<'a>
 {
 }
-unsafe impl Extends<ShaderCreateInfoEXT<'_>>
-    for PipelineShaderStageRequiredSubgroupSizeCreateInfo<'_>
+unsafe impl<'a> Extends<'a, ShaderCreateInfoEXT<'a>>
+    for PipelineShaderStageRequiredSubgroupSizeCreateInfo<'a>
 {
 }
 impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfo<'a> {
@@ -33508,11 +30872,14 @@ impl ::core::default::Default for SubpassShadingPipelineCreateInfoHUAWEI<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassShadingPipelineCreateInfoHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for SubpassShadingPipelineCreateInfoHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI;
 }
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for SubpassShadingPipelineCreateInfoHUAWEI<'_> {}
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>>
+    for SubpassShadingPipelineCreateInfoHUAWEI<'a>
+{
+}
 impl<'a> SubpassShadingPipelineCreateInfoHUAWEI<'a> {
     #[inline]
     pub fn render_pass(mut self, render_pass: RenderPass) -> Self {
@@ -33549,12 +30916,12 @@ impl ::core::default::Default for PhysicalDeviceSubpassShadingPropertiesHUAWEI<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSubpassShadingPropertiesHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSubpassShadingPropertiesHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceSubpassShadingPropertiesHUAWEI<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceSubpassShadingPropertiesHUAWEI<'a>
 {
 }
 impl<'a> PhysicalDeviceSubpassShadingPropertiesHUAWEI<'a> {
@@ -33598,12 +30965,12 @@ impl ::core::default::Default for PhysicalDeviceClusterCullingShaderPropertiesHU
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceClusterCullingShaderPropertiesHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceClusterCullingShaderPropertiesHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceClusterCullingShaderPropertiesHUAWEI<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceClusterCullingShaderPropertiesHUAWEI<'a>
 {
 }
 impl<'a> PhysicalDeviceClusterCullingShaderPropertiesHUAWEI<'a> {
@@ -33655,11 +31022,11 @@ impl ::core::default::Default for MemoryOpaqueCaptureAddressAllocateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryOpaqueCaptureAddressAllocateInfo<'a> {
+unsafe impl TaggedStructure<'_> for MemoryOpaqueCaptureAddressAllocateInfo<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for MemoryOpaqueCaptureAddressAllocateInfo<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for MemoryOpaqueCaptureAddressAllocateInfo<'a> {}
 impl<'a> MemoryOpaqueCaptureAddressAllocateInfo<'a> {
     #[inline]
     pub fn opaque_capture_address(mut self, opaque_capture_address: u64) -> Self {
@@ -33691,7 +31058,7 @@ impl ::core::default::Default for DeviceMemoryOpaqueCaptureAddressInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceMemoryOpaqueCaptureAddressInfo<'a> {
+unsafe impl TaggedStructure<'_> for DeviceMemoryOpaqueCaptureAddressInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO;
 }
 impl<'a> DeviceMemoryOpaqueCaptureAddressInfo<'a> {
@@ -33735,15 +31102,18 @@ impl ::core::default::Default for PhysicalDeviceLineRasterizationFeaturesKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLineRasterizationFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLineRasterizationFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceLineRasterizationFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceLineRasterizationFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceLineRasterizationFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceLineRasterizationFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceLineRasterizationFeaturesKHR<'a> {
     #[inline]
     pub fn rectangular_lines(mut self, rectangular_lines: bool) -> Self {
@@ -33800,12 +31170,12 @@ impl ::core::default::Default for PhysicalDeviceLineRasterizationPropertiesKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLineRasterizationPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLineRasterizationPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceLineRasterizationPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceLineRasterizationPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceLineRasterizationPropertiesKHR<'a> {
@@ -33845,12 +31215,12 @@ impl ::core::default::Default for PipelineRasterizationLineStateCreateInfoKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationLineStateCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationLineStateCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_KHR;
 }
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for PipelineRasterizationLineStateCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for PipelineRasterizationLineStateCreateInfoKHR<'a>
 {
 }
 impl<'a> PipelineRasterizationLineStateCreateInfoKHR<'a> {
@@ -33902,16 +31272,16 @@ impl ::core::default::Default for PhysicalDevicePipelineCreationCacheControlFeat
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineCreationCacheControlFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineCreationCacheControlFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePipelineCreationCacheControlFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelineCreationCacheControlFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDevicePipelineCreationCacheControlFeatures<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePipelineCreationCacheControlFeatures<'a>
 {
 }
 impl<'a> PhysicalDevicePipelineCreationCacheControlFeatures<'a> {
@@ -33970,11 +31340,11 @@ impl ::core::default::Default for PhysicalDeviceVulkan11Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkan11Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkan11Features<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceVulkan11Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVulkan11Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceVulkan11Features<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceVulkan11Features<'a> {}
 impl<'a> PhysicalDeviceVulkan11Features<'a> {
     #[inline]
     pub fn storage_buffer16_bit_access(mut self, storage_buffer16_bit_access: bool) -> Self {
@@ -34096,10 +31466,13 @@ impl ::core::default::Default for PhysicalDeviceVulkan11Properties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkan11Properties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkan11Properties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceVulkan11Properties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceVulkan11Properties<'a>
+{
+}
 impl<'a> PhysicalDeviceVulkan11Properties<'a> {
     #[inline]
     pub fn device_uuid(mut self, device_uuid: [u8; UUID_SIZE]) -> Self {
@@ -34305,11 +31678,11 @@ impl ::core::default::Default for PhysicalDeviceVulkan12Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkan12Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkan12Features<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceVulkan12Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVulkan12Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceVulkan12Features<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceVulkan12Features<'a> {}
 impl<'a> PhysicalDeviceVulkan12Features<'a> {
     #[inline]
     pub fn sampler_mirror_clamp_to_edge(mut self, sampler_mirror_clamp_to_edge: bool) -> Self {
@@ -34962,10 +32335,13 @@ impl ::core::default::Default for PhysicalDeviceVulkan12Properties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkan12Properties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkan12Properties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceVulkan12Properties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceVulkan12Properties<'a>
+{
+}
 impl<'a> PhysicalDeviceVulkan12Properties<'a> {
     #[inline]
     pub fn driver_id(mut self, driver_id: DriverId) -> Self {
@@ -35441,11 +32817,11 @@ impl ::core::default::Default for PhysicalDeviceVulkan13Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkan13Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkan13Features<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceVulkan13Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVulkan13Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceVulkan13Features<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceVulkan13Features<'a> {}
 impl<'a> PhysicalDeviceVulkan13Features<'a> {
     #[inline]
     pub fn robust_image_access(mut self, robust_image_access: bool) -> Self {
@@ -35601,10 +32977,13 @@ impl ::core::default::Default for PhysicalDeviceVulkan13Properties<'_> {
         Self { s_type : Self :: STRUCTURE_TYPE , p_next : :: core :: ptr :: null_mut () , min_subgroup_size : u32 :: default () , max_subgroup_size : u32 :: default () , max_compute_workgroup_subgroups : u32 :: default () , required_subgroup_size_stages : ShaderStageFlags :: default () , max_inline_uniform_block_size : u32 :: default () , max_per_stage_descriptor_inline_uniform_blocks : u32 :: default () , max_per_stage_descriptor_update_after_bind_inline_uniform_blocks : u32 :: default () , max_descriptor_set_inline_uniform_blocks : u32 :: default () , max_descriptor_set_update_after_bind_inline_uniform_blocks : u32 :: default () , max_inline_uniform_total_size : u32 :: default () , integer_dot_product8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product64_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated : Bool32 :: default () , storage_texel_buffer_offset_alignment_bytes : DeviceSize :: default () , storage_texel_buffer_offset_single_texel_alignment : Bool32 :: default () , uniform_texel_buffer_offset_alignment_bytes : DeviceSize :: default () , uniform_texel_buffer_offset_single_texel_alignment : Bool32 :: default () , max_buffer_size : DeviceSize :: default () , _marker : PhantomData , }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVulkan13Properties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVulkan13Properties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceVulkan13Properties<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceVulkan13Properties<'a>
+{
+}
 impl<'a> PhysicalDeviceVulkan13Properties<'a> {
     #[inline]
     pub fn min_subgroup_size(mut self, min_subgroup_size: u32) -> Self {
@@ -36009,13 +33388,19 @@ impl ::core::default::Default for PipelineCompilerControlCreateInfoAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineCompilerControlCreateInfoAMD<'a> {
+unsafe impl TaggedStructure<'_> for PipelineCompilerControlCreateInfoAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineCompilerControlCreateInfoAMD<'_> {}
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for PipelineCompilerControlCreateInfoAMD<'_> {}
-unsafe impl Extends<ExecutionGraphPipelineCreateInfoAMDX<'_>>
-    for PipelineCompilerControlCreateInfoAMD<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineCompilerControlCreateInfoAMD<'a>
+{
+}
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>>
+    for PipelineCompilerControlCreateInfoAMD<'a>
+{
+}
+unsafe impl<'a> Extends<'a, ExecutionGraphPipelineCreateInfoAMDX<'a>>
+    for PipelineCompilerControlCreateInfoAMD<'a>
 {
 }
 impl<'a> PipelineCompilerControlCreateInfoAMD<'a> {
@@ -36052,12 +33437,15 @@ impl ::core::default::Default for PhysicalDeviceCoherentMemoryFeaturesAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCoherentMemoryFeaturesAMD<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCoherentMemoryFeaturesAMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceCoherentMemoryFeaturesAMD<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCoherentMemoryFeaturesAMD<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCoherentMemoryFeaturesAMD<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceCoherentMemoryFeaturesAMD<'a> {}
 impl<'a> PhysicalDeviceCoherentMemoryFeaturesAMD<'a> {
     #[inline]
     pub fn device_coherent_memory(mut self, device_coherent_memory: bool) -> Self {
@@ -36110,7 +33498,7 @@ impl ::core::default::Default for PhysicalDeviceToolProperties<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceToolProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceToolProperties<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_TOOL_PROPERTIES;
 }
 impl<'a> PhysicalDeviceToolProperties<'a> {
@@ -36194,11 +33582,11 @@ impl ::core::default::Default for SamplerCustomBorderColorCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerCustomBorderColorCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SamplerCustomBorderColorCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
 }
-unsafe impl Extends<SamplerCreateInfo<'_>> for SamplerCustomBorderColorCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>> for SamplerCustomBorderColorCreateInfoEXT<'a> {}
 impl<'a> SamplerCustomBorderColorCreateInfoEXT<'a> {
     #[inline]
     pub fn custom_border_color(mut self, custom_border_color: ClearColorValue) -> Self {
@@ -36235,12 +33623,12 @@ impl ::core::default::Default for PhysicalDeviceCustomBorderColorPropertiesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCustomBorderColorPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCustomBorderColorPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceCustomBorderColorPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceCustomBorderColorPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceCustomBorderColorPropertiesEXT<'a> {
@@ -36279,15 +33667,18 @@ impl ::core::default::Default for PhysicalDeviceCustomBorderColorFeaturesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCustomBorderColorFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCustomBorderColorFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceCustomBorderColorFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCustomBorderColorFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCustomBorderColorFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCustomBorderColorFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceCustomBorderColorFeaturesEXT<'a> {
     #[inline]
     pub fn custom_border_colors(mut self, custom_border_colors: bool) -> Self {
@@ -36329,11 +33720,14 @@ impl ::core::default::Default for SamplerBorderColorComponentMappingCreateInfoEX
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerBorderColorComponentMappingCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SamplerBorderColorComponentMappingCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT;
 }
-unsafe impl Extends<SamplerCreateInfo<'_>> for SamplerBorderColorComponentMappingCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>>
+    for SamplerBorderColorComponentMappingCreateInfoEXT<'a>
+{
+}
 impl<'a> SamplerBorderColorComponentMappingCreateInfoEXT<'a> {
     #[inline]
     pub fn components(mut self, components: ComponentMapping) -> Self {
@@ -36372,15 +33766,18 @@ impl ::core::default::Default for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceBorderColorSwizzleFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceBorderColorSwizzleFeaturesEXT<'a> {
     #[inline]
     pub fn border_color_swizzle(mut self, border_color_swizzle: bool) -> Self {
@@ -36486,7 +33883,7 @@ impl ::core::default::Default for AccelerationStructureGeometryTrianglesDataKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureGeometryTrianglesDataKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureGeometryTrianglesDataKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
 }
@@ -36526,50 +33923,6 @@ impl<'a> AccelerationStructureGeometryTrianglesDataKHR<'a> {
         self.transform_data = transform_data;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -36607,7 +33960,7 @@ impl ::core::default::Default for AccelerationStructureGeometryAabbsDataKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureGeometryAabbsDataKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureGeometryAabbsDataKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR;
 }
@@ -36659,7 +34012,7 @@ impl ::core::default::Default for AccelerationStructureGeometryInstancesDataKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureGeometryInstancesDataKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureGeometryInstancesDataKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
 }
@@ -36728,7 +34081,7 @@ impl ::core::default::Default for AccelerationStructureGeometryKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureGeometryKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureGeometryKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACCELERATION_STRUCTURE_GEOMETRY_KHR;
 }
 impl<'a> AccelerationStructureGeometryKHR<'a> {
@@ -36811,7 +34164,7 @@ impl ::core::default::Default for AccelerationStructureBuildGeometryInfoKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureBuildGeometryInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureBuildGeometryInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
 }
@@ -36935,7 +34288,7 @@ impl ::core::default::Default for AccelerationStructureCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
 }
 impl<'a> AccelerationStructureCreateInfoKHR<'a> {
@@ -36968,50 +34321,6 @@ impl<'a> AccelerationStructureCreateInfoKHR<'a> {
     pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
         self.device_address = device_address;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -37105,7 +34414,7 @@ impl ::core::default::Default for AccelerationStructureDeviceAddressInfoKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureDeviceAddressInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureDeviceAddressInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
 }
@@ -37143,7 +34452,7 @@ impl ::core::default::Default for AccelerationStructureVersionInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureVersionInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureVersionInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACCELERATION_STRUCTURE_VERSION_INFO_KHR;
 }
 impl<'a> AccelerationStructureVersionInfoKHR<'a> {
@@ -37181,7 +34490,7 @@ impl ::core::default::Default for CopyAccelerationStructureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyAccelerationStructureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for CopyAccelerationStructureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_ACCELERATION_STRUCTURE_INFO_KHR;
 }
 impl<'a> CopyAccelerationStructureInfoKHR<'a> {
@@ -37240,7 +34549,7 @@ impl ::core::default::Default for CopyAccelerationStructureToMemoryInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyAccelerationStructureToMemoryInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for CopyAccelerationStructureToMemoryInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR;
 }
@@ -37300,7 +34609,7 @@ impl ::core::default::Default for CopyMemoryToAccelerationStructureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyMemoryToAccelerationStructureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for CopyMemoryToAccelerationStructureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR;
 }
@@ -37347,7 +34656,7 @@ impl ::core::default::Default for RayTracingPipelineInterfaceCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RayTracingPipelineInterfaceCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RayTracingPipelineInterfaceCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RAY_TRACING_PIPELINE_INTERFACE_CREATE_INFO_KHR;
 }
@@ -37392,10 +34701,10 @@ impl ::core::default::Default for PipelineLibraryCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineLibraryCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineLibraryCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_LIBRARY_CREATE_INFO_KHR;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineLibraryCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>> for PipelineLibraryCreateInfoKHR<'a> {}
 impl<'a> PipelineLibraryCreateInfoKHR<'a> {
     #[inline]
     pub fn libraries(mut self, libraries: &'a [Pipeline]) -> Self {
@@ -37428,15 +34737,18 @@ impl ::core::default::Default for PhysicalDeviceExtendedDynamicStateFeaturesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExtendedDynamicStateFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExtendedDynamicStateFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExtendedDynamicStateFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExtendedDynamicStateFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceExtendedDynamicStateFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExtendedDynamicStateFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceExtendedDynamicStateFeaturesEXT<'a> {
     #[inline]
     pub fn extended_dynamic_state(mut self, extended_dynamic_state: bool) -> Self {
@@ -37472,15 +34784,18 @@ impl ::core::default::Default for PhysicalDeviceExtendedDynamicState2FeaturesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExtendedDynamicState2FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExtendedDynamicState2FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExtendedDynamicState2FeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExtendedDynamicState2FeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceExtendedDynamicState2FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExtendedDynamicState2FeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceExtendedDynamicState2FeaturesEXT<'a> {
     #[inline]
     pub fn extended_dynamic_state2(mut self, extended_dynamic_state2: bool) -> Self {
@@ -37589,15 +34904,18 @@ impl ::core::default::Default for PhysicalDeviceExtendedDynamicState3FeaturesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExtendedDynamicState3FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExtendedDynamicState3FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExtendedDynamicState3FeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExtendedDynamicState3FeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceExtendedDynamicState3FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExtendedDynamicState3FeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceExtendedDynamicState3FeaturesEXT<'a> {
     #[inline]
     pub fn extended_dynamic_state3_tessellation_domain_origin(
@@ -37901,12 +35219,12 @@ impl ::core::default::Default for PhysicalDeviceExtendedDynamicState3PropertiesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExtendedDynamicState3PropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExtendedDynamicState3PropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceExtendedDynamicState3PropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceExtendedDynamicState3PropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceExtendedDynamicState3PropertiesEXT<'a> {
@@ -38028,10 +35346,10 @@ impl ::core::default::Default for RenderPassTransformBeginInfoQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassTransformBeginInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassTransformBeginInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM;
 }
-unsafe impl Extends<RenderPassBeginInfo<'_>> for RenderPassTransformBeginInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassBeginInfo<'a>> for RenderPassTransformBeginInfoQCOM<'a> {}
 impl<'a> RenderPassTransformBeginInfoQCOM<'a> {
     #[inline]
     pub fn transform(mut self, transform: SurfaceTransformFlagsKHR) -> Self {
@@ -38063,11 +35381,11 @@ impl ::core::default::Default for CopyCommandTransformInfoQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyCommandTransformInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for CopyCommandTransformInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_COMMAND_TRANSFORM_INFO_QCOM;
 }
-unsafe impl Extends<BufferImageCopy2<'_>> for CopyCommandTransformInfoQCOM<'_> {}
-unsafe impl Extends<ImageBlit2<'_>> for CopyCommandTransformInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, BufferImageCopy2<'a>> for CopyCommandTransformInfoQCOM<'a> {}
+unsafe impl<'a> Extends<'a, ImageBlit2<'a>> for CopyCommandTransformInfoQCOM<'a> {}
 impl<'a> CopyCommandTransformInfoQCOM<'a> {
     #[inline]
     pub fn transform(mut self, transform: SurfaceTransformFlagsKHR) -> Self {
@@ -38101,12 +35419,12 @@ impl ::core::default::Default for CommandBufferInheritanceRenderPassTransformInf
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferInheritanceRenderPassTransformInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferInheritanceRenderPassTransformInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM;
 }
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>>
-    for CommandBufferInheritanceRenderPassTransformInfoQCOM<'_>
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for CommandBufferInheritanceRenderPassTransformInfoQCOM<'a>
 {
 }
 impl<'a> CommandBufferInheritanceRenderPassTransformInfoQCOM<'a> {
@@ -38145,12 +35463,18 @@ impl ::core::default::Default for PhysicalDeviceDiagnosticsConfigFeaturesNV<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDiagnosticsConfigFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDiagnosticsConfigFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDiagnosticsConfigFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDiagnosticsConfigFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDiagnosticsConfigFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDiagnosticsConfigFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceDiagnosticsConfigFeaturesNV<'a> {
     #[inline]
     pub fn diagnostics_config(mut self, diagnostics_config: bool) -> Self {
@@ -38182,10 +35506,10 @@ impl ::core::default::Default for DeviceDiagnosticsConfigCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceDiagnosticsConfigCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for DeviceDiagnosticsConfigCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for DeviceDiagnosticsConfigCreateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for DeviceDiagnosticsConfigCreateInfoNV<'a> {}
 impl<'a> DeviceDiagnosticsConfigCreateInfoNV<'a> {
     #[inline]
     pub fn flags(mut self, flags: DeviceDiagnosticsConfigFlagsNV) -> Self {
@@ -38217,16 +35541,16 @@ impl ::core::default::Default for PhysicalDeviceZeroInitializeWorkgroupMemoryFea
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'a>
 {
 }
 impl<'a> PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures<'a> {
@@ -38264,16 +35588,16 @@ impl ::core::default::Default for PhysicalDeviceShaderSubgroupUniformControlFlow
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR<'a> {
@@ -38314,11 +35638,14 @@ impl ::core::default::Default for PhysicalDeviceRobustness2FeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRobustness2FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRobustness2FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceRobustness2FeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRobustness2FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRobustness2FeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceRobustness2FeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceRobustness2FeaturesEXT<'a> {
     #[inline]
     pub fn robust_buffer_access2(mut self, robust_buffer_access2: bool) -> Self {
@@ -38362,11 +35689,14 @@ impl ::core::default::Default for PhysicalDeviceRobustness2PropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRobustness2PropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRobustness2PropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceRobustness2PropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceRobustness2PropertiesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceRobustness2PropertiesEXT<'a> {
     #[inline]
     pub fn robust_storage_buffer_access_size_alignment(
@@ -38411,11 +35741,14 @@ impl ::core::default::Default for PhysicalDeviceImageRobustnessFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageRobustnessFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageRobustnessFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceImageRobustnessFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageRobustnessFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageRobustnessFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceImageRobustnessFeatures<'a> {}
 impl<'a> PhysicalDeviceImageRobustnessFeatures<'a> {
     #[inline]
     pub fn robust_image_access(mut self, robust_image_access: bool) -> Self {
@@ -38453,16 +35786,16 @@ impl ::core::default::Default for PhysicalDeviceWorkgroupMemoryExplicitLayoutFea
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR<'a> {
@@ -38554,15 +35887,18 @@ impl ::core::default::Default for PhysicalDevicePortabilitySubsetFeaturesKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePortabilitySubsetFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePortabilitySubsetFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePortabilitySubsetFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePortabilitySubsetFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePortabilitySubsetFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePortabilitySubsetFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDevicePortabilitySubsetFeaturesKHR<'a> {
     #[inline]
     pub fn constant_alpha_color_blend_factors(
@@ -38677,12 +36013,12 @@ impl ::core::default::Default for PhysicalDevicePortabilitySubsetPropertiesKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePortabilitySubsetPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePortabilitySubsetPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDevicePortabilitySubsetPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePortabilitySubsetPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDevicePortabilitySubsetPropertiesKHR<'a> {
@@ -38721,11 +36057,14 @@ impl ::core::default::Default for PhysicalDevice4444FormatsFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevice4444FormatsFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevice4444FormatsFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevice4444FormatsFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevice4444FormatsFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevice4444FormatsFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevice4444FormatsFeaturesEXT<'a> {}
 impl<'a> PhysicalDevice4444FormatsFeaturesEXT<'a> {
     #[inline]
     pub fn format_a4r4g4b4(mut self, format_a4r4g4b4: bool) -> Self {
@@ -38762,15 +36101,18 @@ impl ::core::default::Default for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSubpassShadingFeaturesHUAWEI<'a>
+{
+}
 impl<'a> PhysicalDeviceSubpassShadingFeaturesHUAWEI<'a> {
     #[inline]
     pub fn subpass_shading(mut self, subpass_shading: bool) -> Self {
@@ -38804,15 +36146,18 @@ impl ::core::default::Default for PhysicalDeviceClusterCullingShaderFeaturesHUAW
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'a>
+{
+}
 impl<'a> PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'a> {
     #[inline]
     pub fn clusterculling_shader(mut self, clusterculling_shader: bool) -> Self {
@@ -38826,50 +36171,6 @@ impl<'a> PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'a> {
     ) -> Self {
         self.multiview_cluster_culling_shader = multiview_cluster_culling_shader.into();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -38896,12 +36197,12 @@ impl ::core::default::Default for PhysicalDeviceClusterCullingShaderVrsFeaturesH
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI;
 }
-unsafe impl Extends<PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'_>>
-    for PhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceClusterCullingShaderFeaturesHUAWEI<'a>>
+    for PhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI<'a>
 {
 }
 impl<'a> PhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI<'a> {
@@ -38939,7 +36240,7 @@ impl ::core::default::Default for BufferCopy2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCopy2<'a> {
+unsafe impl TaggedStructure<'_> for BufferCopy2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_COPY_2;
 }
 impl<'a> BufferCopy2<'a> {
@@ -38991,7 +36292,7 @@ impl ::core::default::Default for ImageCopy2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageCopy2<'a> {
+unsafe impl TaggedStructure<'_> for ImageCopy2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_COPY_2;
 }
 impl<'a> ImageCopy2<'a> {
@@ -39051,7 +36352,7 @@ impl ::core::default::Default for ImageBlit2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageBlit2<'a> {
+unsafe impl TaggedStructure<'_> for ImageBlit2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_BLIT_2;
 }
 impl<'a> ImageBlit2<'a> {
@@ -39074,50 +36375,6 @@ impl<'a> ImageBlit2<'a> {
     pub fn dst_offsets(mut self, dst_offsets: [Offset3D; 2]) -> Self {
         self.dst_offsets = dst_offsets;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -39154,7 +36411,7 @@ impl ::core::default::Default for BufferImageCopy2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferImageCopy2<'a> {
+unsafe impl TaggedStructure<'_> for BufferImageCopy2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_IMAGE_COPY_2;
 }
 impl<'a> BufferImageCopy2<'a> {
@@ -39187,50 +36444,6 @@ impl<'a> BufferImageCopy2<'a> {
     pub fn image_extent(mut self, image_extent: Extent3D) -> Self {
         self.image_extent = image_extent;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -39265,7 +36478,7 @@ impl ::core::default::Default for ImageResolve2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageResolve2<'a> {
+unsafe impl TaggedStructure<'_> for ImageResolve2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_RESOLVE_2;
 }
 impl<'a> ImageResolve2<'a> {
@@ -39325,7 +36538,7 @@ impl ::core::default::Default for CopyBufferInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyBufferInfo2<'a> {
+unsafe impl TaggedStructure<'_> for CopyBufferInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_BUFFER_INFO_2;
 }
 impl<'a> CopyBufferInfo2<'a> {
@@ -39380,7 +36593,7 @@ impl ::core::default::Default for CopyImageInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyImageInfo2<'a> {
+unsafe impl TaggedStructure<'_> for CopyImageInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_IMAGE_INFO_2;
 }
 impl<'a> CopyImageInfo2<'a> {
@@ -39447,7 +36660,7 @@ impl ::core::default::Default for BlitImageInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BlitImageInfo2<'a> {
+unsafe impl TaggedStructure<'_> for BlitImageInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BLIT_IMAGE_INFO_2;
 }
 impl<'a> BlitImageInfo2<'a> {
@@ -39482,50 +36695,6 @@ impl<'a> BlitImageInfo2<'a> {
         self.filter = filter;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -39559,7 +36728,7 @@ impl ::core::default::Default for CopyBufferToImageInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyBufferToImageInfo2<'a> {
+unsafe impl TaggedStructure<'_> for CopyBufferToImageInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_BUFFER_TO_IMAGE_INFO_2;
 }
 impl<'a> CopyBufferToImageInfo2<'a> {
@@ -39617,7 +36786,7 @@ impl ::core::default::Default for CopyImageToBufferInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyImageToBufferInfo2<'a> {
+unsafe impl TaggedStructure<'_> for CopyImageToBufferInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_IMAGE_TO_BUFFER_INFO_2;
 }
 impl<'a> CopyImageToBufferInfo2<'a> {
@@ -39677,7 +36846,7 @@ impl ::core::default::Default for ResolveImageInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ResolveImageInfo2<'a> {
+unsafe impl TaggedStructure<'_> for ResolveImageInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RESOLVE_IMAGE_INFO_2;
 }
 impl<'a> ResolveImageInfo2<'a> {
@@ -39734,15 +36903,18 @@ impl ::core::default::Default for PhysicalDeviceShaderImageAtomicInt64FeaturesEX
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderImageAtomicInt64FeaturesEXT<'a> {
     #[inline]
     pub fn shader_image_int64_atomics(mut self, shader_image_int64_atomics: bool) -> Self {
@@ -39781,10 +36953,10 @@ impl ::core::default::Default for FragmentShadingRateAttachmentInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FragmentShadingRateAttachmentInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for FragmentShadingRateAttachmentInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR;
 }
-unsafe impl Extends<SubpassDescription2<'_>> for FragmentShadingRateAttachmentInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, SubpassDescription2<'a>> for FragmentShadingRateAttachmentInfoKHR<'a> {}
 impl<'a> FragmentShadingRateAttachmentInfoKHR<'a> {
     #[inline]
     pub fn fragment_shading_rate_attachment(
@@ -39829,12 +37001,12 @@ impl ::core::default::Default for PipelineFragmentShadingRateStateCreateInfoKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineFragmentShadingRateStateCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PipelineFragmentShadingRateStateCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>>
-    for PipelineFragmentShadingRateStateCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineFragmentShadingRateStateCreateInfoKHR<'a>
 {
 }
 impl<'a> PipelineFragmentShadingRateStateCreateInfoKHR<'a> {
@@ -39877,15 +37049,18 @@ impl ::core::default::Default for PhysicalDeviceFragmentShadingRateFeaturesKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShadingRateFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShadingRateFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentShadingRateFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentShadingRateFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFragmentShadingRateFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentShadingRateFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceFragmentShadingRateFeaturesKHR<'a> {
     #[inline]
     pub fn pipeline_fragment_shading_rate(mut self, pipeline_fragment_shading_rate: bool) -> Self {
@@ -39965,12 +37140,12 @@ impl ::core::default::Default for PhysicalDeviceFragmentShadingRatePropertiesKHR
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShadingRatePropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShadingRatePropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceFragmentShadingRatePropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFragmentShadingRatePropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHR<'a> {
@@ -40144,7 +37319,7 @@ impl ::core::default::Default for PhysicalDeviceFragmentShadingRateKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShadingRateKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShadingRateKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR;
 }
 impl<'a> PhysicalDeviceFragmentShadingRateKHR<'a> {
@@ -40183,15 +37358,18 @@ impl ::core::default::Default for PhysicalDeviceShaderTerminateInvocationFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderTerminateInvocationFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderTerminateInvocationFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderTerminateInvocationFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderTerminateInvocationFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderTerminateInvocationFeatures<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderTerminateInvocationFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderTerminateInvocationFeatures<'a> {
     #[inline]
     pub fn shader_terminate_invocation(mut self, shader_terminate_invocation: bool) -> Self {
@@ -40227,15 +37405,18 @@ impl ::core::default::Default for PhysicalDeviceFragmentShadingRateEnumsFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceFragmentShadingRateEnumsFeaturesNV<'a> {
     #[inline]
     pub fn fragment_shading_rate_enums(mut self, fragment_shading_rate_enums: bool) -> Self {
@@ -40283,12 +37464,12 @@ impl ::core::default::Default for PhysicalDeviceFragmentShadingRateEnumsProperti
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShadingRateEnumsPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShadingRateEnumsPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceFragmentShadingRateEnumsPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFragmentShadingRateEnumsPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentShadingRateEnumsPropertiesNV<'a> {
@@ -40330,12 +37511,12 @@ impl ::core::default::Default for PipelineFragmentShadingRateEnumStateCreateInfo
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineFragmentShadingRateEnumStateCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for PipelineFragmentShadingRateEnumStateCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>>
-    for PipelineFragmentShadingRateEnumStateCreateInfoNV<'_>
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineFragmentShadingRateEnumStateCreateInfoNV<'a>
 {
 }
 impl<'a> PipelineFragmentShadingRateEnumStateCreateInfoNV<'a> {
@@ -40383,7 +37564,7 @@ impl ::core::default::Default for AccelerationStructureBuildSizesInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureBuildSizesInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureBuildSizesInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 }
@@ -40430,12 +37611,15 @@ impl ::core::default::Default for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceImage2DViewOf3DFeaturesEXT<'a> {
     #[inline]
     pub fn image2_d_view_of3_d(mut self, image2_d_view_of3_d: bool) -> Self {
@@ -40472,15 +37656,18 @@ impl ::core::default::Default for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceImageSlicedViewOf3DFeaturesEXT<'a> {
     #[inline]
     pub fn image_sliced_view_of3_d(mut self, image_sliced_view_of3_d: bool) -> Self {
@@ -40512,18 +37699,18 @@ impl ::core::default::Default for PhysicalDeviceAttachmentFeedbackLoopDynamicSta
         }
     }
 }
-unsafe impl<'a> TaggedStructure
-    for PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'a>
+unsafe impl TaggedStructure<'_>
+    for PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'_>
 {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT<'a> {
@@ -40560,15 +37747,18 @@ impl ::core::default::Default for PhysicalDeviceLegacyVertexAttributesFeaturesEX
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceLegacyVertexAttributesFeaturesEXT<'a> {
     #[inline]
     pub fn legacy_vertex_attributes(mut self, legacy_vertex_attributes: bool) -> Self {
@@ -40600,12 +37790,12 @@ impl ::core::default::Default for PhysicalDeviceLegacyVertexAttributesProperties
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLegacyVertexAttributesPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLegacyVertexAttributesPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceLegacyVertexAttributesPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceLegacyVertexAttributesPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceLegacyVertexAttributesPropertiesEXT<'a> {
@@ -40639,15 +37829,18 @@ impl ::core::default::Default for PhysicalDeviceMutableDescriptorTypeFeaturesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceMutableDescriptorTypeFeaturesEXT<'a> {
     #[inline]
     pub fn mutable_descriptor_type(mut self, mutable_descriptor_type: bool) -> Self {
@@ -40711,11 +37904,17 @@ impl ::core::default::Default for MutableDescriptorTypeCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MutableDescriptorTypeCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MutableDescriptorTypeCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<DescriptorSetLayoutCreateInfo<'_>> for MutableDescriptorTypeCreateInfoEXT<'_> {}
-unsafe impl Extends<DescriptorPoolCreateInfo<'_>> for MutableDescriptorTypeCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, DescriptorSetLayoutCreateInfo<'a>>
+    for MutableDescriptorTypeCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DescriptorPoolCreateInfo<'a>>
+    for MutableDescriptorTypeCreateInfoEXT<'a>
+{
+}
 impl<'a> MutableDescriptorTypeCreateInfoEXT<'a> {
     #[inline]
     pub fn mutable_descriptor_type_lists(
@@ -40751,12 +37950,18 @@ impl ::core::default::Default for PhysicalDeviceDepthClipControlFeaturesEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDepthClipControlFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDepthClipControlFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDepthClipControlFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDepthClipControlFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDepthClipControlFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDepthClipControlFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDepthClipControlFeaturesEXT<'a> {
     #[inline]
     pub fn depth_clip_control(mut self, depth_clip_control: bool) -> Self {
@@ -40790,15 +37995,18 @@ impl ::core::default::Default for PhysicalDeviceDeviceGeneratedCommandsFeaturesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT<'a> {
     #[inline]
     pub fn device_generated_commands(mut self, device_generated_commands: bool) -> Self {
@@ -40860,12 +38068,12 @@ impl ::core::default::Default for PhysicalDeviceDeviceGeneratedCommandsPropertie
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDeviceGeneratedCommandsPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDeviceGeneratedCommandsPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDeviceGeneratedCommandsPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDeviceGeneratedCommandsPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsPropertiesEXT<'a> {
@@ -40988,12 +38196,12 @@ impl ::core::default::Default for GeneratedCommandsPipelineInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeneratedCommandsPipelineInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for GeneratedCommandsPipelineInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GENERATED_COMMANDS_PIPELINE_INFO_EXT;
 }
-unsafe impl Extends<GeneratedCommandsInfoEXT<'_>> for GeneratedCommandsPipelineInfoEXT<'_> {}
-unsafe impl Extends<GeneratedCommandsMemoryRequirementsInfoEXT<'_>>
-    for GeneratedCommandsPipelineInfoEXT<'_>
+unsafe impl<'a> Extends<'a, GeneratedCommandsInfoEXT<'a>> for GeneratedCommandsPipelineInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, GeneratedCommandsMemoryRequirementsInfoEXT<'a>>
+    for GeneratedCommandsPipelineInfoEXT<'a>
 {
 }
 impl<'a> GeneratedCommandsPipelineInfoEXT<'a> {
@@ -41029,12 +38237,12 @@ impl ::core::default::Default for GeneratedCommandsShaderInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeneratedCommandsShaderInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for GeneratedCommandsShaderInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GENERATED_COMMANDS_SHADER_INFO_EXT;
 }
-unsafe impl Extends<GeneratedCommandsInfoEXT<'_>> for GeneratedCommandsShaderInfoEXT<'_> {}
-unsafe impl Extends<GeneratedCommandsMemoryRequirementsInfoEXT<'_>>
-    for GeneratedCommandsShaderInfoEXT<'_>
+unsafe impl<'a> Extends<'a, GeneratedCommandsInfoEXT<'a>> for GeneratedCommandsShaderInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, GeneratedCommandsMemoryRequirementsInfoEXT<'a>>
+    for GeneratedCommandsShaderInfoEXT<'a>
 {
 }
 impl<'a> GeneratedCommandsShaderInfoEXT<'a> {
@@ -41075,7 +38283,7 @@ impl ::core::default::Default for GeneratedCommandsMemoryRequirementsInfoEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeneratedCommandsMemoryRequirementsInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for GeneratedCommandsMemoryRequirementsInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_EXT;
 }
@@ -41106,50 +38314,6 @@ impl<'a> GeneratedCommandsMemoryRequirementsInfoEXT<'a> {
         self.max_draw_count = max_draw_count;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -41177,7 +38341,7 @@ impl ::core::default::Default for IndirectExecutionSetPipelineInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectExecutionSetPipelineInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for IndirectExecutionSetPipelineInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_EXECUTION_SET_PIPELINE_INFO_EXT;
 }
 impl<'a> IndirectExecutionSetPipelineInfoEXT<'a> {
@@ -41218,7 +38382,7 @@ impl ::core::default::Default for IndirectExecutionSetShaderLayoutInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectExecutionSetShaderLayoutInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for IndirectExecutionSetShaderLayoutInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::INDIRECT_EXECUTION_SET_SHADER_LAYOUT_INFO_EXT;
 }
@@ -41264,7 +38428,7 @@ impl ::core::default::Default for IndirectExecutionSetShaderInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectExecutionSetShaderInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for IndirectExecutionSetShaderInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_EXECUTION_SET_SHADER_INFO_EXT;
 }
 impl<'a> IndirectExecutionSetShaderInfoEXT<'a> {
@@ -41344,7 +38508,7 @@ impl ::core::default::Default for IndirectExecutionSetCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectExecutionSetCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for IndirectExecutionSetCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_EXECUTION_SET_CREATE_INFO_EXT;
 }
 impl<'a> IndirectExecutionSetCreateInfoEXT<'a> {
@@ -41401,7 +38565,7 @@ impl ::core::default::Default for GeneratedCommandsInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GeneratedCommandsInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for GeneratedCommandsInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GENERATED_COMMANDS_INFO_EXT;
 }
 impl<'a> GeneratedCommandsInfoEXT<'a> {
@@ -41461,50 +38625,6 @@ impl<'a> GeneratedCommandsInfoEXT<'a> {
         self.max_draw_count = max_draw_count;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -41532,7 +38652,7 @@ impl ::core::default::Default for WriteIndirectExecutionSetPipelineEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WriteIndirectExecutionSetPipelineEXT<'a> {
+unsafe impl TaggedStructure<'_> for WriteIndirectExecutionSetPipelineEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WRITE_INDIRECT_EXECUTION_SET_PIPELINE_EXT;
 }
 impl<'a> WriteIndirectExecutionSetPipelineEXT<'a> {
@@ -41573,7 +38693,7 @@ impl ::core::default::Default for WriteIndirectExecutionSetShaderEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for WriteIndirectExecutionSetShaderEXT<'a> {
+unsafe impl TaggedStructure<'_> for WriteIndirectExecutionSetShaderEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::WRITE_INDIRECT_EXECUTION_SET_SHADER_EXT;
 }
 impl<'a> WriteIndirectExecutionSetShaderEXT<'a> {
@@ -41622,7 +38742,7 @@ impl ::core::default::Default for IndirectCommandsLayoutCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectCommandsLayoutCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for IndirectCommandsLayoutCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_EXT;
 }
 impl<'a> IndirectCommandsLayoutCreateInfoEXT<'a> {
@@ -41651,50 +38771,6 @@ impl<'a> IndirectCommandsLayoutCreateInfoEXT<'a> {
         self.token_count = tokens.len() as _;
         self.p_tokens = tokens.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -41736,7 +38812,7 @@ impl ::core::default::Default for IndirectCommandsLayoutTokenEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for IndirectCommandsLayoutTokenEXT<'a> {
+unsafe impl TaggedStructure<'_> for IndirectCommandsLayoutTokenEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::INDIRECT_COMMANDS_LAYOUT_TOKEN_EXT;
 }
 impl<'a> IndirectCommandsLayoutTokenEXT<'a> {
@@ -41942,12 +39018,12 @@ impl ::core::default::Default for PipelineViewportDepthClipControlCreateInfoEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportDepthClipControlCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportDepthClipControlCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportDepthClipControlCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportDepthClipControlCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineViewportDepthClipControlCreateInfoEXT<'a> {
@@ -41981,15 +39057,18 @@ impl ::core::default::Default for PhysicalDeviceDepthClampControlFeaturesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDepthClampControlFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDepthClampControlFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDepthClampControlFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDepthClampControlFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDepthClampControlFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDepthClampControlFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDepthClampControlFeaturesEXT<'a> {
     #[inline]
     pub fn depth_clamp_control(mut self, depth_clamp_control: bool) -> Self {
@@ -42023,12 +39102,12 @@ impl ::core::default::Default for PipelineViewportDepthClampControlCreateInfoEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineViewportDepthClampControlCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineViewportDepthClampControlCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_VIEWPORT_DEPTH_CLAMP_CONTROL_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineViewportStateCreateInfo<'_>>
-    for PipelineViewportDepthClampControlCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineViewportStateCreateInfo<'a>>
+    for PipelineViewportDepthClampControlCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineViewportDepthClampControlCreateInfoEXT<'a> {
@@ -42067,15 +39146,18 @@ impl ::core::default::Default for PhysicalDeviceVertexInputDynamicStateFeaturesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceVertexInputDynamicStateFeaturesEXT<'a> {
     #[inline]
     pub fn vertex_input_dynamic_state(mut self, vertex_input_dynamic_state: bool) -> Self {
@@ -42107,15 +39189,18 @@ impl ::core::default::Default for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExternalMemoryRDMAFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceExternalMemoryRDMAFeaturesNV<'a> {
     #[inline]
     pub fn external_memory_rdma(mut self, external_memory_rdma: bool) -> Self {
@@ -42147,16 +39232,16 @@ impl ::core::default::Default for PhysicalDeviceShaderRelaxedExtendedInstruction
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_RELAXED_EXTENDED_INSTRUCTION_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR<'a> {
@@ -42199,7 +39284,7 @@ impl ::core::default::Default for VertexInputBindingDescription2EXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VertexInputBindingDescription2EXT<'a> {
+unsafe impl TaggedStructure<'_> for VertexInputBindingDescription2EXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT;
 }
 impl<'a> VertexInputBindingDescription2EXT<'a> {
@@ -42254,7 +39339,7 @@ impl ::core::default::Default for VertexInputAttributeDescription2EXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VertexInputAttributeDescription2EXT<'a> {
+unsafe impl TaggedStructure<'_> for VertexInputAttributeDescription2EXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT;
 }
 impl<'a> VertexInputAttributeDescription2EXT<'a> {
@@ -42303,12 +39388,18 @@ impl ::core::default::Default for PhysicalDeviceColorWriteEnableFeaturesEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceColorWriteEnableFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceColorWriteEnableFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceColorWriteEnableFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceColorWriteEnableFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceColorWriteEnableFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceColorWriteEnableFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceColorWriteEnableFeaturesEXT<'a> {
     #[inline]
     pub fn color_write_enable(mut self, color_write_enable: bool) -> Self {
@@ -42342,10 +39433,13 @@ impl ::core::default::Default for PipelineColorWriteCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineColorWriteCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineColorWriteCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_COLOR_WRITE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineColorBlendStateCreateInfo<'_>> for PipelineColorWriteCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, PipelineColorBlendStateCreateInfo<'a>>
+    for PipelineColorWriteCreateInfoEXT<'a>
+{
+}
 impl<'a> PipelineColorWriteCreateInfoEXT<'a> {
     #[inline]
     pub fn color_write_enables(mut self, color_write_enables: &'a [Bool32]) -> Self {
@@ -42384,10 +39478,10 @@ impl ::core::default::Default for MemoryBarrier2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryBarrier2<'a> {
+unsafe impl TaggedStructure<'_> for MemoryBarrier2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_BARRIER_2;
 }
-unsafe impl Extends<SubpassDependency2<'_>> for MemoryBarrier2<'_> {}
+unsafe impl<'a> Extends<'a, SubpassDependency2<'a>> for MemoryBarrier2<'a> {}
 impl<'a> MemoryBarrier2<'a> {
     #[inline]
     pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2) -> Self {
@@ -42452,7 +39546,7 @@ impl ::core::default::Default for ImageMemoryBarrier2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageMemoryBarrier2<'a> {
+unsafe impl TaggedStructure<'_> for ImageMemoryBarrier2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_MEMORY_BARRIER_2;
 }
 impl<'a> ImageMemoryBarrier2<'a> {
@@ -42506,50 +39600,6 @@ impl<'a> ImageMemoryBarrier2<'a> {
         self.subresource_range = subresource_range;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -42591,7 +39641,7 @@ impl ::core::default::Default for BufferMemoryBarrier2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferMemoryBarrier2<'a> {
+unsafe impl TaggedStructure<'_> for BufferMemoryBarrier2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_MEMORY_BARRIER_2;
 }
 impl<'a> BufferMemoryBarrier2<'a> {
@@ -42640,50 +39690,6 @@ impl<'a> BufferMemoryBarrier2<'a> {
         self.size = size;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -42721,7 +39727,7 @@ impl ::core::default::Default for DependencyInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DependencyInfo<'a> {
+unsafe impl TaggedStructure<'_> for DependencyInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEPENDENCY_INFO;
 }
 impl<'a> DependencyInfo<'a> {
@@ -42785,7 +39791,7 @@ impl ::core::default::Default for SemaphoreSubmitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SemaphoreSubmitInfo<'a> {
+unsafe impl TaggedStructure<'_> for SemaphoreSubmitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SEMAPHORE_SUBMIT_INFO;
 }
 impl<'a> SemaphoreSubmitInfo<'a> {
@@ -42836,7 +39842,7 @@ impl ::core::default::Default for CommandBufferSubmitInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferSubmitInfo<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferSubmitInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMMAND_BUFFER_SUBMIT_INFO;
 }
 impl<'a> CommandBufferSubmitInfo<'a> {
@@ -42849,50 +39855,6 @@ impl<'a> CommandBufferSubmitInfo<'a> {
     pub fn device_mask(mut self, device_mask: u32) -> Self {
         self.device_mask = device_mask;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -42931,7 +39893,7 @@ impl ::core::default::Default for SubmitInfo2<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubmitInfo2<'a> {
+unsafe impl TaggedStructure<'_> for SubmitInfo2<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBMIT_INFO_2;
 }
 impl<'a> SubmitInfo2<'a> {
@@ -42967,50 +39929,6 @@ impl<'a> SubmitInfo2<'a> {
         self.p_signal_semaphore_infos = signal_semaphore_infos.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -43036,10 +39954,10 @@ impl ::core::default::Default for QueueFamilyCheckpointProperties2NV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueueFamilyCheckpointProperties2NV<'a> {
+unsafe impl TaggedStructure<'_> for QueueFamilyCheckpointProperties2NV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV;
 }
-unsafe impl Extends<QueueFamilyProperties2<'_>> for QueueFamilyCheckpointProperties2NV<'_> {}
+unsafe impl<'a> Extends<'a, QueueFamilyProperties2<'a>> for QueueFamilyCheckpointProperties2NV<'a> {}
 impl<'a> QueueFamilyCheckpointProperties2NV<'a> {
     #[inline]
     pub fn checkpoint_execution_stage_mask(
@@ -43076,7 +39994,7 @@ impl ::core::default::Default for CheckpointData2NV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CheckpointData2NV<'a> {
+unsafe impl TaggedStructure<'_> for CheckpointData2NV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CHECKPOINT_DATA_2_NV;
 }
 impl<'a> CheckpointData2NV<'a> {
@@ -43115,11 +40033,14 @@ impl ::core::default::Default for PhysicalDeviceSynchronization2Features<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSynchronization2Features<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSynchronization2Features<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceSynchronization2Features<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSynchronization2Features<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSynchronization2Features<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceSynchronization2Features<'a> {}
 impl<'a> PhysicalDeviceSynchronization2Features<'a> {
     #[inline]
     pub fn synchronization2(mut self, synchronization2: bool) -> Self {
@@ -43151,12 +40072,15 @@ impl ::core::default::Default for PhysicalDeviceHostImageCopyFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceHostImageCopyFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceHostImageCopyFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceHostImageCopyFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceHostImageCopyFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceHostImageCopyFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceHostImageCopyFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceHostImageCopyFeaturesEXT<'a> {
     #[inline]
     pub fn host_image_copy(mut self, host_image_copy: bool) -> Self {
@@ -43198,12 +40122,12 @@ impl ::core::default::Default for PhysicalDeviceHostImageCopyPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceHostImageCopyPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceHostImageCopyPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceHostImageCopyPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceHostImageCopyPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceHostImageCopyPropertiesEXT<'a> {
@@ -43270,7 +40194,7 @@ impl ::core::default::Default for MemoryToImageCopyEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryToImageCopyEXT<'a> {
+unsafe impl TaggedStructure<'_> for MemoryToImageCopyEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_TO_IMAGE_COPY_EXT;
 }
 impl<'a> MemoryToImageCopyEXT<'a> {
@@ -43339,7 +40263,7 @@ impl ::core::default::Default for ImageToMemoryCopyEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageToMemoryCopyEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageToMemoryCopyEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_TO_MEMORY_COPY_EXT;
 }
 impl<'a> ImageToMemoryCopyEXT<'a> {
@@ -43406,7 +40330,7 @@ impl ::core::default::Default for CopyMemoryToImageInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyMemoryToImageInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CopyMemoryToImageInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_MEMORY_TO_IMAGE_INFO_EXT;
 }
 impl<'a> CopyMemoryToImageInfoEXT<'a> {
@@ -43464,7 +40388,7 @@ impl ::core::default::Default for CopyImageToMemoryInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyImageToMemoryInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CopyImageToMemoryInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_IMAGE_TO_MEMORY_INFO_EXT;
 }
 impl<'a> CopyImageToMemoryInfoEXT<'a> {
@@ -43526,7 +40450,7 @@ impl ::core::default::Default for CopyImageToImageInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyImageToImageInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CopyImageToImageInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_IMAGE_TO_IMAGE_INFO_EXT;
 }
 impl<'a> CopyImageToImageInfoEXT<'a> {
@@ -43592,7 +40516,7 @@ impl ::core::default::Default for HostImageLayoutTransitionInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for HostImageLayoutTransitionInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for HostImageLayoutTransitionInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT;
 }
 impl<'a> HostImageLayoutTransitionInfoEXT<'a> {
@@ -43641,10 +40565,10 @@ impl ::core::default::Default for SubresourceHostMemcpySizeEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubresourceHostMemcpySizeEXT<'a> {
+unsafe impl TaggedStructure<'_> for SubresourceHostMemcpySizeEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBRESOURCE_HOST_MEMCPY_SIZE_EXT;
 }
-unsafe impl Extends<SubresourceLayout2KHR<'_>> for SubresourceHostMemcpySizeEXT<'_> {}
+unsafe impl<'a> Extends<'a, SubresourceLayout2KHR<'a>> for SubresourceHostMemcpySizeEXT<'a> {}
 impl<'a> SubresourceHostMemcpySizeEXT<'a> {
     #[inline]
     pub fn size(mut self, size: DeviceSize) -> Self {
@@ -43678,11 +40602,14 @@ impl ::core::default::Default for HostImageCopyDevicePerformanceQueryEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for HostImageCopyDevicePerformanceQueryEXT<'a> {
+unsafe impl TaggedStructure<'_> for HostImageCopyDevicePerformanceQueryEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>> for HostImageCopyDevicePerformanceQueryEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>>
+    for HostImageCopyDevicePerformanceQueryEXT<'a>
+{
+}
 impl<'a> HostImageCopyDevicePerformanceQueryEXT<'a> {
     #[inline]
     pub fn optimal_device_access(mut self, optimal_device_access: bool) -> Self {
@@ -43723,16 +40650,16 @@ impl ::core::default::Default for PhysicalDevicePrimitivesGeneratedQueryFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT<'a> {
@@ -43784,12 +40711,15 @@ impl ::core::default::Default for PhysicalDeviceLegacyDitheringFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLegacyDitheringFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLegacyDitheringFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceLegacyDitheringFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceLegacyDitheringFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceLegacyDitheringFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceLegacyDitheringFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceLegacyDitheringFeaturesEXT<'a> {
     #[inline]
     pub fn legacy_dithering(mut self, legacy_dithering: bool) -> Self {
@@ -43821,16 +40751,16 @@ impl ::core::default::Default for PhysicalDeviceMultisampledRenderToSingleSample
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT<'a> {
@@ -43867,10 +40797,10 @@ impl ::core::default::Default for SubpassResolvePerformanceQueryEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubpassResolvePerformanceQueryEXT<'a> {
+unsafe impl TaggedStructure<'_> for SubpassResolvePerformanceQueryEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBPASS_RESOLVE_PERFORMANCE_QUERY_EXT;
 }
-unsafe impl Extends<FormatProperties2<'_>> for SubpassResolvePerformanceQueryEXT<'_> {}
+unsafe impl<'a> Extends<'a, FormatProperties2<'a>> for SubpassResolvePerformanceQueryEXT<'a> {}
 impl<'a> SubpassResolvePerformanceQueryEXT<'a> {
     #[inline]
     pub fn optimal(mut self, optimal: bool) -> Self {
@@ -43904,12 +40834,15 @@ impl ::core::default::Default for MultisampledRenderToSingleSampledInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MultisampledRenderToSingleSampledInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MultisampledRenderToSingleSampledInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_INFO_EXT;
 }
-unsafe impl Extends<SubpassDescription2<'_>> for MultisampledRenderToSingleSampledInfoEXT<'_> {}
-unsafe impl Extends<RenderingInfo<'_>> for MultisampledRenderToSingleSampledInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SubpassDescription2<'a>>
+    for MultisampledRenderToSingleSampledInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>> for MultisampledRenderToSingleSampledInfoEXT<'a> {}
 impl<'a> MultisampledRenderToSingleSampledInfoEXT<'a> {
     #[inline]
     pub fn multisampled_render_to_single_sampled_enable(
@@ -43950,15 +40883,18 @@ impl ::core::default::Default for PhysicalDevicePipelineProtectedAccessFeaturesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineProtectedAccessFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineProtectedAccessFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePipelineProtectedAccessFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelineProtectedAccessFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePipelineProtectedAccessFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePipelineProtectedAccessFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDevicePipelineProtectedAccessFeaturesEXT<'a> {
     #[inline]
     pub fn pipeline_protected_access(mut self, pipeline_protected_access: bool) -> Self {
@@ -43990,10 +40926,10 @@ impl ::core::default::Default for QueueFamilyVideoPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueueFamilyVideoPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for QueueFamilyVideoPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUEUE_FAMILY_VIDEO_PROPERTIES_KHR;
 }
-unsafe impl Extends<QueueFamilyProperties2<'_>> for QueueFamilyVideoPropertiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, QueueFamilyProperties2<'a>> for QueueFamilyVideoPropertiesKHR<'a> {}
 impl<'a> QueueFamilyVideoPropertiesKHR<'a> {
     #[inline]
     pub fn video_codec_operations(
@@ -44028,11 +40964,14 @@ impl ::core::default::Default for QueueFamilyQueryResultStatusPropertiesKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueueFamilyQueryResultStatusPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for QueueFamilyQueryResultStatusPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::QUEUE_FAMILY_QUERY_RESULT_STATUS_PROPERTIES_KHR;
 }
-unsafe impl Extends<QueueFamilyProperties2<'_>> for QueueFamilyQueryResultStatusPropertiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, QueueFamilyProperties2<'a>>
+    for QueueFamilyQueryResultStatusPropertiesKHR<'a>
+{
+}
 impl<'a> QueueFamilyQueryResultStatusPropertiesKHR<'a> {
     #[inline]
     pub fn query_result_status_support(mut self, query_result_status_support: bool) -> Self {
@@ -44066,13 +41005,13 @@ impl ::core::default::Default for VideoProfileListInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoProfileListInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoProfileListInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_PROFILE_LIST_INFO_KHR;
 }
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>> for VideoProfileListInfoKHR<'_> {}
-unsafe impl Extends<PhysicalDeviceVideoFormatInfoKHR<'_>> for VideoProfileListInfoKHR<'_> {}
-unsafe impl Extends<ImageCreateInfo<'_>> for VideoProfileListInfoKHR<'_> {}
-unsafe impl Extends<BufferCreateInfo<'_>> for VideoProfileListInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>> for VideoProfileListInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceVideoFormatInfoKHR<'a>> for VideoProfileListInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for VideoProfileListInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for VideoProfileListInfoKHR<'a> {}
 impl<'a> VideoProfileListInfoKHR<'a> {
     #[inline]
     pub fn profiles(mut self, profiles: &'a [VideoProfileInfoKHR<'a>]) -> Self {
@@ -44105,7 +41044,7 @@ impl ::core::default::Default for PhysicalDeviceVideoFormatInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVideoFormatInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVideoFormatInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR;
 }
 impl<'a> PhysicalDeviceVideoFormatInfoKHR<'a> {
@@ -44113,50 +41052,6 @@ impl<'a> PhysicalDeviceVideoFormatInfoKHR<'a> {
     pub fn image_usage(mut self, image_usage: ImageUsageFlags) -> Self {
         self.image_usage = image_usage;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -44193,7 +41088,7 @@ impl ::core::default::Default for VideoFormatPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoFormatPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoFormatPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_FORMAT_PROPERTIES_KHR;
 }
 impl<'a> VideoFormatPropertiesKHR<'a> {
@@ -44258,10 +41153,10 @@ impl ::core::default::Default for VideoProfileInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoProfileInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoProfileInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_PROFILE_INFO_KHR;
 }
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoProfileInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoProfileInfoKHR<'a> {}
 impl<'a> VideoProfileInfoKHR<'a> {
     #[inline]
     pub fn video_codec_operation(
@@ -44288,50 +41183,6 @@ impl<'a> VideoProfileInfoKHR<'a> {
     pub fn chroma_bit_depth(mut self, chroma_bit_depth: VideoComponentBitDepthFlagsKHR) -> Self {
         self.chroma_bit_depth = chroma_bit_depth;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -44374,7 +41225,7 @@ impl ::core::default::Default for VideoCapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoCapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoCapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_CAPABILITIES_KHR;
 }
 impl<'a> VideoCapabilitiesKHR<'a> {
@@ -44429,50 +41280,6 @@ impl<'a> VideoCapabilitiesKHR<'a> {
         self.std_header_version = std_header_version;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -44500,7 +41307,7 @@ impl ::core::default::Default for VideoSessionMemoryRequirementsKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoSessionMemoryRequirementsKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoSessionMemoryRequirementsKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_SESSION_MEMORY_REQUIREMENTS_KHR;
 }
 impl<'a> VideoSessionMemoryRequirementsKHR<'a> {
@@ -44545,7 +41352,7 @@ impl ::core::default::Default for BindVideoSessionMemoryInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindVideoSessionMemoryInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for BindVideoSessionMemoryInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_VIDEO_SESSION_MEMORY_INFO_KHR;
 }
 impl<'a> BindVideoSessionMemoryInfoKHR<'a> {
@@ -44600,7 +41407,7 @@ impl ::core::default::Default for VideoPictureResourceInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoPictureResourceInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoPictureResourceInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_PICTURE_RESOURCE_INFO_KHR;
 }
 impl<'a> VideoPictureResourceInfoKHR<'a> {
@@ -44651,7 +41458,7 @@ impl ::core::default::Default for VideoReferenceSlotInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoReferenceSlotInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoReferenceSlotInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_REFERENCE_SLOT_INFO_KHR;
 }
 impl<'a> VideoReferenceSlotInfoKHR<'a> {
@@ -44667,50 +41474,6 @@ impl<'a> VideoReferenceSlotInfoKHR<'a> {
     ) -> Self {
         self.p_picture_resource = picture_resource;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -44737,10 +41500,10 @@ impl ::core::default::Default for VideoDecodeCapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeCapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeCapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoDecodeCapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoDecodeCapabilitiesKHR<'a> {}
 impl<'a> VideoDecodeCapabilitiesKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoDecodeCapabilityFlagsKHR) -> Self {
@@ -44772,11 +41535,11 @@ impl ::core::default::Default for VideoDecodeUsageInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeUsageInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeUsageInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_USAGE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoDecodeUsageInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoDecodeUsageInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoDecodeUsageInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoDecodeUsageInfoKHR<'a> {}
 impl<'a> VideoDecodeUsageInfoKHR<'a> {
     #[inline]
     pub fn video_usage_hints(mut self, video_usage_hints: VideoDecodeUsageFlagsKHR) -> Self {
@@ -44822,7 +41585,7 @@ impl ::core::default::Default for VideoDecodeInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_INFO_KHR;
 }
 impl<'a> VideoDecodeInfoKHR<'a> {
@@ -44868,50 +41631,6 @@ impl<'a> VideoDecodeInfoKHR<'a> {
         self.p_reference_slots = reference_slots.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -44937,15 +41656,18 @@ impl ::core::default::Default for PhysicalDeviceVideoMaintenance1FeaturesKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVideoMaintenance1FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVideoMaintenance1FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceVideoMaintenance1FeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceVideoMaintenance1FeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceVideoMaintenance1FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceVideoMaintenance1FeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceVideoMaintenance1FeaturesKHR<'a> {
     #[inline]
     pub fn video_maintenance1(mut self, video_maintenance1: bool) -> Self {
@@ -44981,11 +41703,11 @@ impl ::core::default::Default for VideoInlineQueryInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoInlineQueryInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoInlineQueryInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_INLINE_QUERY_INFO_KHR;
 }
-unsafe impl Extends<VideoDecodeInfoKHR<'_>> for VideoInlineQueryInfoKHR<'_> {}
-unsafe impl Extends<VideoEncodeInfoKHR<'_>> for VideoInlineQueryInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoDecodeInfoKHR<'a>> for VideoInlineQueryInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, VideoEncodeInfoKHR<'a>> for VideoInlineQueryInfoKHR<'a> {}
 impl<'a> VideoInlineQueryInfoKHR<'a> {
     #[inline]
     pub fn query_pool(mut self, query_pool: QueryPool) -> Self {
@@ -45029,11 +41751,11 @@ impl ::core::default::Default for VideoDecodeH264ProfileInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH264ProfileInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH264ProfileInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H264_PROFILE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoDecodeH264ProfileInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoDecodeH264ProfileInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoDecodeH264ProfileInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoDecodeH264ProfileInfoKHR<'a> {}
 impl<'a> VideoDecodeH264ProfileInfoKHR<'a> {
     #[inline]
     pub fn std_profile_idc(mut self, std_profile_idc: StdVideoH264ProfileIdc) -> Self {
@@ -45072,10 +41794,10 @@ impl ::core::default::Default for VideoDecodeH264CapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH264CapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH264CapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H264_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoDecodeH264CapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoDecodeH264CapabilitiesKHR<'a> {}
 impl<'a> VideoDecodeH264CapabilitiesKHR<'a> {
     #[inline]
     pub fn max_level_idc(mut self, max_level_idc: StdVideoH264LevelIdc) -> Self {
@@ -45118,12 +41840,12 @@ impl ::core::default::Default for VideoDecodeH264SessionParametersAddInfoKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH264SessionParametersAddInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH264SessionParametersAddInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersUpdateInfoKHR<'_>>
-    for VideoDecodeH264SessionParametersAddInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersUpdateInfoKHR<'a>>
+    for VideoDecodeH264SessionParametersAddInfoKHR<'a>
 {
 }
 impl<'a> VideoDecodeH264SessionParametersAddInfoKHR<'a> {
@@ -45168,12 +41890,12 @@ impl ::core::default::Default for VideoDecodeH264SessionParametersCreateInfoKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH264SessionParametersCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH264SessionParametersCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_DECODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersCreateInfoKHR<'_>>
-    for VideoDecodeH264SessionParametersCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersCreateInfoKHR<'a>>
+    for VideoDecodeH264SessionParametersCreateInfoKHR<'a>
 {
 }
 impl<'a> VideoDecodeH264SessionParametersCreateInfoKHR<'a> {
@@ -45224,10 +41946,10 @@ impl ::core::default::Default for VideoDecodeH264PictureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH264PictureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH264PictureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H264_PICTURE_INFO_KHR;
 }
-unsafe impl Extends<VideoDecodeInfoKHR<'_>> for VideoDecodeH264PictureInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoDecodeInfoKHR<'a>> for VideoDecodeH264PictureInfoKHR<'a> {}
 impl<'a> VideoDecodeH264PictureInfoKHR<'a> {
     #[inline]
     pub fn std_picture_info(mut self, std_picture_info: &'a StdVideoDecodeH264PictureInfo) -> Self {
@@ -45265,10 +41987,10 @@ impl ::core::default::Default for VideoDecodeH264DpbSlotInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH264DpbSlotInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH264DpbSlotInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H264_DPB_SLOT_INFO_KHR;
 }
-unsafe impl Extends<VideoReferenceSlotInfoKHR<'_>> for VideoDecodeH264DpbSlotInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoReferenceSlotInfoKHR<'a>> for VideoDecodeH264DpbSlotInfoKHR<'a> {}
 impl<'a> VideoDecodeH264DpbSlotInfoKHR<'a> {
     #[inline]
     pub fn std_reference_info(
@@ -45303,11 +42025,11 @@ impl ::core::default::Default for VideoDecodeH265ProfileInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH265ProfileInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH265ProfileInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H265_PROFILE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoDecodeH265ProfileInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoDecodeH265ProfileInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoDecodeH265ProfileInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoDecodeH265ProfileInfoKHR<'a> {}
 impl<'a> VideoDecodeH265ProfileInfoKHR<'a> {
     #[inline]
     pub fn std_profile_idc(mut self, std_profile_idc: StdVideoH265ProfileIdc) -> Self {
@@ -45339,10 +42061,10 @@ impl ::core::default::Default for VideoDecodeH265CapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH265CapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH265CapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H265_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoDecodeH265CapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoDecodeH265CapabilitiesKHR<'a> {}
 impl<'a> VideoDecodeH265CapabilitiesKHR<'a> {
     #[inline]
     pub fn max_level_idc(mut self, max_level_idc: StdVideoH265LevelIdc) -> Self {
@@ -45384,12 +42106,12 @@ impl ::core::default::Default for VideoDecodeH265SessionParametersAddInfoKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH265SessionParametersAddInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH265SessionParametersAddInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersUpdateInfoKHR<'_>>
-    for VideoDecodeH265SessionParametersAddInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersUpdateInfoKHR<'a>>
+    for VideoDecodeH265SessionParametersAddInfoKHR<'a>
 {
 }
 impl<'a> VideoDecodeH265SessionParametersAddInfoKHR<'a> {
@@ -45442,12 +42164,12 @@ impl ::core::default::Default for VideoDecodeH265SessionParametersCreateInfoKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH265SessionParametersCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH265SessionParametersCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersCreateInfoKHR<'_>>
-    for VideoDecodeH265SessionParametersCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersCreateInfoKHR<'a>>
+    for VideoDecodeH265SessionParametersCreateInfoKHR<'a>
 {
 }
 impl<'a> VideoDecodeH265SessionParametersCreateInfoKHR<'a> {
@@ -45503,10 +42225,10 @@ impl ::core::default::Default for VideoDecodeH265PictureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH265PictureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH265PictureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H265_PICTURE_INFO_KHR;
 }
-unsafe impl Extends<VideoDecodeInfoKHR<'_>> for VideoDecodeH265PictureInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoDecodeInfoKHR<'a>> for VideoDecodeH265PictureInfoKHR<'a> {}
 impl<'a> VideoDecodeH265PictureInfoKHR<'a> {
     #[inline]
     pub fn std_picture_info(mut self, std_picture_info: &'a StdVideoDecodeH265PictureInfo) -> Self {
@@ -45544,10 +42266,10 @@ impl ::core::default::Default for VideoDecodeH265DpbSlotInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeH265DpbSlotInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeH265DpbSlotInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_H265_DPB_SLOT_INFO_KHR;
 }
-unsafe impl Extends<VideoReferenceSlotInfoKHR<'_>> for VideoDecodeH265DpbSlotInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoReferenceSlotInfoKHR<'a>> for VideoDecodeH265DpbSlotInfoKHR<'a> {}
 impl<'a> VideoDecodeH265DpbSlotInfoKHR<'a> {
     #[inline]
     pub fn std_reference_info(
@@ -45584,11 +42306,11 @@ impl ::core::default::Default for VideoDecodeAV1ProfileInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeAV1ProfileInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeAV1ProfileInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_AV1_PROFILE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoDecodeAV1ProfileInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoDecodeAV1ProfileInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoDecodeAV1ProfileInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoDecodeAV1ProfileInfoKHR<'a> {}
 impl<'a> VideoDecodeAV1ProfileInfoKHR<'a> {
     #[inline]
     pub fn std_profile(mut self, std_profile: StdVideoAV1Profile) -> Self {
@@ -45625,10 +42347,10 @@ impl ::core::default::Default for VideoDecodeAV1CapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeAV1CapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeAV1CapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_AV1_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoDecodeAV1CapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoDecodeAV1CapabilitiesKHR<'a> {}
 impl<'a> VideoDecodeAV1CapabilitiesKHR<'a> {
     #[inline]
     pub fn max_level(mut self, max_level: StdVideoAV1Level) -> Self {
@@ -45660,12 +42382,12 @@ impl ::core::default::Default for VideoDecodeAV1SessionParametersCreateInfoKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeAV1SessionParametersCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeAV1SessionParametersCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_DECODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersCreateInfoKHR<'_>>
-    for VideoDecodeAV1SessionParametersCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersCreateInfoKHR<'a>>
+    for VideoDecodeAV1SessionParametersCreateInfoKHR<'a>
 {
 }
 impl<'a> VideoDecodeAV1SessionParametersCreateInfoKHR<'a> {
@@ -45712,10 +42434,10 @@ impl ::core::default::Default for VideoDecodeAV1PictureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeAV1PictureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeAV1PictureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_AV1_PICTURE_INFO_KHR;
 }
-unsafe impl Extends<VideoDecodeInfoKHR<'_>> for VideoDecodeAV1PictureInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoDecodeInfoKHR<'a>> for VideoDecodeAV1PictureInfoKHR<'a> {}
 impl<'a> VideoDecodeAV1PictureInfoKHR<'a> {
     #[inline]
     pub fn std_picture_info(mut self, std_picture_info: &'a StdVideoDecodeAV1PictureInfo) -> Self {
@@ -45772,10 +42494,10 @@ impl ::core::default::Default for VideoDecodeAV1DpbSlotInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoDecodeAV1DpbSlotInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoDecodeAV1DpbSlotInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_DECODE_AV1_DPB_SLOT_INFO_KHR;
 }
-unsafe impl Extends<VideoReferenceSlotInfoKHR<'_>> for VideoDecodeAV1DpbSlotInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoReferenceSlotInfoKHR<'a>> for VideoDecodeAV1DpbSlotInfoKHR<'a> {}
 impl<'a> VideoDecodeAV1DpbSlotInfoKHR<'a> {
     #[inline]
     pub fn std_reference_info(
@@ -45826,7 +42548,7 @@ impl ::core::default::Default for VideoSessionCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoSessionCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoSessionCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_SESSION_CREATE_INFO_KHR;
 }
 impl<'a> VideoSessionCreateInfoKHR<'a> {
@@ -45875,50 +42597,6 @@ impl<'a> VideoSessionCreateInfoKHR<'a> {
         self.p_std_header_version = std_header_version;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -45948,7 +42626,7 @@ impl ::core::default::Default for VideoSessionParametersCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoSessionParametersCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoSessionParametersCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR;
 }
 impl<'a> VideoSessionParametersCreateInfoKHR<'a> {
@@ -45969,50 +42647,6 @@ impl<'a> VideoSessionParametersCreateInfoKHR<'a> {
     pub fn video_session(mut self, video_session: VideoSessionKHR) -> Self {
         self.video_session = video_session;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -46039,7 +42673,7 @@ impl ::core::default::Default for VideoSessionParametersUpdateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoSessionParametersUpdateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoSessionParametersUpdateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_SESSION_PARAMETERS_UPDATE_INFO_KHR;
 }
 impl<'a> VideoSessionParametersUpdateInfoKHR<'a> {
@@ -46047,50 +42681,6 @@ impl<'a> VideoSessionParametersUpdateInfoKHR<'a> {
     pub fn update_sequence_count(mut self, update_sequence_count: u32) -> Self {
         self.update_sequence_count = update_sequence_count;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -46117,7 +42707,7 @@ impl ::core::default::Default for VideoEncodeSessionParametersGetInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeSessionParametersGetInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeSessionParametersGetInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_SESSION_PARAMETERS_GET_INFO_KHR;
 }
@@ -46129,50 +42719,6 @@ impl<'a> VideoEncodeSessionParametersGetInfoKHR<'a> {
     ) -> Self {
         self.video_session_parameters = video_session_parameters;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -46199,7 +42745,7 @@ impl ::core::default::Default for VideoEncodeSessionParametersFeedbackInfoKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeSessionParametersFeedbackInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeSessionParametersFeedbackInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR;
 }
@@ -46208,50 +42754,6 @@ impl<'a> VideoEncodeSessionParametersFeedbackInfoKHR<'a> {
     pub fn has_overrides(mut self, has_overrides: bool) -> Self {
         self.has_overrides = has_overrides.into();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -46286,7 +42788,7 @@ impl ::core::default::Default for VideoBeginCodingInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoBeginCodingInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoBeginCodingInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_BEGIN_CODING_INFO_KHR;
 }
 impl<'a> VideoBeginCodingInfoKHR<'a> {
@@ -46314,50 +42816,6 @@ impl<'a> VideoBeginCodingInfoKHR<'a> {
         self.p_reference_slots = reference_slots.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -46383,7 +42841,7 @@ impl ::core::default::Default for VideoEndCodingInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEndCodingInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEndCodingInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_END_CODING_INFO_KHR;
 }
 impl<'a> VideoEndCodingInfoKHR<'a> {
@@ -46417,7 +42875,7 @@ impl ::core::default::Default for VideoCodingControlInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoCodingControlInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoCodingControlInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_CODING_CONTROL_INFO_KHR;
 }
 impl<'a> VideoCodingControlInfoKHR<'a> {
@@ -46425,50 +42883,6 @@ impl<'a> VideoCodingControlInfoKHR<'a> {
     pub fn flags(mut self, flags: VideoCodingControlFlagsKHR) -> Self {
         self.flags = flags;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -46499,11 +42913,11 @@ impl ::core::default::Default for VideoEncodeUsageInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeUsageInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeUsageInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_USAGE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoEncodeUsageInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoEncodeUsageInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoEncodeUsageInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoEncodeUsageInfoKHR<'a> {}
 impl<'a> VideoEncodeUsageInfoKHR<'a> {
     #[inline]
     pub fn video_usage_hints(mut self, video_usage_hints: VideoEncodeUsageFlagsKHR) -> Self {
@@ -46561,7 +42975,7 @@ impl ::core::default::Default for VideoEncodeInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_INFO_KHR;
 }
 impl<'a> VideoEncodeInfoKHR<'a> {
@@ -46615,50 +43029,6 @@ impl<'a> VideoEncodeInfoKHR<'a> {
         self.preceding_externally_encoded_bytes = preceding_externally_encoded_bytes;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -46684,11 +43054,14 @@ impl ::core::default::Default for QueryPoolVideoEncodeFeedbackCreateInfoKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueryPoolVideoEncodeFeedbackCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for QueryPoolVideoEncodeFeedbackCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR;
 }
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for QueryPoolVideoEncodeFeedbackCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>>
+    for QueryPoolVideoEncodeFeedbackCreateInfoKHR<'a>
+{
+}
 impl<'a> QueryPoolVideoEncodeFeedbackCreateInfoKHR<'a> {
     #[inline]
     pub fn encode_feedback_flags(
@@ -46723,12 +43096,12 @@ impl ::core::default::Default for VideoEncodeQualityLevelInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeQualityLevelInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeQualityLevelInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR;
 }
-unsafe impl Extends<VideoCodingControlInfoKHR<'_>> for VideoEncodeQualityLevelInfoKHR<'_> {}
-unsafe impl Extends<VideoSessionParametersCreateInfoKHR<'_>>
-    for VideoEncodeQualityLevelInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoCodingControlInfoKHR<'a>> for VideoEncodeQualityLevelInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, VideoSessionParametersCreateInfoKHR<'a>>
+    for VideoEncodeQualityLevelInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeQualityLevelInfoKHR<'a> {
@@ -46764,7 +43137,7 @@ impl ::core::default::Default for PhysicalDeviceVideoEncodeQualityLevelInfoKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceVideoEncodeQualityLevelInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceVideoEncodeQualityLevelInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR;
 }
@@ -46806,7 +43179,7 @@ impl ::core::default::Default for VideoEncodeQualityLevelPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeQualityLevelPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeQualityLevelPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR;
 }
 impl<'a> VideoEncodeQualityLevelPropertiesKHR<'a> {
@@ -46825,50 +43198,6 @@ impl<'a> VideoEncodeQualityLevelPropertiesKHR<'a> {
     ) -> Self {
         self.preferred_rate_control_layer_count = preferred_rate_control_layer_count;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -46905,11 +43234,11 @@ impl ::core::default::Default for VideoEncodeRateControlInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeRateControlInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeRateControlInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_RATE_CONTROL_INFO_KHR;
 }
-unsafe impl Extends<VideoCodingControlInfoKHR<'_>> for VideoEncodeRateControlInfoKHR<'_> {}
-unsafe impl Extends<VideoBeginCodingInfoKHR<'_>> for VideoEncodeRateControlInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCodingControlInfoKHR<'a>> for VideoEncodeRateControlInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, VideoBeginCodingInfoKHR<'a>> for VideoEncodeRateControlInfoKHR<'a> {}
 impl<'a> VideoEncodeRateControlInfoKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoEncodeRateControlFlagsKHR) -> Self {
@@ -46974,7 +43303,7 @@ impl ::core::default::Default for VideoEncodeRateControlLayerInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeRateControlLayerInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeRateControlLayerInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR;
 }
 impl<'a> VideoEncodeRateControlLayerInfoKHR<'a> {
@@ -46997,50 +43326,6 @@ impl<'a> VideoEncodeRateControlLayerInfoKHR<'a> {
     pub fn frame_rate_denominator(mut self, frame_rate_denominator: u32) -> Self {
         self.frame_rate_denominator = frame_rate_denominator;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -47079,10 +43364,10 @@ impl ::core::default::Default for VideoEncodeCapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeCapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeCapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoEncodeCapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoEncodeCapabilitiesKHR<'a> {}
 impl<'a> VideoEncodeCapabilitiesKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoEncodeCapabilityFlagsKHR) -> Self {
@@ -47177,10 +43462,10 @@ impl ::core::default::Default for VideoEncodeH264CapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264CapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264CapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoEncodeH264CapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoEncodeH264CapabilitiesKHR<'a> {}
 impl<'a> VideoEncodeH264CapabilitiesKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoEncodeH264CapabilityFlagsKHR) -> Self {
@@ -47297,12 +43582,12 @@ impl ::core::default::Default for VideoEncodeH264QualityLevelPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264QualityLevelPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264QualityLevelPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_KHR;
 }
-unsafe impl Extends<VideoEncodeQualityLevelPropertiesKHR<'_>>
-    for VideoEncodeH264QualityLevelPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeQualityLevelPropertiesKHR<'a>>
+    for VideoEncodeH264QualityLevelPropertiesKHR<'a>
 {
 }
 impl<'a> VideoEncodeH264QualityLevelPropertiesKHR<'a> {
@@ -47393,10 +43678,13 @@ impl ::core::default::Default for VideoEncodeH264SessionCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264SessionCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264SessionCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_SESSION_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionCreateInfoKHR<'_>> for VideoEncodeH264SessionCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoSessionCreateInfoKHR<'a>>
+    for VideoEncodeH264SessionCreateInfoKHR<'a>
+{
+}
 impl<'a> VideoEncodeH264SessionCreateInfoKHR<'a> {
     #[inline]
     pub fn use_max_level_idc(mut self, use_max_level_idc: bool) -> Self {
@@ -47439,12 +43727,12 @@ impl ::core::default::Default for VideoEncodeH264SessionParametersAddInfoKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264SessionParametersAddInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264SessionParametersAddInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersUpdateInfoKHR<'_>>
-    for VideoEncodeH264SessionParametersAddInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersUpdateInfoKHR<'a>>
+    for VideoEncodeH264SessionParametersAddInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH264SessionParametersAddInfoKHR<'a> {
@@ -47489,12 +43777,12 @@ impl ::core::default::Default for VideoEncodeH264SessionParametersCreateInfoKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264SessionParametersCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264SessionParametersCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersCreateInfoKHR<'_>>
-    for VideoEncodeH264SessionParametersCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersCreateInfoKHR<'a>>
+    for VideoEncodeH264SessionParametersCreateInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH264SessionParametersCreateInfoKHR<'a> {
@@ -47547,12 +43835,12 @@ impl ::core::default::Default for VideoEncodeH264SessionParametersGetInfoKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264SessionParametersGetInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264SessionParametersGetInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeSessionParametersGetInfoKHR<'_>>
-    for VideoEncodeH264SessionParametersGetInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeSessionParametersGetInfoKHR<'a>>
+    for VideoEncodeH264SessionParametersGetInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH264SessionParametersGetInfoKHR<'a> {
@@ -47603,12 +43891,12 @@ impl ::core::default::Default for VideoEncodeH264SessionParametersFeedbackInfoKH
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264SessionParametersFeedbackInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264SessionParametersFeedbackInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeSessionParametersFeedbackInfoKHR<'_>>
-    for VideoEncodeH264SessionParametersFeedbackInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeSessionParametersFeedbackInfoKHR<'a>>
+    for VideoEncodeH264SessionParametersFeedbackInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH264SessionParametersFeedbackInfoKHR<'a> {
@@ -47647,10 +43935,10 @@ impl ::core::default::Default for VideoEncodeH264DpbSlotInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264DpbSlotInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264DpbSlotInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR;
 }
-unsafe impl Extends<VideoReferenceSlotInfoKHR<'_>> for VideoEncodeH264DpbSlotInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoReferenceSlotInfoKHR<'a>> for VideoEncodeH264DpbSlotInfoKHR<'a> {}
 impl<'a> VideoEncodeH264DpbSlotInfoKHR<'a> {
     #[inline]
     pub fn std_reference_info(
@@ -47691,10 +43979,10 @@ impl ::core::default::Default for VideoEncodeH264PictureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264PictureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264PictureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_PICTURE_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeInfoKHR<'_>> for VideoEncodeH264PictureInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoEncodeInfoKHR<'a>> for VideoEncodeH264PictureInfoKHR<'a> {}
 impl<'a> VideoEncodeH264PictureInfoKHR<'a> {
     #[inline]
     pub fn nalu_slice_entries(
@@ -47740,11 +44028,11 @@ impl ::core::default::Default for VideoEncodeH264ProfileInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264ProfileInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264ProfileInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_PROFILE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoEncodeH264ProfileInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoEncodeH264ProfileInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoEncodeH264ProfileInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoEncodeH264ProfileInfoKHR<'a> {}
 impl<'a> VideoEncodeH264ProfileInfoKHR<'a> {
     #[inline]
     pub fn std_profile_idc(mut self, std_profile_idc: StdVideoH264ProfileIdc) -> Self {
@@ -47778,7 +44066,7 @@ impl ::core::default::Default for VideoEncodeH264NaluSliceInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264NaluSliceInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264NaluSliceInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR;
 }
 impl<'a> VideoEncodeH264NaluSliceInfoKHR<'a> {
@@ -47825,11 +44113,14 @@ impl ::core::default::Default for VideoEncodeH264RateControlInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264RateControlInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264RateControlInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR;
 }
-unsafe impl Extends<VideoCodingControlInfoKHR<'_>> for VideoEncodeH264RateControlInfoKHR<'_> {}
-unsafe impl Extends<VideoBeginCodingInfoKHR<'_>> for VideoEncodeH264RateControlInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCodingControlInfoKHR<'a>>
+    for VideoEncodeH264RateControlInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, VideoBeginCodingInfoKHR<'a>> for VideoEncodeH264RateControlInfoKHR<'a> {}
 impl<'a> VideoEncodeH264RateControlInfoKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoEncodeH264RateControlFlagsKHR) -> Self {
@@ -47941,11 +44232,14 @@ impl ::core::default::Default for VideoEncodeH264GopRemainingFrameInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264GopRemainingFrameInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264GopRemainingFrameInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_KHR;
 }
-unsafe impl Extends<VideoBeginCodingInfoKHR<'_>> for VideoEncodeH264GopRemainingFrameInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoBeginCodingInfoKHR<'a>>
+    for VideoEncodeH264GopRemainingFrameInfoKHR<'a>
+{
+}
 impl<'a> VideoEncodeH264GopRemainingFrameInfoKHR<'a> {
     #[inline]
     pub fn use_gop_remaining_frames(mut self, use_gop_remaining_frames: bool) -> Self {
@@ -48002,12 +44296,12 @@ impl ::core::default::Default for VideoEncodeH264RateControlLayerInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH264RateControlLayerInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH264RateControlLayerInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeRateControlLayerInfoKHR<'_>>
-    for VideoEncodeH264RateControlLayerInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeRateControlLayerInfoKHR<'a>>
+    for VideoEncodeH264RateControlLayerInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH264RateControlLayerInfoKHR<'a> {
@@ -48096,10 +44390,10 @@ impl ::core::default::Default for VideoEncodeH265CapabilitiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265CapabilitiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265CapabilitiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H265_CAPABILITIES_KHR;
 }
-unsafe impl Extends<VideoCapabilitiesKHR<'_>> for VideoEncodeH265CapabilitiesKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCapabilitiesKHR<'a>> for VideoEncodeH265CapabilitiesKHR<'a> {}
 impl<'a> VideoEncodeH265CapabilitiesKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoEncodeH265CapabilityFlagsKHR) -> Self {
@@ -48233,12 +44527,12 @@ impl ::core::default::Default for VideoEncodeH265QualityLevelPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265QualityLevelPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265QualityLevelPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_KHR;
 }
-unsafe impl Extends<VideoEncodeQualityLevelPropertiesKHR<'_>>
-    for VideoEncodeH265QualityLevelPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeQualityLevelPropertiesKHR<'a>>
+    for VideoEncodeH265QualityLevelPropertiesKHR<'a>
 {
 }
 impl<'a> VideoEncodeH265QualityLevelPropertiesKHR<'a> {
@@ -48321,10 +44615,13 @@ impl ::core::default::Default for VideoEncodeH265SessionCreateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265SessionCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265SessionCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H265_SESSION_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionCreateInfoKHR<'_>> for VideoEncodeH265SessionCreateInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoSessionCreateInfoKHR<'a>>
+    for VideoEncodeH265SessionCreateInfoKHR<'a>
+{
+}
 impl<'a> VideoEncodeH265SessionCreateInfoKHR<'a> {
     #[inline]
     pub fn use_max_level_idc(mut self, use_max_level_idc: bool) -> Self {
@@ -48371,12 +44668,12 @@ impl ::core::default::Default for VideoEncodeH265SessionParametersAddInfoKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265SessionParametersAddInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265SessionParametersAddInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersUpdateInfoKHR<'_>>
-    for VideoEncodeH265SessionParametersAddInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersUpdateInfoKHR<'a>>
+    for VideoEncodeH265SessionParametersAddInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH265SessionParametersAddInfoKHR<'a> {
@@ -48429,12 +44726,12 @@ impl ::core::default::Default for VideoEncodeH265SessionParametersCreateInfoKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265SessionParametersCreateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265SessionParametersCreateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR;
 }
-unsafe impl Extends<VideoSessionParametersCreateInfoKHR<'_>>
-    for VideoEncodeH265SessionParametersCreateInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoSessionParametersCreateInfoKHR<'a>>
+    for VideoEncodeH265SessionParametersCreateInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH265SessionParametersCreateInfoKHR<'a> {
@@ -48496,12 +44793,12 @@ impl ::core::default::Default for VideoEncodeH265SessionParametersGetInfoKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265SessionParametersGetInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265SessionParametersGetInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeSessionParametersGetInfoKHR<'_>>
-    for VideoEncodeH265SessionParametersGetInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeSessionParametersGetInfoKHR<'a>>
+    for VideoEncodeH265SessionParametersGetInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH265SessionParametersGetInfoKHR<'a> {
@@ -48564,12 +44861,12 @@ impl ::core::default::Default for VideoEncodeH265SessionParametersFeedbackInfoKH
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265SessionParametersFeedbackInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265SessionParametersFeedbackInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeSessionParametersFeedbackInfoKHR<'_>>
-    for VideoEncodeH265SessionParametersFeedbackInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeSessionParametersFeedbackInfoKHR<'a>>
+    for VideoEncodeH265SessionParametersFeedbackInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH265SessionParametersFeedbackInfoKHR<'a> {
@@ -48617,10 +44914,10 @@ impl ::core::default::Default for VideoEncodeH265PictureInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265PictureInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265PictureInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H265_PICTURE_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeInfoKHR<'_>> for VideoEncodeH265PictureInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoEncodeInfoKHR<'a>> for VideoEncodeH265PictureInfoKHR<'a> {}
 impl<'a> VideoEncodeH265PictureInfoKHR<'a> {
     #[inline]
     pub fn nalu_slice_segment_entries(
@@ -48663,7 +44960,7 @@ impl ::core::default::Default for VideoEncodeH265NaluSliceSegmentInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265NaluSliceSegmentInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265NaluSliceSegmentInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR;
 }
@@ -48714,11 +45011,14 @@ impl ::core::default::Default for VideoEncodeH265RateControlInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265RateControlInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265RateControlInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H265_RATE_CONTROL_INFO_KHR;
 }
-unsafe impl Extends<VideoCodingControlInfoKHR<'_>> for VideoEncodeH265RateControlInfoKHR<'_> {}
-unsafe impl Extends<VideoBeginCodingInfoKHR<'_>> for VideoEncodeH265RateControlInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoCodingControlInfoKHR<'a>>
+    for VideoEncodeH265RateControlInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, VideoBeginCodingInfoKHR<'a>> for VideoEncodeH265RateControlInfoKHR<'a> {}
 impl<'a> VideoEncodeH265RateControlInfoKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoEncodeH265RateControlFlagsKHR) -> Self {
@@ -48830,11 +45130,14 @@ impl ::core::default::Default for VideoEncodeH265GopRemainingFrameInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265GopRemainingFrameInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265GopRemainingFrameInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_KHR;
 }
-unsafe impl Extends<VideoBeginCodingInfoKHR<'_>> for VideoEncodeH265GopRemainingFrameInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoBeginCodingInfoKHR<'a>>
+    for VideoEncodeH265GopRemainingFrameInfoKHR<'a>
+{
+}
 impl<'a> VideoEncodeH265GopRemainingFrameInfoKHR<'a> {
     #[inline]
     pub fn use_gop_remaining_frames(mut self, use_gop_remaining_frames: bool) -> Self {
@@ -48891,12 +45194,12 @@ impl ::core::default::Default for VideoEncodeH265RateControlLayerInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265RateControlLayerInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265RateControlLayerInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_KHR;
 }
-unsafe impl Extends<VideoEncodeRateControlLayerInfoKHR<'_>>
-    for VideoEncodeH265RateControlLayerInfoKHR<'_>
+unsafe impl<'a> Extends<'a, VideoEncodeRateControlLayerInfoKHR<'a>>
+    for VideoEncodeH265RateControlLayerInfoKHR<'a>
 {
 }
 impl<'a> VideoEncodeH265RateControlLayerInfoKHR<'a> {
@@ -48955,11 +45258,11 @@ impl ::core::default::Default for VideoEncodeH265ProfileInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265ProfileInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265ProfileInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H265_PROFILE_INFO_KHR;
 }
-unsafe impl Extends<VideoProfileInfoKHR<'_>> for VideoEncodeH265ProfileInfoKHR<'_> {}
-unsafe impl Extends<QueryPoolCreateInfo<'_>> for VideoEncodeH265ProfileInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoProfileInfoKHR<'a>> for VideoEncodeH265ProfileInfoKHR<'a> {}
+unsafe impl<'a> Extends<'a, QueryPoolCreateInfo<'a>> for VideoEncodeH265ProfileInfoKHR<'a> {}
 impl<'a> VideoEncodeH265ProfileInfoKHR<'a> {
     #[inline]
     pub fn std_profile_idc(mut self, std_profile_idc: StdVideoH265ProfileIdc) -> Self {
@@ -48991,10 +45294,10 @@ impl ::core::default::Default for VideoEncodeH265DpbSlotInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for VideoEncodeH265DpbSlotInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for VideoEncodeH265DpbSlotInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::VIDEO_ENCODE_H265_DPB_SLOT_INFO_KHR;
 }
-unsafe impl Extends<VideoReferenceSlotInfoKHR<'_>> for VideoEncodeH265DpbSlotInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, VideoReferenceSlotInfoKHR<'a>> for VideoEncodeH265DpbSlotInfoKHR<'a> {}
 impl<'a> VideoEncodeH265DpbSlotInfoKHR<'a> {
     #[inline]
     pub fn std_reference_info(
@@ -49029,15 +45332,18 @@ impl ::core::default::Default for PhysicalDeviceInheritedViewportScissorFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceInheritedViewportScissorFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceInheritedViewportScissorFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceInheritedViewportScissorFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceInheritedViewportScissorFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceInheritedViewportScissorFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceInheritedViewportScissorFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceInheritedViewportScissorFeaturesNV<'a> {
     #[inline]
     pub fn inherited_viewport_scissor2_d(mut self, inherited_viewport_scissor2_d: bool) -> Self {
@@ -49073,12 +45379,12 @@ impl ::core::default::Default for CommandBufferInheritanceViewportScissorInfoNV<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferInheritanceViewportScissorInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferInheritanceViewportScissorInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV;
 }
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>>
-    for CommandBufferInheritanceViewportScissorInfoNV<'_>
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for CommandBufferInheritanceViewportScissorInfoNV<'a>
 {
 }
 impl<'a> CommandBufferInheritanceViewportScissorInfoNV<'a> {
@@ -49122,15 +45428,18 @@ impl ::core::default::Default for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT<'a> {
     #[inline]
     pub fn ycbcr2plane444_formats(mut self, ycbcr2plane444_formats: bool) -> Self {
@@ -49164,12 +45473,15 @@ impl ::core::default::Default for PhysicalDeviceProvokingVertexFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceProvokingVertexFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceProvokingVertexFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceProvokingVertexFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceProvokingVertexFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceProvokingVertexFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceProvokingVertexFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceProvokingVertexFeaturesEXT<'a> {
     #[inline]
     pub fn provoking_vertex_last(mut self, provoking_vertex_last: bool) -> Self {
@@ -49212,12 +45524,12 @@ impl ::core::default::Default for PhysicalDeviceProvokingVertexPropertiesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceProvokingVertexPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceProvokingVertexPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceProvokingVertexPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceProvokingVertexPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceProvokingVertexPropertiesEXT<'a> {
@@ -49263,12 +45575,12 @@ impl ::core::default::Default for PipelineRasterizationProvokingVertexStateCreat
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRasterizationProvokingVertexStateCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRasterizationProvokingVertexStateCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for PipelineRasterizationProvokingVertexStateCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for PipelineRasterizationProvokingVertexStateCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineRasterizationProvokingVertexStateCreateInfoEXT<'a> {
@@ -49304,7 +45616,7 @@ impl ::core::default::Default for CuModuleCreateInfoNVX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CuModuleCreateInfoNVX<'a> {
+unsafe impl TaggedStructure<'_> for CuModuleCreateInfoNVX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CU_MODULE_CREATE_INFO_NVX;
 }
 impl<'a> CuModuleCreateInfoNVX<'a> {
@@ -49341,7 +45653,7 @@ impl ::core::default::Default for CuFunctionCreateInfoNVX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CuFunctionCreateInfoNVX<'a> {
+unsafe impl TaggedStructure<'_> for CuFunctionCreateInfoNVX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CU_FUNCTION_CREATE_INFO_NVX;
 }
 impl<'a> CuFunctionCreateInfoNVX<'a> {
@@ -49410,7 +45722,7 @@ impl ::core::default::Default for CuLaunchInfoNVX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CuLaunchInfoNVX<'a> {
+unsafe impl TaggedStructure<'_> for CuLaunchInfoNVX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CU_LAUNCH_INFO_NVX;
 }
 impl<'a> CuLaunchInfoNVX<'a> {
@@ -49497,12 +45809,18 @@ impl ::core::default::Default for PhysicalDeviceDescriptorBufferFeaturesEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorBufferFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorBufferFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDescriptorBufferFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDescriptorBufferFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDescriptorBufferFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDescriptorBufferFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDescriptorBufferFeaturesEXT<'a> {
     #[inline]
     pub fn descriptor_buffer(mut self, descriptor_buffer: bool) -> Self {
@@ -49622,12 +45940,12 @@ impl ::core::default::Default for PhysicalDeviceDescriptorBufferPropertiesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorBufferPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorBufferPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDescriptorBufferPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDescriptorBufferPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceDescriptorBufferPropertiesEXT<'a> {
@@ -49906,12 +46224,12 @@ impl ::core::default::Default for PhysicalDeviceDescriptorBufferDensityMapProper
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorBufferDensityMapPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorBufferDensityMapPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_DENSITY_MAP_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDescriptorBufferDensityMapPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDescriptorBufferDensityMapPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceDescriptorBufferDensityMapPropertiesEXT<'a> {
@@ -49953,7 +46271,7 @@ impl ::core::default::Default for DescriptorAddressInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorAddressInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorAddressInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_ADDRESS_INFO_EXT;
 }
 impl<'a> DescriptorAddressInfoEXT<'a> {
@@ -49999,7 +46317,7 @@ impl ::core::default::Default for DescriptorBufferBindingInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorBufferBindingInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorBufferBindingInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_BUFFER_BINDING_INFO_EXT;
 }
 impl<'a> DescriptorBufferBindingInfoEXT<'a> {
@@ -50012,50 +46330,6 @@ impl<'a> DescriptorBufferBindingInfoEXT<'a> {
     pub fn usage(mut self, usage: BufferUsageFlags) -> Self {
         self.usage = usage;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -50082,12 +46356,12 @@ impl ::core::default::Default for DescriptorBufferBindingPushDescriptorBufferHan
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorBufferBindingPushDescriptorBufferHandleEXT<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorBufferBindingPushDescriptorBufferHandleEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DESCRIPTOR_BUFFER_BINDING_PUSH_DESCRIPTOR_BUFFER_HANDLE_EXT;
 }
-unsafe impl Extends<DescriptorBufferBindingInfoEXT<'_>>
-    for DescriptorBufferBindingPushDescriptorBufferHandleEXT<'_>
+unsafe impl<'a> Extends<'a, DescriptorBufferBindingInfoEXT<'a>>
+    for DescriptorBufferBindingPushDescriptorBufferHandleEXT<'a>
 {
 }
 impl<'a> DescriptorBufferBindingPushDescriptorBufferHandleEXT<'a> {
@@ -50154,7 +46428,7 @@ impl ::core::default::Default for DescriptorGetInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorGetInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorGetInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_GET_INFO_EXT;
 }
 impl<'a> DescriptorGetInfoEXT<'a> {
@@ -50193,7 +46467,7 @@ impl ::core::default::Default for BufferCaptureDescriptorDataInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCaptureDescriptorDataInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for BufferCaptureDescriptorDataInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT;
 }
 impl<'a> BufferCaptureDescriptorDataInfoEXT<'a> {
@@ -50227,7 +46501,7 @@ impl ::core::default::Default for ImageCaptureDescriptorDataInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageCaptureDescriptorDataInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageCaptureDescriptorDataInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT;
 }
 impl<'a> ImageCaptureDescriptorDataInfoEXT<'a> {
@@ -50261,7 +46535,7 @@ impl ::core::default::Default for ImageViewCaptureDescriptorDataInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewCaptureDescriptorDataInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewCaptureDescriptorDataInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::IMAGE_VIEW_CAPTURE_DESCRIPTOR_DATA_INFO_EXT;
 }
@@ -50296,7 +46570,7 @@ impl ::core::default::Default for SamplerCaptureDescriptorDataInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerCaptureDescriptorDataInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SamplerCaptureDescriptorDataInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT;
 }
 impl<'a> SamplerCaptureDescriptorDataInfoEXT<'a> {
@@ -50332,7 +46606,7 @@ impl ::core::default::Default for AccelerationStructureCaptureDescriptorDataInfo
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureCaptureDescriptorDataInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureCaptureDescriptorDataInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT;
 }
@@ -50378,20 +46652,26 @@ impl ::core::default::Default for OpaqueCaptureDescriptorDataCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OpaqueCaptureDescriptorDataCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for OpaqueCaptureDescriptorDataCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT;
 }
-unsafe impl Extends<BufferCreateInfo<'_>> for OpaqueCaptureDescriptorDataCreateInfoEXT<'_> {}
-unsafe impl Extends<ImageCreateInfo<'_>> for OpaqueCaptureDescriptorDataCreateInfoEXT<'_> {}
-unsafe impl Extends<ImageViewCreateInfo<'_>> for OpaqueCaptureDescriptorDataCreateInfoEXT<'_> {}
-unsafe impl Extends<SamplerCreateInfo<'_>> for OpaqueCaptureDescriptorDataCreateInfoEXT<'_> {}
-unsafe impl Extends<AccelerationStructureCreateInfoKHR<'_>>
-    for OpaqueCaptureDescriptorDataCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for OpaqueCaptureDescriptorDataCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for OpaqueCaptureDescriptorDataCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>>
+    for OpaqueCaptureDescriptorDataCreateInfoEXT<'a>
 {
 }
-unsafe impl Extends<AccelerationStructureCreateInfoNV<'_>>
-    for OpaqueCaptureDescriptorDataCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>>
+    for OpaqueCaptureDescriptorDataCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, AccelerationStructureCreateInfoKHR<'a>>
+    for OpaqueCaptureDescriptorDataCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, AccelerationStructureCreateInfoNV<'a>>
+    for OpaqueCaptureDescriptorDataCreateInfoEXT<'a>
 {
 }
 impl<'a> OpaqueCaptureDescriptorDataCreateInfoEXT<'a> {
@@ -50428,15 +46708,18 @@ impl ::core::default::Default for PhysicalDeviceShaderIntegerDotProductFeatures<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderIntegerDotProductFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderIntegerDotProductFeatures<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderIntegerDotProductFeatures<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderIntegerDotProductFeatures<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderIntegerDotProductFeatures<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderIntegerDotProductFeatures<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderIntegerDotProductFeatures<'a> {
     #[inline]
     pub fn shader_integer_dot_product(mut self, shader_integer_dot_product: bool) -> Self {
@@ -50493,12 +46776,12 @@ impl ::core::default::Default for PhysicalDeviceShaderIntegerDotProductPropertie
         Self { s_type : Self :: STRUCTURE_TYPE , p_next : :: core :: ptr :: null_mut () , integer_dot_product8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product64_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated : Bool32 :: default () , _marker : PhantomData , }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderIntegerDotProductProperties<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderIntegerDotProductProperties<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShaderIntegerDotProductProperties<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderIntegerDotProductProperties<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderIntegerDotProductProperties<'a> {
@@ -50806,10 +47089,10 @@ impl ::core::default::Default for PhysicalDeviceDrmPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDrmPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDrmPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_DRM_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceDrmPropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>> for PhysicalDeviceDrmPropertiesEXT<'a> {}
 impl<'a> PhysicalDeviceDrmPropertiesEXT<'a> {
     #[inline]
     pub fn has_primary(mut self, has_primary: bool) -> Self {
@@ -50866,16 +47149,16 @@ impl ::core::default::Default for PhysicalDeviceFragmentShaderBarycentricFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentShaderBarycentricFeaturesKHR<'a> {
@@ -50909,12 +47192,12 @@ impl ::core::default::Default for PhysicalDeviceFragmentShaderBarycentricPropert
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFragmentShaderBarycentricPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFragmentShaderBarycentricPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceFragmentShaderBarycentricPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceFragmentShaderBarycentricPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceFragmentShaderBarycentricPropertiesKHR<'a> {
@@ -50954,15 +47237,18 @@ impl ::core::default::Default for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRayTracingMotionBlurFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceRayTracingMotionBlurFeaturesNV<'a> {
     #[inline]
     pub fn ray_tracing_motion_blur(mut self, ray_tracing_motion_blur: bool) -> Self {
@@ -51003,15 +47289,18 @@ impl ::core::default::Default for PhysicalDeviceRayTracingValidationFeaturesNV<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingValidationFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingValidationFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRayTracingValidationFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRayTracingValidationFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRayTracingValidationFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRayTracingValidationFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceRayTracingValidationFeaturesNV<'a> {
     #[inline]
     pub fn ray_tracing_validation(mut self, ray_tracing_validation: bool) -> Self {
@@ -51052,12 +47341,12 @@ impl ::core::default::Default for AccelerationStructureGeometryMotionTrianglesDa
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureGeometryMotionTrianglesDataNV<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureGeometryMotionTrianglesDataNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_GEOMETRY_MOTION_TRIANGLES_DATA_NV;
 }
-unsafe impl Extends<AccelerationStructureGeometryTrianglesDataKHR<'_>>
-    for AccelerationStructureGeometryMotionTrianglesDataNV<'_>
+unsafe impl<'a> Extends<'a, AccelerationStructureGeometryTrianglesDataKHR<'a>>
+    for AccelerationStructureGeometryMotionTrianglesDataNV<'a>
 {
 }
 impl<'a> AccelerationStructureGeometryMotionTrianglesDataNV<'a> {
@@ -51093,11 +47382,11 @@ impl ::core::default::Default for AccelerationStructureMotionInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureMotionInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureMotionInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ACCELERATION_STRUCTURE_MOTION_INFO_NV;
 }
-unsafe impl Extends<AccelerationStructureCreateInfoKHR<'_>>
-    for AccelerationStructureMotionInfoNV<'_>
+unsafe impl<'a> Extends<'a, AccelerationStructureCreateInfoKHR<'a>>
+    for AccelerationStructureMotionInfoNV<'a>
 {
 }
 impl<'a> AccelerationStructureMotionInfoNV<'a> {
@@ -51319,7 +47608,7 @@ impl ::core::default::Default for MemoryGetRemoteAddressInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryGetRemoteAddressInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for MemoryGetRemoteAddressInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_GET_REMOTE_ADDRESS_INFO_NV;
 }
 impl<'a> MemoryGetRemoteAddressInfoNV<'a> {
@@ -51360,10 +47649,10 @@ impl ::core::default::Default for ImportMemoryBufferCollectionFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMemoryBufferCollectionFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for ImportMemoryBufferCollectionFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_MEMORY_BUFFER_COLLECTION_FUCHSIA;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMemoryBufferCollectionFUCHSIA<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMemoryBufferCollectionFUCHSIA<'a> {}
 impl<'a> ImportMemoryBufferCollectionFUCHSIA<'a> {
     #[inline]
     pub fn collection(mut self, collection: BufferCollectionFUCHSIA) -> Self {
@@ -51402,11 +47691,11 @@ impl ::core::default::Default for BufferCollectionImageCreateInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCollectionImageCreateInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for BufferCollectionImageCreateInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::BUFFER_COLLECTION_IMAGE_CREATE_INFO_FUCHSIA;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for BufferCollectionImageCreateInfoFUCHSIA<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for BufferCollectionImageCreateInfoFUCHSIA<'a> {}
 impl<'a> BufferCollectionImageCreateInfoFUCHSIA<'a> {
     #[inline]
     pub fn collection(mut self, collection: BufferCollectionFUCHSIA) -> Self {
@@ -51445,11 +47734,11 @@ impl ::core::default::Default for BufferCollectionBufferCreateInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCollectionBufferCreateInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for BufferCollectionBufferCreateInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::BUFFER_COLLECTION_BUFFER_CREATE_INFO_FUCHSIA;
 }
-unsafe impl Extends<BufferCreateInfo<'_>> for BufferCollectionBufferCreateInfoFUCHSIA<'_> {}
+unsafe impl<'a> Extends<'a, BufferCreateInfo<'a>> for BufferCollectionBufferCreateInfoFUCHSIA<'a> {}
 impl<'a> BufferCollectionBufferCreateInfoFUCHSIA<'a> {
     #[inline]
     pub fn collection(mut self, collection: BufferCollectionFUCHSIA) -> Self {
@@ -51486,7 +47775,7 @@ impl ::core::default::Default for BufferCollectionCreateInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCollectionCreateInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for BufferCollectionCreateInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_COLLECTION_CREATE_INFO_FUCHSIA;
 }
 impl<'a> BufferCollectionCreateInfoFUCHSIA<'a> {
@@ -51540,7 +47829,7 @@ impl ::core::default::Default for BufferCollectionPropertiesFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCollectionPropertiesFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for BufferCollectionPropertiesFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_COLLECTION_PROPERTIES_FUCHSIA;
 }
 impl<'a> BufferCollectionPropertiesFUCHSIA<'a> {
@@ -51637,7 +47926,7 @@ impl ::core::default::Default for BufferConstraintsInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferConstraintsInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for BufferConstraintsInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_CONSTRAINTS_INFO_FUCHSIA;
 }
 impl<'a> BufferConstraintsInfoFUCHSIA<'a> {
@@ -51687,7 +47976,7 @@ impl ::core::default::Default for SysmemColorSpaceFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SysmemColorSpaceFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for SysmemColorSpaceFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SYSMEM_COLOR_SPACE_FUCHSIA;
 }
 impl<'a> SysmemColorSpaceFUCHSIA<'a> {
@@ -51731,7 +48020,7 @@ impl ::core::default::Default for ImageFormatConstraintsInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageFormatConstraintsInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for ImageFormatConstraintsInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_FORMAT_CONSTRAINTS_INFO_FUCHSIA;
 }
 impl<'a> ImageFormatConstraintsInfoFUCHSIA<'a> {
@@ -51795,7 +48084,7 @@ impl ::core::default::Default for ImageConstraintsInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageConstraintsInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for ImageConstraintsInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_CONSTRAINTS_INFO_FUCHSIA;
 }
 impl<'a> ImageConstraintsInfoFUCHSIA<'a> {
@@ -51854,7 +48143,7 @@ impl ::core::default::Default for BufferCollectionConstraintsInfoFUCHSIA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BufferCollectionConstraintsInfoFUCHSIA<'a> {
+unsafe impl TaggedStructure<'_> for BufferCollectionConstraintsInfoFUCHSIA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BUFFER_COLLECTION_CONSTRAINTS_INFO_FUCHSIA;
 }
 impl<'a> BufferCollectionConstraintsInfoFUCHSIA<'a> {
@@ -51927,7 +48216,7 @@ impl ::core::default::Default for CudaModuleCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CudaModuleCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for CudaModuleCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CUDA_MODULE_CREATE_INFO_NV;
 }
 impl<'a> CudaModuleCreateInfoNV<'a> {
@@ -51964,7 +48253,7 @@ impl ::core::default::Default for CudaFunctionCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CudaFunctionCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for CudaFunctionCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CUDA_FUNCTION_CREATE_INFO_NV;
 }
 impl<'a> CudaFunctionCreateInfoNV<'a> {
@@ -52033,7 +48322,7 @@ impl ::core::default::Default for CudaLaunchInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CudaLaunchInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for CudaLaunchInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::CUDA_LAUNCH_INFO_NV;
 }
 impl<'a> CudaLaunchInfoNV<'a> {
@@ -52114,12 +48403,15 @@ impl ::core::default::Default for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceRGBA10X6FormatsFeaturesEXT<'a> {
     #[inline]
     pub fn format_rgba10x6_without_y_cb_cr_sampler(
@@ -52159,10 +48451,10 @@ impl ::core::default::Default for FormatProperties3<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FormatProperties3<'a> {
+unsafe impl TaggedStructure<'_> for FormatProperties3<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FORMAT_PROPERTIES_3;
 }
-unsafe impl Extends<FormatProperties2<'_>> for FormatProperties3<'_> {}
+unsafe impl<'a> Extends<'a, FormatProperties2<'a>> for FormatProperties3<'a> {}
 impl<'a> FormatProperties3<'a> {
     #[inline]
     pub fn linear_tiling_features(mut self, linear_tiling_features: FormatFeatureFlags2) -> Self {
@@ -52206,10 +48498,10 @@ impl ::core::default::Default for DrmFormatModifierPropertiesList2EXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DrmFormatModifierPropertiesList2EXT<'a> {
+unsafe impl TaggedStructure<'_> for DrmFormatModifierPropertiesList2EXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT;
 }
-unsafe impl Extends<FormatProperties2<'_>> for DrmFormatModifierPropertiesList2EXT<'_> {}
+unsafe impl<'a> Extends<'a, FormatProperties2<'a>> for DrmFormatModifierPropertiesList2EXT<'a> {}
 impl<'a> DrmFormatModifierPropertiesList2EXT<'a> {
     #[inline]
     pub fn drm_format_modifier_properties(
@@ -52289,12 +48581,12 @@ impl ::core::default::Default for AndroidHardwareBufferFormatProperties2ANDROID<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AndroidHardwareBufferFormatProperties2ANDROID<'a> {
+unsafe impl TaggedStructure<'_> for AndroidHardwareBufferFormatProperties2ANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID;
 }
-unsafe impl Extends<AndroidHardwareBufferPropertiesANDROID<'_>>
-    for AndroidHardwareBufferFormatProperties2ANDROID<'_>
+unsafe impl<'a> Extends<'a, AndroidHardwareBufferPropertiesANDROID<'a>>
+    for AndroidHardwareBufferFormatProperties2ANDROID<'a>
 {
 }
 impl<'a> AndroidHardwareBufferFormatProperties2ANDROID<'a> {
@@ -52377,10 +48669,10 @@ impl ::core::default::Default for PipelineRenderingCreateInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRenderingCreateInfo<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRenderingCreateInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_RENDERING_CREATE_INFO;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineRenderingCreateInfo<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>> for PipelineRenderingCreateInfo<'a> {}
 impl<'a> PipelineRenderingCreateInfo<'a> {
     #[inline]
     pub fn view_mask(mut self, view_mask: u32) -> Self {
@@ -52442,7 +48734,7 @@ impl ::core::default::Default for RenderingInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderingInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDERING_INFO;
 }
 impl<'a> RenderingInfo<'a> {
@@ -52487,50 +48779,6 @@ impl<'a> RenderingInfo<'a> {
     ) -> Self {
         self.p_stencil_attachment = stencil_attachment;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -52587,7 +48835,7 @@ impl ::core::default::Default for RenderingAttachmentInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingAttachmentInfo<'a> {
+unsafe impl TaggedStructure<'_> for RenderingAttachmentInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDERING_ATTACHMENT_INFO;
 }
 impl<'a> RenderingAttachmentInfo<'a> {
@@ -52660,11 +48908,14 @@ impl ::core::default::Default for RenderingFragmentShadingRateAttachmentInfoKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingFragmentShadingRateAttachmentInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RenderingFragmentShadingRateAttachmentInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR;
 }
-unsafe impl Extends<RenderingInfo<'_>> for RenderingFragmentShadingRateAttachmentInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>>
+    for RenderingFragmentShadingRateAttachmentInfoKHR<'a>
+{
+}
 impl<'a> RenderingFragmentShadingRateAttachmentInfoKHR<'a> {
     #[inline]
     pub fn image_view(mut self, image_view: ImageView) -> Self {
@@ -52711,11 +48962,14 @@ impl ::core::default::Default for RenderingFragmentDensityMapAttachmentInfoEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingFragmentDensityMapAttachmentInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for RenderingFragmentDensityMapAttachmentInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT;
 }
-unsafe impl Extends<RenderingInfo<'_>> for RenderingFragmentDensityMapAttachmentInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>>
+    for RenderingFragmentDensityMapAttachmentInfoEXT<'a>
+{
+}
 impl<'a> RenderingFragmentDensityMapAttachmentInfoEXT<'a> {
     #[inline]
     pub fn image_view(mut self, image_view: ImageView) -> Self {
@@ -52752,11 +49006,14 @@ impl ::core::default::Default for PhysicalDeviceDynamicRenderingFeatures<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDynamicRenderingFeatures<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDynamicRenderingFeatures<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDynamicRenderingFeatures<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDynamicRenderingFeatures<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDynamicRenderingFeatures<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceDynamicRenderingFeatures<'a> {}
 impl<'a> PhysicalDeviceDynamicRenderingFeatures<'a> {
     #[inline]
     pub fn dynamic_rendering(mut self, dynamic_rendering: bool) -> Self {
@@ -52800,11 +49057,11 @@ impl ::core::default::Default for CommandBufferInheritanceRenderingInfo<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CommandBufferInheritanceRenderingInfo<'a> {
+unsafe impl TaggedStructure<'_> for CommandBufferInheritanceRenderingInfo<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COMMAND_BUFFER_INHERITANCE_RENDERING_INFO;
 }
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>>
-    for CommandBufferInheritanceRenderingInfo<'_>
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for CommandBufferInheritanceRenderingInfo<'a>
 {
 }
 impl<'a> CommandBufferInheritanceRenderingInfo<'a> {
@@ -52868,11 +49125,11 @@ impl ::core::default::Default for AttachmentSampleCountInfoAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AttachmentSampleCountInfoAMD<'a> {
+unsafe impl TaggedStructure<'_> for AttachmentSampleCountInfoAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ATTACHMENT_SAMPLE_COUNT_INFO_AMD;
 }
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>> for AttachmentSampleCountInfoAMD<'_> {}
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for AttachmentSampleCountInfoAMD<'_> {}
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>> for AttachmentSampleCountInfoAMD<'a> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>> for AttachmentSampleCountInfoAMD<'a> {}
 impl<'a> AttachmentSampleCountInfoAMD<'a> {
     #[inline]
     pub fn color_attachment_samples(
@@ -52918,12 +49175,18 @@ impl ::core::default::Default for MultiviewPerViewAttributesInfoNVX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MultiviewPerViewAttributesInfoNVX<'a> {
+unsafe impl TaggedStructure<'_> for MultiviewPerViewAttributesInfoNVX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX;
 }
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>> for MultiviewPerViewAttributesInfoNVX<'_> {}
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for MultiviewPerViewAttributesInfoNVX<'_> {}
-unsafe impl Extends<RenderingInfo<'_>> for MultiviewPerViewAttributesInfoNVX<'_> {}
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for MultiviewPerViewAttributesInfoNVX<'a>
+{
+}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for MultiviewPerViewAttributesInfoNVX<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>> for MultiviewPerViewAttributesInfoNVX<'a> {}
 impl<'a> MultiviewPerViewAttributesInfoNVX<'a> {
     #[inline]
     pub fn per_view_attributes(mut self, per_view_attributes: bool) -> Self {
@@ -52963,12 +49226,15 @@ impl ::core::default::Default for PhysicalDeviceImageViewMinLodFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageViewMinLodFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageViewMinLodFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceImageViewMinLodFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageViewMinLodFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageViewMinLodFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceImageViewMinLodFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceImageViewMinLodFeaturesEXT<'a> {
     #[inline]
     pub fn min_lod(mut self, min_lod: bool) -> Self {
@@ -53000,10 +49266,10 @@ impl ::core::default::Default for ImageViewMinLodCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewMinLodCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewMinLodCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT;
 }
-unsafe impl Extends<ImageViewCreateInfo<'_>> for ImageViewMinLodCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for ImageViewMinLodCreateInfoEXT<'a> {}
 impl<'a> ImageViewMinLodCreateInfoEXT<'a> {
     #[inline]
     pub fn min_lod(mut self, min_lod: f32) -> Self {
@@ -53039,18 +49305,18 @@ impl ::core::default::Default for PhysicalDeviceRasterizationOrderAttachmentAcce
         }
     }
 }
-unsafe impl<'a> TaggedStructure
-    for PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'a>
+unsafe impl TaggedStructure<'_>
+    for PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'_>
 {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT<'a> {
@@ -53106,15 +49372,18 @@ impl ::core::default::Default for PhysicalDeviceLinearColorAttachmentFeaturesNV<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLinearColorAttachmentFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLinearColorAttachmentFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceLinearColorAttachmentFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceLinearColorAttachmentFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceLinearColorAttachmentFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceLinearColorAttachmentFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceLinearColorAttachmentFeaturesNV<'a> {
     #[inline]
     pub fn linear_color_attachment(mut self, linear_color_attachment: bool) -> Self {
@@ -53146,15 +49415,18 @@ impl ::core::default::Default for PhysicalDeviceGraphicsPipelineLibraryFeaturesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT<'a> {
     #[inline]
     pub fn graphics_pipeline_library(mut self, graphics_pipeline_library: bool) -> Self {
@@ -53186,12 +49458,15 @@ impl ::core::default::Default for PhysicalDevicePipelineBinaryFeaturesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineBinaryFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineBinaryFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDevicePipelineBinaryFeaturesKHR<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePipelineBinaryFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelineBinaryFeaturesKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDevicePipelineBinaryFeaturesKHR<'a> {}
 impl<'a> PhysicalDevicePipelineBinaryFeaturesKHR<'a> {
     #[inline]
     pub fn pipeline_binaries(mut self, pipeline_binaries: bool) -> Self {
@@ -53223,11 +49498,14 @@ impl ::core::default::Default for DevicePipelineBinaryInternalCacheControlKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DevicePipelineBinaryInternalCacheControlKHR<'a> {
+unsafe impl TaggedStructure<'_> for DevicePipelineBinaryInternalCacheControlKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DEVICE_PIPELINE_BINARY_INTERNAL_CACHE_CONTROL_KHR;
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for DevicePipelineBinaryInternalCacheControlKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for DevicePipelineBinaryInternalCacheControlKHR<'a>
+{
+}
 impl<'a> DevicePipelineBinaryInternalCacheControlKHR<'a> {
     #[inline]
     pub fn disable_internal_cache(mut self, disable_internal_cache: bool) -> Self {
@@ -53267,12 +49545,12 @@ impl ::core::default::Default for PhysicalDevicePipelineBinaryPropertiesKHR<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineBinaryPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineBinaryPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_BINARY_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDevicePipelineBinaryPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePipelineBinaryPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDevicePipelineBinaryPropertiesKHR<'a> {
@@ -53341,12 +49619,12 @@ impl ::core::default::Default for PhysicalDeviceGraphicsPipelineLibraryPropertie
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceGraphicsPipelineLibraryPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceGraphicsPipelineLibraryPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceGraphicsPipelineLibraryPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceGraphicsPipelineLibraryPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceGraphicsPipelineLibraryPropertiesEXT<'a> {
@@ -53392,10 +49670,13 @@ impl ::core::default::Default for GraphicsPipelineLibraryCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GraphicsPipelineLibraryCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for GraphicsPipelineLibraryCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for GraphicsPipelineLibraryCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for GraphicsPipelineLibraryCreateInfoEXT<'a>
+{
+}
 impl<'a> GraphicsPipelineLibraryCreateInfoEXT<'a> {
     #[inline]
     pub fn flags(mut self, flags: GraphicsPipelineLibraryFlagsEXT) -> Self {
@@ -53427,16 +49708,16 @@ impl ::core::default::Default for PhysicalDeviceDescriptorSetHostMappingFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'a>
 {
 }
 impl<'a> PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE<'a> {
@@ -53472,7 +49753,7 @@ impl ::core::default::Default for DescriptorSetBindingReferenceVALVE<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetBindingReferenceVALVE<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetBindingReferenceVALVE<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DESCRIPTOR_SET_BINDING_REFERENCE_VALVE;
 }
 impl<'a> DescriptorSetBindingReferenceVALVE<'a> {
@@ -53513,7 +49794,7 @@ impl ::core::default::Default for DescriptorSetLayoutHostMappingInfoVALVE<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DescriptorSetLayoutHostMappingInfoVALVE<'a> {
+unsafe impl TaggedStructure<'_> for DescriptorSetLayoutHostMappingInfoVALVE<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE;
 }
@@ -53557,15 +49838,18 @@ impl ::core::default::Default for PhysicalDeviceNestedCommandBufferFeaturesEXT<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceNestedCommandBufferFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceNestedCommandBufferFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceNestedCommandBufferFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceNestedCommandBufferFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceNestedCommandBufferFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceNestedCommandBufferFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceNestedCommandBufferFeaturesEXT<'a> {
     #[inline]
     pub fn nested_command_buffer(mut self, nested_command_buffer: bool) -> Self {
@@ -53613,12 +49897,12 @@ impl ::core::default::Default for PhysicalDeviceNestedCommandBufferPropertiesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceNestedCommandBufferPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceNestedCommandBufferPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceNestedCommandBufferPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceNestedCommandBufferPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceNestedCommandBufferPropertiesEXT<'a> {
@@ -53655,15 +49939,18 @@ impl ::core::default::Default for PhysicalDeviceShaderModuleIdentifierFeaturesEX
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderModuleIdentifierFeaturesEXT<'a> {
     #[inline]
     pub fn shader_module_identifier(mut self, shader_module_identifier: bool) -> Self {
@@ -53695,12 +49982,12 @@ impl ::core::default::Default for PhysicalDeviceShaderModuleIdentifierProperties
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderModuleIdentifierPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderModuleIdentifierPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShaderModuleIdentifierPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderModuleIdentifierPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderModuleIdentifierPropertiesEXT<'a> {
@@ -53739,12 +50026,12 @@ impl ::core::default::Default for PipelineShaderStageModuleIdentifierCreateInfoE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineShaderStageModuleIdentifierCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineShaderStageModuleIdentifierCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT;
 }
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>>
-    for PipelineShaderStageModuleIdentifierCreateInfoEXT<'_>
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>>
+    for PipelineShaderStageModuleIdentifierCreateInfoEXT<'a>
 {
 }
 impl<'a> PipelineShaderStageModuleIdentifierCreateInfoEXT<'a> {
@@ -53791,7 +50078,7 @@ impl ::core::default::Default for ShaderModuleIdentifierEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ShaderModuleIdentifierEXT<'a> {
+unsafe impl TaggedStructure<'_> for ShaderModuleIdentifierEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SHADER_MODULE_IDENTIFIER_EXT;
 }
 impl<'a> ShaderModuleIdentifierEXT<'a> {
@@ -53834,12 +50121,12 @@ impl ::core::default::Default for ImageCompressionControlEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageCompressionControlEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageCompressionControlEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_COMPRESSION_CONTROL_EXT;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageCompressionControlEXT<'_> {}
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for ImageCompressionControlEXT<'_> {}
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>> for ImageCompressionControlEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImageCompressionControlEXT<'a> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for ImageCompressionControlEXT<'a> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>> for ImageCompressionControlEXT<'a> {}
 impl<'a> ImageCompressionControlEXT<'a> {
     #[inline]
     pub fn flags(mut self, flags: ImageCompressionFlagsEXT) -> Self {
@@ -53880,15 +50167,18 @@ impl ::core::default::Default for PhysicalDeviceImageCompressionControlFeaturesE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageCompressionControlFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageCompressionControlFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceImageCompressionControlFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageCompressionControlFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageCompressionControlFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImageCompressionControlFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceImageCompressionControlFeaturesEXT<'a> {
     #[inline]
     pub fn image_compression_control(mut self, image_compression_control: bool) -> Self {
@@ -53922,12 +50212,12 @@ impl ::core::default::Default for ImageCompressionPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageCompressionPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImageCompressionPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_COMPRESSION_PROPERTIES_EXT;
 }
-unsafe impl Extends<ImageFormatProperties2<'_>> for ImageCompressionPropertiesEXT<'_> {}
-unsafe impl Extends<SurfaceFormat2KHR<'_>> for ImageCompressionPropertiesEXT<'_> {}
-unsafe impl Extends<SubresourceLayout2KHR<'_>> for ImageCompressionPropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageFormatProperties2<'a>> for ImageCompressionPropertiesEXT<'a> {}
+unsafe impl<'a> Extends<'a, SurfaceFormat2KHR<'a>> for ImageCompressionPropertiesEXT<'a> {}
+unsafe impl<'a> Extends<'a, SubresourceLayout2KHR<'a>> for ImageCompressionPropertiesEXT<'a> {}
 impl<'a> ImageCompressionPropertiesEXT<'a> {
     #[inline]
     pub fn image_compression_flags(
@@ -53970,16 +50260,16 @@ impl ::core::default::Default for PhysicalDeviceImageCompressionControlSwapchain
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT<'a> {
@@ -54016,7 +50306,7 @@ impl ::core::default::Default for ImageSubresource2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageSubresource2KHR<'a> {
+unsafe impl TaggedStructure<'_> for ImageSubresource2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_SUBRESOURCE_2_KHR;
 }
 impl<'a> ImageSubresource2KHR<'a> {
@@ -54050,7 +50340,7 @@ impl ::core::default::Default for SubresourceLayout2KHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SubresourceLayout2KHR<'a> {
+unsafe impl TaggedStructure<'_> for SubresourceLayout2KHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SUBRESOURCE_LAYOUT_2_KHR;
 }
 impl<'a> SubresourceLayout2KHR<'a> {
@@ -54058,50 +50348,6 @@ impl<'a> SubresourceLayout2KHR<'a> {
     pub fn subresource_layout(mut self, subresource_layout: SubresourceLayout) -> Self {
         self.subresource_layout = subresource_layout;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -54128,11 +50374,11 @@ impl ::core::default::Default for RenderPassCreationControlEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassCreationControlEXT<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassCreationControlEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_CREATION_CONTROL_EXT;
 }
-unsafe impl Extends<RenderPassCreateInfo2<'_>> for RenderPassCreationControlEXT<'_> {}
-unsafe impl Extends<SubpassDescription2<'_>> for RenderPassCreationControlEXT<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassCreateInfo2<'a>> for RenderPassCreationControlEXT<'a> {}
+unsafe impl<'a> Extends<'a, SubpassDescription2<'a>> for RenderPassCreationControlEXT<'a> {}
 impl<'a> RenderPassCreationControlEXT<'a> {
     #[inline]
     pub fn disallow_merging(mut self, disallow_merging: bool) -> Self {
@@ -54179,11 +50425,14 @@ impl ::core::default::Default for RenderPassCreationFeedbackCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassCreationFeedbackCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassCreationFeedbackCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDER_PASS_CREATION_FEEDBACK_CREATE_INFO_EXT;
 }
-unsafe impl Extends<RenderPassCreateInfo2<'_>> for RenderPassCreationFeedbackCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, RenderPassCreateInfo2<'a>>
+    for RenderPassCreationFeedbackCreateInfoEXT<'a>
+{
+}
 impl<'a> RenderPassCreationFeedbackCreateInfoEXT<'a> {
     #[inline]
     pub fn render_pass_feedback(
@@ -54270,11 +50519,14 @@ impl ::core::default::Default for RenderPassSubpassFeedbackCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassSubpassFeedbackCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassSubpassFeedbackCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::RENDER_PASS_SUBPASS_FEEDBACK_CREATE_INFO_EXT;
 }
-unsafe impl Extends<SubpassDescription2<'_>> for RenderPassSubpassFeedbackCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SubpassDescription2<'a>>
+    for RenderPassSubpassFeedbackCreateInfoEXT<'a>
+{
+}
 impl<'a> RenderPassSubpassFeedbackCreateInfoEXT<'a> {
     #[inline]
     pub fn subpass_feedback(
@@ -54309,15 +50561,18 @@ impl ::core::default::Default for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceSubpassMergeFeedbackFeaturesEXT<'a> {
     #[inline]
     pub fn subpass_merge_feedback(mut self, subpass_merge_feedback: bool) -> Self {
@@ -54388,7 +50643,7 @@ impl ::core::default::Default for MicromapBuildInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MicromapBuildInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MicromapBuildInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MICROMAP_BUILD_INFO_EXT;
 }
 impl<'a> MicromapBuildInfoEXT<'a> {
@@ -54479,7 +50734,7 @@ impl ::core::default::Default for MicromapCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MicromapCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MicromapCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MICROMAP_CREATE_INFO_EXT;
 }
 impl<'a> MicromapCreateInfoEXT<'a> {
@@ -54538,7 +50793,7 @@ impl ::core::default::Default for MicromapVersionInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MicromapVersionInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MicromapVersionInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MICROMAP_VERSION_INFO_EXT;
 }
 impl<'a> MicromapVersionInfoEXT<'a> {
@@ -54576,7 +50831,7 @@ impl ::core::default::Default for CopyMicromapInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyMicromapInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CopyMicromapInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_MICROMAP_INFO_EXT;
 }
 impl<'a> CopyMicromapInfoEXT<'a> {
@@ -54635,7 +50890,7 @@ impl ::core::default::Default for CopyMicromapToMemoryInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyMicromapToMemoryInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CopyMicromapToMemoryInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_MICROMAP_TO_MEMORY_INFO_EXT;
 }
 impl<'a> CopyMicromapToMemoryInfoEXT<'a> {
@@ -54694,7 +50949,7 @@ impl ::core::default::Default for CopyMemoryToMicromapInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CopyMemoryToMicromapInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for CopyMemoryToMicromapInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COPY_MEMORY_TO_MICROMAP_INFO_EXT;
 }
 impl<'a> CopyMemoryToMicromapInfoEXT<'a> {
@@ -54742,7 +50997,7 @@ impl ::core::default::Default for MicromapBuildSizesInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MicromapBuildSizesInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MicromapBuildSizesInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MICROMAP_BUILD_SIZES_INFO_EXT;
 }
 impl<'a> MicromapBuildSizesInfoEXT<'a> {
@@ -54844,12 +51099,15 @@ impl ::core::default::Default for PhysicalDeviceOpacityMicromapFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceOpacityMicromapFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceOpacityMicromapFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceOpacityMicromapFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceOpacityMicromapFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceOpacityMicromapFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceOpacityMicromapFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceOpacityMicromapFeaturesEXT<'a> {
     #[inline]
     pub fn micromap(mut self, micromap: bool) -> Self {
@@ -54893,12 +51151,12 @@ impl ::core::default::Default for PhysicalDeviceOpacityMicromapPropertiesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceOpacityMicromapPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceOpacityMicromapPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceOpacityMicromapPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceOpacityMicromapPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceOpacityMicromapPropertiesEXT<'a> {
@@ -54973,12 +51231,12 @@ impl ::core::default::Default for AccelerationStructureTrianglesOpacityMicromapE
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureTrianglesOpacityMicromapEXT<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureTrianglesOpacityMicromapEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT;
 }
-unsafe impl Extends<AccelerationStructureGeometryTrianglesDataKHR<'_>>
-    for AccelerationStructureTrianglesOpacityMicromapEXT<'_>
+unsafe impl<'a> Extends<'a, AccelerationStructureGeometryTrianglesDataKHR<'a>>
+    for AccelerationStructureTrianglesOpacityMicromapEXT<'a>
 {
 }
 impl<'a> AccelerationStructureTrianglesOpacityMicromapEXT<'a> {
@@ -55044,15 +51302,18 @@ impl ::core::default::Default for PhysicalDeviceDisplacementMicromapFeaturesNV<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDisplacementMicromapFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDisplacementMicromapFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDisplacementMicromapFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDisplacementMicromapFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDisplacementMicromapFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDisplacementMicromapFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceDisplacementMicromapFeaturesNV<'a> {
     #[inline]
     pub fn displacement_micromap(mut self, displacement_micromap: bool) -> Self {
@@ -55084,12 +51345,12 @@ impl ::core::default::Default for PhysicalDeviceDisplacementMicromapPropertiesNV
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDisplacementMicromapPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDisplacementMicromapPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceDisplacementMicromapPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceDisplacementMicromapPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceDisplacementMicromapPropertiesNV<'a> {
@@ -55196,12 +51457,12 @@ impl ::core::default::Default for AccelerationStructureTrianglesDisplacementMicr
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AccelerationStructureTrianglesDisplacementMicromapNV<'a> {
+unsafe impl TaggedStructure<'_> for AccelerationStructureTrianglesDisplacementMicromapNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV;
 }
-unsafe impl Extends<AccelerationStructureGeometryTrianglesDataKHR<'_>>
-    for AccelerationStructureTrianglesDisplacementMicromapNV<'_>
+unsafe impl<'a> Extends<'a, AccelerationStructureGeometryTrianglesDataKHR<'a>>
+    for AccelerationStructureTrianglesDisplacementMicromapNV<'a>
 {
 }
 impl<'a> AccelerationStructureTrianglesDisplacementMicromapNV<'a> {
@@ -55325,7 +51586,7 @@ impl ::core::default::Default for PipelinePropertiesIdentifierEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelinePropertiesIdentifierEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelinePropertiesIdentifierEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_PROPERTIES_IDENTIFIER_EXT;
 }
 impl<'a> PipelinePropertiesIdentifierEXT<'a> {
@@ -55359,15 +51620,18 @@ impl ::core::default::Default for PhysicalDevicePipelinePropertiesFeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelinePropertiesFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelinePropertiesFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_PROPERTIES_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePipelinePropertiesFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelinePropertiesFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePipelinePropertiesFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePipelinePropertiesFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDevicePipelinePropertiesFeaturesEXT<'a> {
     #[inline]
     pub fn pipeline_properties_identifier(mut self, pipeline_properties_identifier: bool) -> Self {
@@ -55399,16 +51663,16 @@ impl ::core::default::Default for PhysicalDeviceShaderEarlyAndLateFragmentTestsF
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD<'a> {
@@ -55445,13 +51709,13 @@ impl ::core::default::Default for ExternalMemoryAcquireUnmodifiedEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalMemoryAcquireUnmodifiedEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExternalMemoryAcquireUnmodifiedEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT;
 }
-unsafe impl Extends<BufferMemoryBarrier<'_>> for ExternalMemoryAcquireUnmodifiedEXT<'_> {}
-unsafe impl Extends<BufferMemoryBarrier2<'_>> for ExternalMemoryAcquireUnmodifiedEXT<'_> {}
-unsafe impl Extends<ImageMemoryBarrier<'_>> for ExternalMemoryAcquireUnmodifiedEXT<'_> {}
-unsafe impl Extends<ImageMemoryBarrier2<'_>> for ExternalMemoryAcquireUnmodifiedEXT<'_> {}
+unsafe impl<'a> Extends<'a, BufferMemoryBarrier<'a>> for ExternalMemoryAcquireUnmodifiedEXT<'a> {}
+unsafe impl<'a> Extends<'a, BufferMemoryBarrier2<'a>> for ExternalMemoryAcquireUnmodifiedEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageMemoryBarrier<'a>> for ExternalMemoryAcquireUnmodifiedEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageMemoryBarrier2<'a>> for ExternalMemoryAcquireUnmodifiedEXT<'a> {}
 impl<'a> ExternalMemoryAcquireUnmodifiedEXT<'a> {
     #[inline]
     pub fn acquire_unmodified_memory(mut self, acquire_unmodified_memory: bool) -> Self {
@@ -55483,16 +51747,16 @@ impl ::core::default::Default for ExportMetalObjectCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalObjectCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalObjectCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_OBJECT_CREATE_INFO_EXT;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
-unsafe impl Extends<ImageCreateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
-unsafe impl Extends<ImageViewCreateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
-unsafe impl Extends<BufferViewCreateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
-unsafe impl Extends<SemaphoreCreateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
-unsafe impl Extends<EventCreateInfo<'_>> for ExportMetalObjectCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, BufferViewCreateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, SemaphoreCreateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, EventCreateInfo<'a>> for ExportMetalObjectCreateInfoEXT<'a> {}
 impl<'a> ExportMetalObjectCreateInfoEXT<'a> {
     #[inline]
     pub fn export_object_type(mut self, export_object_type: ExportMetalObjectTypeFlagsEXT) -> Self {
@@ -55522,55 +51786,10 @@ impl ::core::default::Default for ExportMetalObjectsInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalObjectsInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalObjectsInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_OBJECTS_INFO_EXT;
 }
-impl<'a> ExportMetalObjectsInfoEXT<'a> {
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
-}
+impl<'a> ExportMetalObjectsInfoEXT<'a> {}
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
@@ -55595,10 +51814,10 @@ impl ::core::default::Default for ExportMetalDeviceInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalDeviceInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalDeviceInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_DEVICE_INFO_EXT;
 }
-unsafe impl Extends<ExportMetalObjectsInfoEXT<'_>> for ExportMetalDeviceInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ExportMetalObjectsInfoEXT<'a>> for ExportMetalDeviceInfoEXT<'a> {}
 impl<'a> ExportMetalDeviceInfoEXT<'a> {
     #[inline]
     pub fn mtl_device(mut self, mtl_device: MTLDevice_id) -> Self {
@@ -55632,10 +51851,10 @@ impl ::core::default::Default for ExportMetalCommandQueueInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalCommandQueueInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalCommandQueueInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_COMMAND_QUEUE_INFO_EXT;
 }
-unsafe impl Extends<ExportMetalObjectsInfoEXT<'_>> for ExportMetalCommandQueueInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ExportMetalObjectsInfoEXT<'a>> for ExportMetalCommandQueueInfoEXT<'a> {}
 impl<'a> ExportMetalCommandQueueInfoEXT<'a> {
     #[inline]
     pub fn queue(mut self, queue: Queue) -> Self {
@@ -55674,10 +51893,10 @@ impl ::core::default::Default for ExportMetalBufferInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalBufferInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalBufferInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_BUFFER_INFO_EXT;
 }
-unsafe impl Extends<ExportMetalObjectsInfoEXT<'_>> for ExportMetalBufferInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ExportMetalObjectsInfoEXT<'a>> for ExportMetalBufferInfoEXT<'a> {}
 impl<'a> ExportMetalBufferInfoEXT<'a> {
     #[inline]
     pub fn memory(mut self, memory: DeviceMemory) -> Self {
@@ -55714,10 +51933,10 @@ impl ::core::default::Default for ImportMetalBufferInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMetalBufferInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImportMetalBufferInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_METAL_BUFFER_INFO_EXT;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportMetalBufferInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportMetalBufferInfoEXT<'a> {}
 impl<'a> ImportMetalBufferInfoEXT<'a> {
     #[inline]
     pub fn mtl_buffer(mut self, mtl_buffer: MTLBuffer_id) -> Self {
@@ -55757,10 +51976,10 @@ impl ::core::default::Default for ExportMetalTextureInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalTextureInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalTextureInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_TEXTURE_INFO_EXT;
 }
-unsafe impl Extends<ExportMetalObjectsInfoEXT<'_>> for ExportMetalTextureInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ExportMetalObjectsInfoEXT<'a>> for ExportMetalTextureInfoEXT<'a> {}
 impl<'a> ExportMetalTextureInfoEXT<'a> {
     #[inline]
     pub fn image(mut self, image: Image) -> Self {
@@ -55814,10 +52033,10 @@ impl ::core::default::Default for ImportMetalTextureInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMetalTextureInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImportMetalTextureInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_METAL_TEXTURE_INFO_EXT;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImportMetalTextureInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImportMetalTextureInfoEXT<'a> {}
 impl<'a> ImportMetalTextureInfoEXT<'a> {
     #[inline]
     pub fn plane(mut self, plane: ImageAspectFlags) -> Self {
@@ -55856,10 +52075,10 @@ impl ::core::default::Default for ExportMetalIOSurfaceInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalIOSurfaceInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalIOSurfaceInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_IO_SURFACE_INFO_EXT;
 }
-unsafe impl Extends<ExportMetalObjectsInfoEXT<'_>> for ExportMetalIOSurfaceInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ExportMetalObjectsInfoEXT<'a>> for ExportMetalIOSurfaceInfoEXT<'a> {}
 impl<'a> ExportMetalIOSurfaceInfoEXT<'a> {
     #[inline]
     pub fn image(mut self, image: Image) -> Self {
@@ -55896,10 +52115,10 @@ impl ::core::default::Default for ImportMetalIOSurfaceInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMetalIOSurfaceInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImportMetalIOSurfaceInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_METAL_IO_SURFACE_INFO_EXT;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImportMetalIOSurfaceInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImportMetalIOSurfaceInfoEXT<'a> {}
 impl<'a> ImportMetalIOSurfaceInfoEXT<'a> {
     #[inline]
     pub fn io_surface(mut self, io_surface: IOSurfaceRef) -> Self {
@@ -55935,10 +52154,10 @@ impl ::core::default::Default for ExportMetalSharedEventInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExportMetalSharedEventInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ExportMetalSharedEventInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXPORT_METAL_SHARED_EVENT_INFO_EXT;
 }
-unsafe impl Extends<ExportMetalObjectsInfoEXT<'_>> for ExportMetalSharedEventInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, ExportMetalObjectsInfoEXT<'a>> for ExportMetalSharedEventInfoEXT<'a> {}
 impl<'a> ExportMetalSharedEventInfoEXT<'a> {
     #[inline]
     pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
@@ -55980,11 +52199,11 @@ impl ::core::default::Default for ImportMetalSharedEventInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportMetalSharedEventInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ImportMetalSharedEventInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_METAL_SHARED_EVENT_INFO_EXT;
 }
-unsafe impl Extends<SemaphoreCreateInfo<'_>> for ImportMetalSharedEventInfoEXT<'_> {}
-unsafe impl Extends<EventCreateInfo<'_>> for ImportMetalSharedEventInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SemaphoreCreateInfo<'a>> for ImportMetalSharedEventInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, EventCreateInfo<'a>> for ImportMetalSharedEventInfoEXT<'a> {}
 impl<'a> ImportMetalSharedEventInfoEXT<'a> {
     #[inline]
     pub fn mtl_shared_event(mut self, mtl_shared_event: MTLSharedEvent_id) -> Self {
@@ -56016,15 +52235,18 @@ impl ::core::default::Default for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceNonSeamlessCubeMapFeaturesEXT<'a> {
     #[inline]
     pub fn non_seamless_cube_map(mut self, non_seamless_cube_map: bool) -> Self {
@@ -56056,15 +52278,18 @@ impl ::core::default::Default for PhysicalDevicePipelineRobustnessFeaturesEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineRobustnessFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineRobustnessFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePipelineRobustnessFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelineRobustnessFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePipelineRobustnessFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePipelineRobustnessFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDevicePipelineRobustnessFeaturesEXT<'a> {
     #[inline]
     pub fn pipeline_robustness(mut self, pipeline_robustness: bool) -> Self {
@@ -56102,13 +52327,22 @@ impl ::core::default::Default for PipelineRobustnessCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineRobustnessCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for PipelineRobustnessCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PIPELINE_ROBUSTNESS_CREATE_INFO_EXT;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for PipelineRobustnessCreateInfoEXT<'_> {}
-unsafe impl Extends<ComputePipelineCreateInfo<'_>> for PipelineRobustnessCreateInfoEXT<'_> {}
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>> for PipelineRobustnessCreateInfoEXT<'_> {}
-unsafe impl Extends<RayTracingPipelineCreateInfoKHR<'_>> for PipelineRobustnessCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for PipelineRobustnessCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, ComputePipelineCreateInfo<'a>> for PipelineRobustnessCreateInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>>
+    for PipelineRobustnessCreateInfoEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, RayTracingPipelineCreateInfoKHR<'a>>
+    for PipelineRobustnessCreateInfoEXT<'a>
+{
+}
 impl<'a> PipelineRobustnessCreateInfoEXT<'a> {
     #[inline]
     pub fn storage_buffers(mut self, storage_buffers: PipelineRobustnessBufferBehaviorEXT) -> Self {
@@ -56161,12 +52395,12 @@ impl ::core::default::Default for PhysicalDevicePipelineRobustnessPropertiesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineRobustnessPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineRobustnessPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDevicePipelineRobustnessPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDevicePipelineRobustnessPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDevicePipelineRobustnessPropertiesEXT<'a> {
@@ -56231,10 +52465,10 @@ impl ::core::default::Default for ImageViewSampleWeightCreateInfoQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageViewSampleWeightCreateInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for ImageViewSampleWeightCreateInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_VIEW_SAMPLE_WEIGHT_CREATE_INFO_QCOM;
 }
-unsafe impl Extends<ImageViewCreateInfo<'_>> for ImageViewSampleWeightCreateInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, ImageViewCreateInfo<'a>> for ImageViewSampleWeightCreateInfoQCOM<'a> {}
 impl<'a> ImageViewSampleWeightCreateInfoQCOM<'a> {
     #[inline]
     pub fn filter_center(mut self, filter_center: Offset2D) -> Self {
@@ -56280,12 +52514,18 @@ impl ::core::default::Default for PhysicalDeviceImageProcessingFeaturesQCOM<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageProcessingFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageProcessingFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceImageProcessingFeaturesQCOM<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageProcessingFeaturesQCOM<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageProcessingFeaturesQCOM<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImageProcessingFeaturesQCOM<'a>
+{
+}
 impl<'a> PhysicalDeviceImageProcessingFeaturesQCOM<'a> {
     #[inline]
     pub fn texture_sample_weighted(mut self, texture_sample_weighted: bool) -> Self {
@@ -56333,12 +52573,12 @@ impl ::core::default::Default for PhysicalDeviceImageProcessingPropertiesQCOM<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageProcessingPropertiesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageProcessingPropertiesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_PROCESSING_PROPERTIES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceImageProcessingPropertiesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceImageProcessingPropertiesQCOM<'a>
 {
 }
 impl<'a> PhysicalDeviceImageProcessingPropertiesQCOM<'a> {
@@ -56387,12 +52627,15 @@ impl ::core::default::Default for PhysicalDeviceTilePropertiesFeaturesQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceTilePropertiesFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceTilePropertiesFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceTilePropertiesFeaturesQCOM<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceTilePropertiesFeaturesQCOM<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceTilePropertiesFeaturesQCOM<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceTilePropertiesFeaturesQCOM<'a> {}
 impl<'a> PhysicalDeviceTilePropertiesFeaturesQCOM<'a> {
     #[inline]
     pub fn tile_properties(mut self, tile_properties: bool) -> Self {
@@ -56428,7 +52671,7 @@ impl ::core::default::Default for TilePropertiesQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for TilePropertiesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for TilePropertiesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::TILE_PROPERTIES_QCOM;
 }
 impl<'a> TilePropertiesQCOM<'a> {
@@ -56472,12 +52715,15 @@ impl ::core::default::Default for PhysicalDeviceAmigoProfilingFeaturesSEC<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceAmigoProfilingFeaturesSEC<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceAmigoProfilingFeaturesSEC<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceAmigoProfilingFeaturesSEC<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceAmigoProfilingFeaturesSEC<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceAmigoProfilingFeaturesSEC<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceAmigoProfilingFeaturesSEC<'a> {}
 impl<'a> PhysicalDeviceAmigoProfilingFeaturesSEC<'a> {
     #[inline]
     pub fn amigo_profiling(mut self, amigo_profiling: bool) -> Self {
@@ -56511,10 +52757,10 @@ impl ::core::default::Default for AmigoProfilingSubmitInfoSEC<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AmigoProfilingSubmitInfoSEC<'a> {
+unsafe impl TaggedStructure<'_> for AmigoProfilingSubmitInfoSEC<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::AMIGO_PROFILING_SUBMIT_INFO_SEC;
 }
-unsafe impl Extends<SubmitInfo<'_>> for AmigoProfilingSubmitInfoSEC<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for AmigoProfilingSubmitInfoSEC<'a> {}
 impl<'a> AmigoProfilingSubmitInfoSEC<'a> {
     #[inline]
     pub fn first_draw_timestamp(mut self, first_draw_timestamp: u64) -> Self {
@@ -56551,16 +52797,16 @@ impl ::core::default::Default for PhysicalDeviceAttachmentFeedbackLoopLayoutFeat
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT<'a> {
@@ -56597,15 +52843,18 @@ impl ::core::default::Default for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDepthClampZeroOneFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDepthClampZeroOneFeaturesEXT<'a> {
     #[inline]
     pub fn depth_clamp_zero_one(mut self, depth_clamp_zero_one: bool) -> Self {
@@ -56637,15 +52886,18 @@ impl ::core::default::Default for PhysicalDeviceAddressBindingReportFeaturesEXT<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceAddressBindingReportFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceAddressBindingReportFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceAddressBindingReportFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceAddressBindingReportFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceAddressBindingReportFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceAddressBindingReportFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceAddressBindingReportFeaturesEXT<'a> {
     #[inline]
     pub fn report_address_binding(mut self, report_address_binding: bool) -> Self {
@@ -56683,11 +52935,11 @@ impl ::core::default::Default for DeviceAddressBindingCallbackDataEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceAddressBindingCallbackDataEXT<'a> {
+unsafe impl TaggedStructure<'_> for DeviceAddressBindingCallbackDataEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_ADDRESS_BINDING_CALLBACK_DATA_EXT;
 }
-unsafe impl Extends<DebugUtilsMessengerCallbackDataEXT<'_>>
-    for DeviceAddressBindingCallbackDataEXT<'_>
+unsafe impl<'a> Extends<'a, DebugUtilsMessengerCallbackDataEXT<'a>>
+    for DeviceAddressBindingCallbackDataEXT<'a>
 {
 }
 impl<'a> DeviceAddressBindingCallbackDataEXT<'a> {
@@ -56736,11 +52988,14 @@ impl ::core::default::Default for PhysicalDeviceOpticalFlowFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceOpticalFlowFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceOpticalFlowFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceOpticalFlowFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceOpticalFlowFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceOpticalFlowFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceOpticalFlowFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceOpticalFlowFeaturesNV<'a> {
     #[inline]
     pub fn optical_flow(mut self, optical_flow: bool) -> Self {
@@ -56792,10 +53047,13 @@ impl ::core::default::Default for PhysicalDeviceOpticalFlowPropertiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceOpticalFlowPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceOpticalFlowPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_OPTICAL_FLOW_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceOpticalFlowPropertiesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceOpticalFlowPropertiesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceOpticalFlowPropertiesNV<'a> {
     #[inline]
     pub fn supported_output_grid_sizes(
@@ -56883,11 +53141,14 @@ impl ::core::default::Default for OpticalFlowImageFormatInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OpticalFlowImageFormatInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for OpticalFlowImageFormatInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV;
 }
-unsafe impl Extends<PhysicalDeviceImageFormatInfo2<'_>> for OpticalFlowImageFormatInfoNV<'_> {}
-unsafe impl Extends<ImageCreateInfo<'_>> for OpticalFlowImageFormatInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceImageFormatInfo2<'a>>
+    for OpticalFlowImageFormatInfoNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for OpticalFlowImageFormatInfoNV<'a> {}
 impl<'a> OpticalFlowImageFormatInfoNV<'a> {
     #[inline]
     pub fn usage(mut self, usage: OpticalFlowUsageFlagsNV) -> Self {
@@ -56919,7 +53180,7 @@ impl ::core::default::Default for OpticalFlowImageFormatPropertiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OpticalFlowImageFormatPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for OpticalFlowImageFormatPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_NV;
 }
 impl<'a> OpticalFlowImageFormatPropertiesNV<'a> {
@@ -56969,7 +53230,7 @@ impl ::core::default::Default for OpticalFlowSessionCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OpticalFlowSessionCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for OpticalFlowSessionCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::OPTICAL_FLOW_SESSION_CREATE_INFO_NV;
 }
 impl<'a> OpticalFlowSessionCreateInfoNV<'a> {
@@ -57018,50 +53279,6 @@ impl<'a> OpticalFlowSessionCreateInfoNV<'a> {
         self.flags = flags;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -57091,12 +53308,12 @@ impl ::core::default::Default for OpticalFlowSessionCreatePrivateDataInfoNV<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OpticalFlowSessionCreatePrivateDataInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for OpticalFlowSessionCreatePrivateDataInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::OPTICAL_FLOW_SESSION_CREATE_PRIVATE_DATA_INFO_NV;
 }
-unsafe impl Extends<OpticalFlowSessionCreateInfoNV<'_>>
-    for OpticalFlowSessionCreatePrivateDataInfoNV<'_>
+unsafe impl<'a> Extends<'a, OpticalFlowSessionCreateInfoNV<'a>>
+    for OpticalFlowSessionCreatePrivateDataInfoNV<'a>
 {
 }
 impl<'a> OpticalFlowSessionCreatePrivateDataInfoNV<'a> {
@@ -57144,7 +53361,7 @@ impl ::core::default::Default for OpticalFlowExecuteInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OpticalFlowExecuteInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for OpticalFlowExecuteInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::OPTICAL_FLOW_EXECUTE_INFO_NV;
 }
 impl<'a> OpticalFlowExecuteInfoNV<'a> {
@@ -57186,11 +53403,11 @@ impl ::core::default::Default for PhysicalDeviceFaultFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFaultFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFaultFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_FAULT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceFaultFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFaultFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceFaultFeaturesEXT<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceFaultFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceFaultFeaturesEXT<'a> {
     #[inline]
     pub fn device_fault(mut self, device_fault: bool) -> Self {
@@ -57310,7 +53527,7 @@ impl ::core::default::Default for DeviceFaultCountsEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceFaultCountsEXT<'a> {
+unsafe impl TaggedStructure<'_> for DeviceFaultCountsEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_FAULT_COUNTS_EXT;
 }
 impl<'a> DeviceFaultCountsEXT<'a> {
@@ -57372,7 +53589,7 @@ impl ::core::default::Default for DeviceFaultInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceFaultInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DeviceFaultInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_FAULT_INFO_EXT;
 }
 impl<'a> DeviceFaultInfoEXT<'a> {
@@ -57523,16 +53740,16 @@ impl ::core::default::Default for PhysicalDevicePipelineLibraryGroupHandlesFeatu
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT<'a> {
@@ -57570,7 +53787,7 @@ impl ::core::default::Default for DepthBiasInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DepthBiasInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DepthBiasInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEPTH_BIAS_INFO_EXT;
 }
 impl<'a> DepthBiasInfoEXT<'a> {
@@ -57588,50 +53805,6 @@ impl<'a> DepthBiasInfoEXT<'a> {
     pub fn depth_bias_slope_factor(mut self, depth_bias_slope_factor: f32) -> Self {
         self.depth_bias_slope_factor = depth_bias_slope_factor;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -57660,12 +53833,12 @@ impl ::core::default::Default for DepthBiasRepresentationInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DepthBiasRepresentationInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for DepthBiasRepresentationInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEPTH_BIAS_REPRESENTATION_INFO_EXT;
 }
-unsafe impl Extends<DepthBiasInfoEXT<'_>> for DepthBiasRepresentationInfoEXT<'_> {}
-unsafe impl Extends<PipelineRasterizationStateCreateInfo<'_>>
-    for DepthBiasRepresentationInfoEXT<'_>
+unsafe impl<'a> Extends<'a, DepthBiasInfoEXT<'a>> for DepthBiasRepresentationInfoEXT<'a> {}
+unsafe impl<'a> Extends<'a, PipelineRasterizationStateCreateInfo<'a>>
+    for DepthBiasRepresentationInfoEXT<'a>
 {
 }
 impl<'a> DepthBiasRepresentationInfoEXT<'a> {
@@ -57753,12 +53926,12 @@ impl ::core::default::Default for PhysicalDeviceShaderCoreBuiltinsPropertiesARM<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderCoreBuiltinsPropertiesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderCoreBuiltinsPropertiesARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_PROPERTIES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShaderCoreBuiltinsPropertiesARM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderCoreBuiltinsPropertiesARM<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderCoreBuiltinsPropertiesARM<'a> {
@@ -57802,15 +53975,18 @@ impl ::core::default::Default for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderCoreBuiltinsFeaturesARM<'a> {
     #[inline]
     pub fn shader_core_builtins(mut self, shader_core_builtins: bool) -> Self {
@@ -57858,13 +54034,13 @@ impl ::core::default::Default for FrameBoundaryEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for FrameBoundaryEXT<'a> {
+unsafe impl TaggedStructure<'_> for FrameBoundaryEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::FRAME_BOUNDARY_EXT;
 }
-unsafe impl Extends<SubmitInfo<'_>> for FrameBoundaryEXT<'_> {}
-unsafe impl Extends<SubmitInfo2<'_>> for FrameBoundaryEXT<'_> {}
-unsafe impl Extends<PresentInfoKHR<'_>> for FrameBoundaryEXT<'_> {}
-unsafe impl Extends<BindSparseInfo<'_>> for FrameBoundaryEXT<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for FrameBoundaryEXT<'a> {}
+unsafe impl<'a> Extends<'a, SubmitInfo2<'a>> for FrameBoundaryEXT<'a> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for FrameBoundaryEXT<'a> {}
+unsafe impl<'a> Extends<'a, BindSparseInfo<'a>> for FrameBoundaryEXT<'a> {}
 impl<'a> FrameBoundaryEXT<'a> {
     #[inline]
     pub fn flags(mut self, flags: FrameBoundaryFlagsEXT) -> Self {
@@ -57924,12 +54100,15 @@ impl ::core::default::Default for PhysicalDeviceFrameBoundaryFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceFrameBoundaryFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceFrameBoundaryFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceFrameBoundaryFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceFrameBoundaryFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceFrameBoundaryFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceFrameBoundaryFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceFrameBoundaryFeaturesEXT<'a> {
     #[inline]
     pub fn frame_boundary(mut self, frame_boundary: bool) -> Self {
@@ -57961,16 +54140,16 @@ impl ::core::default::Default for PhysicalDeviceDynamicRenderingUnusedAttachment
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT<'a> {
@@ -58007,10 +54186,10 @@ impl ::core::default::Default for SurfacePresentModeEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfacePresentModeEXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfacePresentModeEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_PRESENT_MODE_EXT;
 }
-unsafe impl Extends<PhysicalDeviceSurfaceInfo2KHR<'_>> for SurfacePresentModeEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceSurfaceInfo2KHR<'a>> for SurfacePresentModeEXT<'a> {}
 impl<'a> SurfacePresentModeEXT<'a> {
     #[inline]
     pub fn present_mode(mut self, present_mode: PresentModeKHR) -> Self {
@@ -58050,10 +54229,13 @@ impl ::core::default::Default for SurfacePresentScalingCapabilitiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfacePresentScalingCapabilitiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfacePresentScalingCapabilitiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_PRESENT_SCALING_CAPABILITIES_EXT;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for SurfacePresentScalingCapabilitiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>>
+    for SurfacePresentScalingCapabilitiesEXT<'a>
+{
+}
 impl<'a> SurfacePresentScalingCapabilitiesEXT<'a> {
     #[inline]
     pub fn supported_present_scaling(
@@ -58116,10 +54298,13 @@ impl ::core::default::Default for SurfacePresentModeCompatibilityEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SurfacePresentModeCompatibilityEXT<'a> {
+unsafe impl TaggedStructure<'_> for SurfacePresentModeCompatibilityEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SURFACE_PRESENT_MODE_COMPATIBILITY_EXT;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for SurfacePresentModeCompatibilityEXT<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>>
+    for SurfacePresentModeCompatibilityEXT<'a>
+{
+}
 impl<'a> SurfacePresentModeCompatibilityEXT<'a> {
     #[inline]
     pub fn present_modes(mut self, present_modes: &'a mut [PresentModeKHR]) -> Self {
@@ -58152,15 +54337,18 @@ impl ::core::default::Default for PhysicalDeviceSwapchainMaintenance1FeaturesEXT
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceSwapchainMaintenance1FeaturesEXT<'a> {
     #[inline]
     pub fn swapchain_maintenance1(mut self, swapchain_maintenance1: bool) -> Self {
@@ -58194,10 +54382,10 @@ impl ::core::default::Default for SwapchainPresentFenceInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainPresentFenceInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainPresentFenceInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_PRESENT_FENCE_INFO_EXT;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for SwapchainPresentFenceInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for SwapchainPresentFenceInfoEXT<'a> {}
 impl<'a> SwapchainPresentFenceInfoEXT<'a> {
     #[inline]
     pub fn fences(mut self, fences: &'a [Fence]) -> Self {
@@ -58232,10 +54420,10 @@ impl ::core::default::Default for SwapchainPresentModesCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainPresentModesCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainPresentModesCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SwapchainPresentModesCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for SwapchainPresentModesCreateInfoEXT<'a> {}
 impl<'a> SwapchainPresentModesCreateInfoEXT<'a> {
     #[inline]
     pub fn present_modes(mut self, present_modes: &'a [PresentModeKHR]) -> Self {
@@ -58270,10 +54458,10 @@ impl ::core::default::Default for SwapchainPresentModeInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainPresentModeInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainPresentModeInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_PRESENT_MODE_INFO_EXT;
 }
-unsafe impl Extends<PresentInfoKHR<'_>> for SwapchainPresentModeInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, PresentInfoKHR<'a>> for SwapchainPresentModeInfoEXT<'a> {}
 impl<'a> SwapchainPresentModeInfoEXT<'a> {
     #[inline]
     pub fn present_modes(mut self, present_modes: &'a [PresentModeKHR]) -> Self {
@@ -58310,10 +54498,13 @@ impl ::core::default::Default for SwapchainPresentScalingCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainPresentScalingCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainPresentScalingCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_EXT;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SwapchainPresentScalingCreateInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>>
+    for SwapchainPresentScalingCreateInfoEXT<'a>
+{
+}
 impl<'a> SwapchainPresentScalingCreateInfoEXT<'a> {
     #[inline]
     pub fn scaling_behavior(mut self, scaling_behavior: PresentScalingFlagsEXT) -> Self {
@@ -58359,7 +54550,7 @@ impl ::core::default::Default for ReleaseSwapchainImagesInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ReleaseSwapchainImagesInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ReleaseSwapchainImagesInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RELEASE_SWAPCHAIN_IMAGES_INFO_EXT;
 }
 impl<'a> ReleaseSwapchainImagesInfoEXT<'a> {
@@ -58405,12 +54596,18 @@ impl ::core::default::Default for PhysicalDeviceDepthBiasControlFeaturesEXT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDepthBiasControlFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDepthBiasControlFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceDepthBiasControlFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceDepthBiasControlFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDepthBiasControlFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDepthBiasControlFeaturesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceDepthBiasControlFeaturesEXT<'a> {
     #[inline]
     pub fn depth_bias_control(mut self, depth_bias_control: bool) -> Self {
@@ -58461,16 +54658,16 @@ impl ::core::default::Default for PhysicalDeviceRayTracingInvocationReorderFeatu
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceRayTracingInvocationReorderFeaturesNV<'a> {
@@ -58505,12 +54702,12 @@ impl ::core::default::Default for PhysicalDeviceRayTracingInvocationReorderPrope
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingInvocationReorderPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingInvocationReorderPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceRayTracingInvocationReorderPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceRayTracingInvocationReorderPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceRayTracingInvocationReorderPropertiesNV<'a> {
@@ -58548,16 +54745,16 @@ impl ::core::default::Default for PhysicalDeviceExtendedSparseAddressSpaceFeatur
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV<'a> {
@@ -58595,12 +54792,12 @@ impl ::core::default::Default for PhysicalDeviceExtendedSparseAddressSpaceProper
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExtendedSparseAddressSpacePropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExtendedSparseAddressSpacePropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceExtendedSparseAddressSpacePropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceExtendedSparseAddressSpacePropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceExtendedSparseAddressSpacePropertiesNV<'a> {
@@ -58668,7 +54865,7 @@ impl ::core::default::Default for DirectDriverLoadingInfoLUNARG<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DirectDriverLoadingInfoLUNARG<'a> {
+unsafe impl TaggedStructure<'_> for DirectDriverLoadingInfoLUNARG<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DIRECT_DRIVER_LOADING_INFO_LUNARG;
 }
 impl<'a> DirectDriverLoadingInfoLUNARG<'a> {
@@ -58714,10 +54911,10 @@ impl ::core::default::Default for DirectDriverLoadingListLUNARG<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DirectDriverLoadingListLUNARG<'a> {
+unsafe impl TaggedStructure<'_> for DirectDriverLoadingListLUNARG<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DIRECT_DRIVER_LOADING_LIST_LUNARG;
 }
-unsafe impl Extends<InstanceCreateInfo<'_>> for DirectDriverLoadingListLUNARG<'_> {}
+unsafe impl<'a> Extends<'a, InstanceCreateInfo<'a>> for DirectDriverLoadingListLUNARG<'a> {}
 impl<'a> DirectDriverLoadingListLUNARG<'a> {
     #[inline]
     pub fn mode(mut self, mode: DirectDriverLoadingModeLUNARG) -> Self {
@@ -58755,16 +54952,16 @@ impl ::core::default::Default for PhysicalDeviceMultiviewPerViewViewportsFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'a>
 {
 }
 impl<'a> PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM<'a> {
@@ -58798,15 +54995,18 @@ impl ::core::default::Default for PhysicalDeviceRayTracingPositionFetchFeaturesK
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceRayTracingPositionFetchFeaturesKHR<'a> {
     #[inline]
     pub fn ray_tracing_position_fetch(mut self, ray_tracing_position_fetch: bool) -> Self {
@@ -58840,7 +55040,7 @@ impl ::core::default::Default for DeviceImageSubresourceInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceImageSubresourceInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for DeviceImageSubresourceInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::DEVICE_IMAGE_SUBRESOURCE_INFO_KHR;
 }
 impl<'a> DeviceImageSubresourceInfoKHR<'a> {
@@ -58883,10 +55083,13 @@ impl ::core::default::Default for PhysicalDeviceShaderCorePropertiesARM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderCorePropertiesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderCorePropertiesARM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceShaderCorePropertiesARM<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderCorePropertiesARM<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderCorePropertiesARM<'a> {
     #[inline]
     pub fn pixel_rate(mut self, pixel_rate: u32) -> Self {
@@ -58928,16 +55131,16 @@ impl ::core::default::Default for PhysicalDeviceMultiviewPerViewRenderAreasFeatu
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'a>
 {
 }
 impl<'a> PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM<'a> {
@@ -58976,15 +55179,18 @@ impl ::core::default::Default for MultiviewPerViewRenderAreasRenderPassBeginInfo
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM;
 }
-unsafe impl Extends<RenderPassBeginInfo<'_>>
-    for MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'_>
+unsafe impl<'a> Extends<'a, RenderPassBeginInfo<'a>>
+    for MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'a>
 {
 }
-unsafe impl Extends<RenderingInfo<'_>> for MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>>
+    for MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'a>
+{
+}
 impl<'a> MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM<'a> {
     #[inline]
     pub fn per_view_render_areas(mut self, per_view_render_areas: &'a [Rect2D]) -> Self {
@@ -59017,10 +55223,10 @@ impl ::core::default::Default for QueryLowLatencySupportNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for QueryLowLatencySupportNV<'a> {
+unsafe impl TaggedStructure<'_> for QueryLowLatencySupportNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::QUERY_LOW_LATENCY_SUPPORT_NV;
 }
-unsafe impl Extends<SemaphoreCreateInfo<'_>> for QueryLowLatencySupportNV<'_> {}
+unsafe impl<'a> Extends<'a, SemaphoreCreateInfo<'a>> for QueryLowLatencySupportNV<'a> {}
 impl<'a> QueryLowLatencySupportNV<'a> {
     #[inline]
     pub fn queried_low_latency_data(mut self, queried_low_latency_data: *mut c_void) -> Self {
@@ -59058,7 +55264,7 @@ impl ::core::default::Default for MemoryMapInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryMapInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for MemoryMapInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_MAP_INFO_KHR;
 }
 impl<'a> MemoryMapInfoKHR<'a> {
@@ -59081,50 +55287,6 @@ impl<'a> MemoryMapInfoKHR<'a> {
     pub fn size(mut self, size: DeviceSize) -> Self {
         self.size = size;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -59153,7 +55315,7 @@ impl ::core::default::Default for MemoryUnmapInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryUnmapInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for MemoryUnmapInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_UNMAP_INFO_KHR;
 }
 impl<'a> MemoryUnmapInfoKHR<'a> {
@@ -59192,11 +55354,14 @@ impl ::core::default::Default for PhysicalDeviceShaderObjectFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderObjectFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderObjectFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderObjectFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderObjectFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderObjectFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderObjectFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceShaderObjectFeaturesEXT<'a> {
     #[inline]
     pub fn shader_object(mut self, shader_object: bool) -> Self {
@@ -59230,11 +55395,14 @@ impl ::core::default::Default for PhysicalDeviceShaderObjectPropertiesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderObjectPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderObjectPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>> for PhysicalDeviceShaderObjectPropertiesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderObjectPropertiesEXT<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderObjectPropertiesEXT<'a> {
     #[inline]
     pub fn shader_binary_uuid(mut self, shader_binary_uuid: [u8; UUID_SIZE]) -> Self {
@@ -59293,7 +55461,7 @@ impl ::core::default::Default for ShaderCreateInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ShaderCreateInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for ShaderCreateInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SHADER_CREATE_INFO_EXT;
 }
 impl<'a> ShaderCreateInfoEXT<'a> {
@@ -59353,50 +55521,6 @@ impl<'a> ShaderCreateInfoEXT<'a> {
         self.p_specialization_info = specialization_info;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -59426,12 +55550,15 @@ impl ::core::default::Default for PhysicalDeviceShaderTileImageFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderTileImageFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderTileImageFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderTileImageFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderTileImageFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderTileImageFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderTileImageFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceShaderTileImageFeaturesEXT<'a> {
     #[inline]
     pub fn shader_tile_image_color_read_access(
@@ -59486,12 +55613,12 @@ impl ::core::default::Default for PhysicalDeviceShaderTileImagePropertiesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderTileImagePropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderTileImagePropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShaderTileImagePropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderTileImagePropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderTileImagePropertiesEXT<'a> {
@@ -59547,10 +55674,10 @@ impl ::core::default::Default for ImportScreenBufferInfoQNX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImportScreenBufferInfoQNX<'a> {
+unsafe impl TaggedStructure<'_> for ImportScreenBufferInfoQNX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMPORT_SCREEN_BUFFER_INFO_QNX;
 }
-unsafe impl Extends<MemoryAllocateInfo<'_>> for ImportScreenBufferInfoQNX<'_> {}
+unsafe impl<'a> Extends<'a, MemoryAllocateInfo<'a>> for ImportScreenBufferInfoQNX<'a> {}
 impl<'a> ImportScreenBufferInfoQNX<'a> {
     #[inline]
     pub fn buffer(mut self, buffer: &'a mut _screen_buffer) -> Self {
@@ -59584,7 +55711,7 @@ impl ::core::default::Default for ScreenBufferPropertiesQNX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ScreenBufferPropertiesQNX<'a> {
+unsafe impl TaggedStructure<'_> for ScreenBufferPropertiesQNX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SCREEN_BUFFER_PROPERTIES_QNX;
 }
 impl<'a> ScreenBufferPropertiesQNX<'a> {
@@ -59597,50 +55724,6 @@ impl<'a> ScreenBufferPropertiesQNX<'a> {
     pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.memory_type_bits = memory_type_bits;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -59683,10 +55766,10 @@ impl ::core::default::Default for ScreenBufferFormatPropertiesQNX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ScreenBufferFormatPropertiesQNX<'a> {
+unsafe impl TaggedStructure<'_> for ScreenBufferFormatPropertiesQNX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SCREEN_BUFFER_FORMAT_PROPERTIES_QNX;
 }
-unsafe impl Extends<ScreenBufferPropertiesQNX<'_>> for ScreenBufferFormatPropertiesQNX<'_> {}
+unsafe impl<'a> Extends<'a, ScreenBufferPropertiesQNX<'a>> for ScreenBufferFormatPropertiesQNX<'a> {}
 impl<'a> ScreenBufferFormatPropertiesQNX<'a> {
     #[inline]
     pub fn format(mut self, format: Format) -> Self {
@@ -59764,11 +55847,11 @@ impl ::core::default::Default for ExternalFormatQNX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExternalFormatQNX<'a> {
+unsafe impl TaggedStructure<'_> for ExternalFormatQNX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXTERNAL_FORMAT_QNX;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ExternalFormatQNX<'_> {}
-unsafe impl Extends<SamplerYcbcrConversionCreateInfo<'_>> for ExternalFormatQNX<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ExternalFormatQNX<'a> {}
+unsafe impl<'a> Extends<'a, SamplerYcbcrConversionCreateInfo<'a>> for ExternalFormatQNX<'a> {}
 impl<'a> ExternalFormatQNX<'a> {
     #[inline]
     pub fn external_format(mut self, external_format: u64) -> Self {
@@ -59800,16 +55883,16 @@ impl ::core::default::Default for PhysicalDeviceExternalMemoryScreenBufferFeatur
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'a>
 {
 }
 impl<'a> PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX<'a> {
@@ -59845,15 +55928,18 @@ impl ::core::default::Default for PhysicalDeviceCooperativeMatrixFeaturesKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCooperativeMatrixFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCooperativeMatrixFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceCooperativeMatrixFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCooperativeMatrixFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCooperativeMatrixFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCooperativeMatrixFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceCooperativeMatrixFeaturesKHR<'a> {
     #[inline]
     pub fn cooperative_matrix(mut self, cooperative_matrix: bool) -> Self {
@@ -59910,7 +55996,7 @@ impl ::core::default::Default for CooperativeMatrixPropertiesKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for CooperativeMatrixPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for CooperativeMatrixPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::COOPERATIVE_MATRIX_PROPERTIES_KHR;
 }
 impl<'a> CooperativeMatrixPropertiesKHR<'a> {
@@ -59984,12 +56070,12 @@ impl ::core::default::Default for PhysicalDeviceCooperativeMatrixPropertiesKHR<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCooperativeMatrixPropertiesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCooperativeMatrixPropertiesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceCooperativeMatrixPropertiesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceCooperativeMatrixPropertiesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceCooperativeMatrixPropertiesKHR<'a> {
@@ -60034,12 +56120,12 @@ impl ::core::default::Default for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderEnqueuePropertiesAMDX<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceShaderEnqueuePropertiesAMDX<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceShaderEnqueuePropertiesAMDX<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderEnqueuePropertiesAMDX<'a> {
@@ -60106,12 +56192,15 @@ impl ::core::default::Default for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderEnqueueFeaturesAMDX<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {}
 impl<'a> PhysicalDeviceShaderEnqueueFeaturesAMDX<'a> {
     #[inline]
     pub fn shader_enqueue(mut self, shader_enqueue: bool) -> Self {
@@ -60155,7 +56244,7 @@ impl ::core::default::Default for ExecutionGraphPipelineCreateInfoAMDX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExecutionGraphPipelineCreateInfoAMDX<'a> {
+unsafe impl TaggedStructure<'_> for ExecutionGraphPipelineCreateInfoAMDX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX;
 }
 impl<'a> ExecutionGraphPipelineCreateInfoAMDX<'a> {
@@ -60190,50 +56279,6 @@ impl<'a> ExecutionGraphPipelineCreateInfoAMDX<'a> {
         self.base_pipeline_index = base_pipeline_index;
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -60261,12 +56306,12 @@ impl ::core::default::Default for PipelineShaderStageNodeCreateInfoAMDX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PipelineShaderStageNodeCreateInfoAMDX<'a> {
+unsafe impl TaggedStructure<'_> for PipelineShaderStageNodeCreateInfoAMDX<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX;
 }
-unsafe impl Extends<PipelineShaderStageCreateInfo<'_>>
-    for PipelineShaderStageNodeCreateInfoAMDX<'_>
+unsafe impl<'a> Extends<'a, PipelineShaderStageCreateInfo<'a>>
+    for PipelineShaderStageNodeCreateInfoAMDX<'a>
 {
 }
 impl<'a> PipelineShaderStageNodeCreateInfoAMDX<'a> {
@@ -60313,7 +56358,7 @@ impl ::core::default::Default for ExecutionGraphPipelineScratchSizeAMDX<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ExecutionGraphPipelineScratchSizeAMDX<'a> {
+unsafe impl TaggedStructure<'_> for ExecutionGraphPipelineScratchSizeAMDX<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX;
 }
 impl<'a> ExecutionGraphPipelineScratchSizeAMDX<'a> {
@@ -60426,11 +56471,11 @@ impl ::core::default::Default for PhysicalDeviceAntiLagFeaturesAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceAntiLagFeaturesAMD<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceAntiLagFeaturesAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_ANTI_LAG_FEATURES_AMD;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceAntiLagFeaturesAMD<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceAntiLagFeaturesAMD<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>> for PhysicalDeviceAntiLagFeaturesAMD<'a> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceAntiLagFeaturesAMD<'a> {}
 impl<'a> PhysicalDeviceAntiLagFeaturesAMD<'a> {
     #[inline]
     pub fn anti_lag(mut self, anti_lag: bool) -> Self {
@@ -60466,7 +56511,7 @@ impl ::core::default::Default for AntiLagDataAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AntiLagDataAMD<'a> {
+unsafe impl TaggedStructure<'_> for AntiLagDataAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ANTI_LAG_DATA_AMD;
 }
 impl<'a> AntiLagDataAMD<'a> {
@@ -60515,7 +56560,7 @@ impl ::core::default::Default for AntiLagPresentationInfoAMD<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AntiLagPresentationInfoAMD<'a> {
+unsafe impl TaggedStructure<'_> for AntiLagPresentationInfoAMD<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::ANTI_LAG_PRESENTATION_INFO_AMD;
 }
 impl<'a> AntiLagPresentationInfoAMD<'a> {
@@ -60554,11 +56599,11 @@ impl ::core::default::Default for BindMemoryStatusKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindMemoryStatusKHR<'a> {
+unsafe impl TaggedStructure<'_> for BindMemoryStatusKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_MEMORY_STATUS_KHR;
 }
-unsafe impl Extends<BindBufferMemoryInfo<'_>> for BindMemoryStatusKHR<'_> {}
-unsafe impl Extends<BindImageMemoryInfo<'_>> for BindMemoryStatusKHR<'_> {}
+unsafe impl<'a> Extends<'a, BindBufferMemoryInfo<'a>> for BindMemoryStatusKHR<'a> {}
+unsafe impl<'a> Extends<'a, BindImageMemoryInfo<'a>> for BindMemoryStatusKHR<'a> {}
 impl<'a> BindMemoryStatusKHR<'a> {
     #[inline]
     pub fn result(mut self, result: &'a mut Result) -> Self {
@@ -60602,7 +56647,7 @@ impl ::core::default::Default for BindDescriptorSetsInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindDescriptorSetsInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for BindDescriptorSetsInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BIND_DESCRIPTOR_SETS_INFO_KHR;
 }
 impl<'a> BindDescriptorSetsInfoKHR<'a> {
@@ -60632,50 +56677,6 @@ impl<'a> BindDescriptorSetsInfoKHR<'a> {
         self.dynamic_offset_count = dynamic_offsets.len() as _;
         self.p_dynamic_offsets = dynamic_offsets.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -60710,7 +56711,7 @@ impl ::core::default::Default for PushConstantsInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PushConstantsInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PushConstantsInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PUSH_CONSTANTS_INFO_KHR;
 }
 impl<'a> PushConstantsInfoKHR<'a> {
@@ -60734,50 +56735,6 @@ impl<'a> PushConstantsInfoKHR<'a> {
         self.size = values.len() as _;
         self.p_values = values.as_ptr().cast();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -60812,7 +56769,7 @@ impl ::core::default::Default for PushDescriptorSetInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PushDescriptorSetInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PushDescriptorSetInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PUSH_DESCRIPTOR_SET_INFO_KHR;
 }
 impl<'a> PushDescriptorSetInfoKHR<'a> {
@@ -60836,50 +56793,6 @@ impl<'a> PushDescriptorSetInfoKHR<'a> {
         self.descriptor_write_count = descriptor_writes.len() as _;
         self.p_descriptor_writes = descriptor_writes.as_ptr();
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -60912,7 +56825,7 @@ impl ::core::default::Default for PushDescriptorSetWithTemplateInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PushDescriptorSetWithTemplateInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for PushDescriptorSetWithTemplateInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR;
 }
 impl<'a> PushDescriptorSetWithTemplateInfoKHR<'a> {
@@ -60938,50 +56851,6 @@ impl<'a> PushDescriptorSetWithTemplateInfoKHR<'a> {
     pub fn data(mut self, data: *const c_void) -> Self {
         self.p_data = data;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -61018,7 +56887,7 @@ impl ::core::default::Default for SetDescriptorBufferOffsetsInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SetDescriptorBufferOffsetsInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for SetDescriptorBufferOffsetsInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT;
 }
 impl<'a> SetDescriptorBufferOffsetsInfoEXT<'a> {
@@ -61049,50 +56918,6 @@ impl<'a> SetDescriptorBufferOffsetsInfoEXT<'a> {
         self.p_offsets = offsets.as_ptr();
         self
     }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
-    }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -61122,7 +56947,7 @@ impl ::core::default::Default for BindDescriptorBufferEmbeddedSamplersInfoEXT<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BindDescriptorBufferEmbeddedSamplersInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for BindDescriptorBufferEmbeddedSamplersInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::BIND_DESCRIPTOR_BUFFER_EMBEDDED_SAMPLERS_INFO_EXT;
 }
@@ -61141,50 +56966,6 @@ impl<'a> BindDescriptorBufferEmbeddedSamplersInfoEXT<'a> {
     pub fn set(mut self, set: u32) -> Self {
         self.set = set;
         self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the"]
-    #[doc = r" chain will look like `A -> D -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r" If `next` contains a pointer chain of its own, this function will panic.  Call"]
-    #[doc = r" `unsafe` [`Self::extend()`] to insert this chain instead."]
-    pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-        assert!(
-            next_base.p_next.is_null(),
-            "push() expects a struct without an existing p_next pointer chain (equal to NULL)"
-        );
-        next_base.p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
-    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
-    #[doc = r" valid extension structs can be pushed into the chain."]
-    #[doc = r" If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,"]
-    #[doc = r" then the chain will look like `A -> D -> E -> B -> C`."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring"]
-    #[doc = r" all non-`NULL` pointers to point to a valid Vulkan structure starting with the"]
-    #[doc = r" [`BaseOutStructure`] layout."]
-    #[doc = r""]
-    #[doc = r" The last struct in this chain (i.e. the one where `p_next` is `NULL`) must"]
-    #[doc = r" be writable memory, as its `p_next` field will be updated with the value of"]
-    #[doc = r" `self.p_next`."]
-    pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-        let last_next = ptr_chain_iter(next).last().unwrap();
-        (*last_next).p_next = self.p_next as _;
-        self.p_next = <*mut T>::cast(next);
-        self
-    }
-    #[doc(hidden)]
-    #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-    pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-        self.extend(next)
     }
 }
 #[repr(C)]
@@ -61211,11 +56992,14 @@ impl ::core::default::Default for PhysicalDeviceCubicClampFeaturesQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCubicClampFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCubicClampFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceCubicClampFeaturesQCOM<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCubicClampFeaturesQCOM<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCubicClampFeaturesQCOM<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceCubicClampFeaturesQCOM<'a> {}
 impl<'a> PhysicalDeviceCubicClampFeaturesQCOM<'a> {
     #[inline]
     pub fn cubic_range_clamp(mut self, cubic_range_clamp: bool) -> Self {
@@ -61247,12 +57031,15 @@ impl ::core::default::Default for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceYcbcrDegammaFeaturesQCOM<'a> {}
 impl<'a> PhysicalDeviceYcbcrDegammaFeaturesQCOM<'a> {
     #[inline]
     pub fn ycbcr_degamma(mut self, ycbcr_degamma: bool) -> Self {
@@ -61286,12 +57073,12 @@ impl ::core::default::Default for SamplerYcbcrConversionYcbcrDegammaCreateInfoQC
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for SamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM;
 }
-unsafe impl Extends<SamplerYcbcrConversionCreateInfo<'_>>
-    for SamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM<'_>
+unsafe impl<'a> Extends<'a, SamplerYcbcrConversionCreateInfo<'a>>
+    for SamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM<'a>
 {
 }
 impl<'a> SamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM<'a> {
@@ -61330,12 +57117,15 @@ impl ::core::default::Default for PhysicalDeviceCubicWeightsFeaturesQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCubicWeightsFeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCubicWeightsFeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceCubicWeightsFeaturesQCOM<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCubicWeightsFeaturesQCOM<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCubicWeightsFeaturesQCOM<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceCubicWeightsFeaturesQCOM<'a> {}
 impl<'a> PhysicalDeviceCubicWeightsFeaturesQCOM<'a> {
     #[inline]
     pub fn selectable_cubic_weights(mut self, selectable_cubic_weights: bool) -> Self {
@@ -61367,10 +57157,10 @@ impl ::core::default::Default for SamplerCubicWeightsCreateInfoQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerCubicWeightsCreateInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for SamplerCubicWeightsCreateInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM;
 }
-unsafe impl Extends<SamplerCreateInfo<'_>> for SamplerCubicWeightsCreateInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>> for SamplerCubicWeightsCreateInfoQCOM<'a> {}
 impl<'a> SamplerCubicWeightsCreateInfoQCOM<'a> {
     #[inline]
     pub fn cubic_weights(mut self, cubic_weights: CubicFilterWeightsQCOM) -> Self {
@@ -61402,10 +57192,10 @@ impl ::core::default::Default for BlitImageCubicWeightsInfoQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for BlitImageCubicWeightsInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for BlitImageCubicWeightsInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM;
 }
-unsafe impl Extends<BlitImageInfo2<'_>> for BlitImageCubicWeightsInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, BlitImageInfo2<'a>> for BlitImageCubicWeightsInfoQCOM<'a> {}
 impl<'a> BlitImageCubicWeightsInfoQCOM<'a> {
     #[inline]
     pub fn cubic_weights(mut self, cubic_weights: CubicFilterWeightsQCOM) -> Self {
@@ -61437,15 +57227,18 @@ impl ::core::default::Default for PhysicalDeviceImageProcessing2FeaturesQCOM<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageProcessing2FeaturesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageProcessing2FeaturesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceImageProcessing2FeaturesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageProcessing2FeaturesQCOM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageProcessing2FeaturesQCOM<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImageProcessing2FeaturesQCOM<'a>
+{
+}
 impl<'a> PhysicalDeviceImageProcessing2FeaturesQCOM<'a> {
     #[inline]
     pub fn texture_block_match2(mut self, texture_block_match2: bool) -> Self {
@@ -61477,12 +57270,12 @@ impl ::core::default::Default for PhysicalDeviceImageProcessing2PropertiesQCOM<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageProcessing2PropertiesQCOM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageProcessing2PropertiesQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceImageProcessing2PropertiesQCOM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceImageProcessing2PropertiesQCOM<'a>
 {
 }
 impl<'a> PhysicalDeviceImageProcessing2PropertiesQCOM<'a> {
@@ -61518,11 +57311,11 @@ impl ::core::default::Default for SamplerBlockMatchWindowCreateInfoQCOM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SamplerBlockMatchWindowCreateInfoQCOM<'a> {
+unsafe impl TaggedStructure<'_> for SamplerBlockMatchWindowCreateInfoQCOM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM;
 }
-unsafe impl Extends<SamplerCreateInfo<'_>> for SamplerBlockMatchWindowCreateInfoQCOM<'_> {}
+unsafe impl<'a> Extends<'a, SamplerCreateInfo<'a>> for SamplerBlockMatchWindowCreateInfoQCOM<'a> {}
 impl<'a> SamplerBlockMatchWindowCreateInfoQCOM<'a> {
     #[inline]
     pub fn window_extent(mut self, window_extent: Extent2D) -> Self {
@@ -61562,16 +57355,16 @@ impl ::core::default::Default for PhysicalDeviceDescriptorPoolOverallocationFeat
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceDescriptorPoolOverallocationFeaturesNV<'a> {
@@ -61605,12 +57398,12 @@ impl ::core::default::Default for PhysicalDeviceLayeredDriverPropertiesMSFT<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceLayeredDriverPropertiesMSFT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceLayeredDriverPropertiesMSFT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceLayeredDriverPropertiesMSFT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceLayeredDriverPropertiesMSFT<'a>
 {
 }
 impl<'a> PhysicalDeviceLayeredDriverPropertiesMSFT<'a> {
@@ -61646,15 +57439,18 @@ impl ::core::default::Default for PhysicalDevicePerStageDescriptorSetFeaturesNV<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDevicePerStageDescriptorSetFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDevicePerStageDescriptorSetFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDevicePerStageDescriptorSetFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDevicePerStageDescriptorSetFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDevicePerStageDescriptorSetFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDevicePerStageDescriptorSetFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDevicePerStageDescriptorSetFeaturesNV<'a> {
     #[inline]
     pub fn per_stage_descriptor_set(mut self, per_stage_descriptor_set: bool) -> Self {
@@ -61691,16 +57487,16 @@ impl ::core::default::Default for PhysicalDeviceExternalFormatResolveFeaturesAND
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalFormatResolveFeaturesANDROID<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalFormatResolveFeaturesANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceExternalFormatResolveFeaturesANDROID<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceExternalFormatResolveFeaturesANDROID<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceExternalFormatResolveFeaturesANDROID<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceExternalFormatResolveFeaturesANDROID<'a>
 {
 }
 impl<'a> PhysicalDeviceExternalFormatResolveFeaturesANDROID<'a> {
@@ -61738,12 +57534,12 @@ impl ::core::default::Default for PhysicalDeviceExternalFormatResolvePropertiesA
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceExternalFormatResolvePropertiesANDROID<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceExternalFormatResolvePropertiesANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceExternalFormatResolvePropertiesANDROID<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceExternalFormatResolvePropertiesANDROID<'a>
 {
 }
 impl<'a> PhysicalDeviceExternalFormatResolvePropertiesANDROID<'a> {
@@ -61797,12 +57593,12 @@ impl ::core::default::Default for AndroidHardwareBufferFormatResolvePropertiesAN
         }
     }
 }
-unsafe impl<'a> TaggedStructure for AndroidHardwareBufferFormatResolvePropertiesANDROID<'a> {
+unsafe impl TaggedStructure<'_> for AndroidHardwareBufferFormatResolvePropertiesANDROID<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID;
 }
-unsafe impl Extends<AndroidHardwareBufferPropertiesANDROID<'_>>
-    for AndroidHardwareBufferFormatResolvePropertiesANDROID<'_>
+unsafe impl<'a> Extends<'a, AndroidHardwareBufferPropertiesANDROID<'a>>
+    for AndroidHardwareBufferFormatResolvePropertiesANDROID<'a>
 {
 }
 impl<'a> AndroidHardwareBufferFormatResolvePropertiesANDROID<'a> {
@@ -61840,7 +57636,7 @@ impl ::core::default::Default for LatencySleepModeInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for LatencySleepModeInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for LatencySleepModeInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::LATENCY_SLEEP_MODE_INFO_NV;
 }
 impl<'a> LatencySleepModeInfoNV<'a> {
@@ -61886,7 +57682,7 @@ impl ::core::default::Default for LatencySleepInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for LatencySleepInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for LatencySleepInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::LATENCY_SLEEP_INFO_NV;
 }
 impl<'a> LatencySleepInfoNV<'a> {
@@ -61927,7 +57723,7 @@ impl ::core::default::Default for SetLatencyMarkerInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SetLatencyMarkerInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for SetLatencyMarkerInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SET_LATENCY_MARKER_INFO_NV;
 }
 impl<'a> SetLatencyMarkerInfoNV<'a> {
@@ -61968,7 +57764,7 @@ impl ::core::default::Default for GetLatencyMarkerInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for GetLatencyMarkerInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for GetLatencyMarkerInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::GET_LATENCY_MARKER_INFO_NV;
 }
 impl<'a> GetLatencyMarkerInfoNV<'a> {
@@ -62029,7 +57825,7 @@ impl ::core::default::Default for LatencyTimingsFrameReportNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for LatencyTimingsFrameReportNV<'a> {
+unsafe impl TaggedStructure<'_> for LatencyTimingsFrameReportNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::LATENCY_TIMINGS_FRAME_REPORT_NV;
 }
 impl<'a> LatencyTimingsFrameReportNV<'a> {
@@ -62128,7 +57924,7 @@ impl ::core::default::Default for OutOfBandQueueTypeInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for OutOfBandQueueTypeInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for OutOfBandQueueTypeInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::OUT_OF_BAND_QUEUE_TYPE_INFO_NV;
 }
 impl<'a> OutOfBandQueueTypeInfoNV<'a> {
@@ -62162,11 +57958,11 @@ impl ::core::default::Default for LatencySubmissionPresentIdNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for LatencySubmissionPresentIdNV<'a> {
+unsafe impl TaggedStructure<'_> for LatencySubmissionPresentIdNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::LATENCY_SUBMISSION_PRESENT_ID_NV;
 }
-unsafe impl Extends<SubmitInfo<'_>> for LatencySubmissionPresentIdNV<'_> {}
-unsafe impl Extends<SubmitInfo2<'_>> for LatencySubmissionPresentIdNV<'_> {}
+unsafe impl<'a> Extends<'a, SubmitInfo<'a>> for LatencySubmissionPresentIdNV<'a> {}
+unsafe impl<'a> Extends<'a, SubmitInfo2<'a>> for LatencySubmissionPresentIdNV<'a> {}
 impl<'a> LatencySubmissionPresentIdNV<'a> {
     #[inline]
     pub fn present_id(mut self, present_id: u64) -> Self {
@@ -62198,10 +57994,10 @@ impl ::core::default::Default for SwapchainLatencyCreateInfoNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for SwapchainLatencyCreateInfoNV<'a> {
+unsafe impl TaggedStructure<'_> for SwapchainLatencyCreateInfoNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::SWAPCHAIN_LATENCY_CREATE_INFO_NV;
 }
-unsafe impl Extends<SwapchainCreateInfoKHR<'_>> for SwapchainLatencyCreateInfoNV<'_> {}
+unsafe impl<'a> Extends<'a, SwapchainCreateInfoKHR<'a>> for SwapchainLatencyCreateInfoNV<'a> {}
 impl<'a> SwapchainLatencyCreateInfoNV<'a> {
     #[inline]
     pub fn latency_mode_enable(mut self, latency_mode_enable: bool) -> Self {
@@ -62235,10 +58031,10 @@ impl ::core::default::Default for LatencySurfaceCapabilitiesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for LatencySurfaceCapabilitiesNV<'a> {
+unsafe impl TaggedStructure<'_> for LatencySurfaceCapabilitiesNV<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::LATENCY_SURFACE_CAPABILITIES_NV;
 }
-unsafe impl Extends<SurfaceCapabilities2KHR<'_>> for LatencySurfaceCapabilitiesNV<'_> {}
+unsafe impl<'a> Extends<'a, SurfaceCapabilities2KHR<'a>> for LatencySurfaceCapabilitiesNV<'a> {}
 impl<'a> LatencySurfaceCapabilitiesNV<'a> {
     #[inline]
     pub fn present_modes(mut self, present_modes: &'a mut [PresentModeKHR]) -> Self {
@@ -62271,12 +58067,15 @@ impl ::core::default::Default for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCudaKernelLaunchFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceCudaKernelLaunchFeaturesNV<'a> {
     #[inline]
     pub fn cuda_kernel_launch_features(mut self, cuda_kernel_launch_features: bool) -> Self {
@@ -62310,12 +58109,12 @@ impl ::core::default::Default for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCudaKernelLaunchPropertiesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceCudaKernelLaunchPropertiesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceCudaKernelLaunchPropertiesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceCudaKernelLaunchPropertiesNV<'a> {
@@ -62354,12 +58153,18 @@ impl ::core::default::Default for DeviceQueueShaderCoreControlCreateInfoARM<'_> 
         }
     }
 }
-unsafe impl<'a> TaggedStructure for DeviceQueueShaderCoreControlCreateInfoARM<'a> {
+unsafe impl TaggedStructure<'_> for DeviceQueueShaderCoreControlCreateInfoARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::DEVICE_QUEUE_SHADER_CORE_CONTROL_CREATE_INFO_ARM;
 }
-unsafe impl Extends<DeviceQueueCreateInfo<'_>> for DeviceQueueShaderCoreControlCreateInfoARM<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for DeviceQueueShaderCoreControlCreateInfoARM<'_> {}
+unsafe impl<'a> Extends<'a, DeviceQueueCreateInfo<'a>>
+    for DeviceQueueShaderCoreControlCreateInfoARM<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for DeviceQueueShaderCoreControlCreateInfoARM<'a>
+{
+}
 impl<'a> DeviceQueueShaderCoreControlCreateInfoARM<'a> {
     #[inline]
     pub fn shader_core_count(mut self, shader_core_count: u32) -> Self {
@@ -62391,15 +58196,18 @@ impl ::core::default::Default for PhysicalDeviceSchedulingControlsFeaturesARM<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSchedulingControlsFeaturesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSchedulingControlsFeaturesARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceSchedulingControlsFeaturesARM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceSchedulingControlsFeaturesARM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceSchedulingControlsFeaturesARM<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceSchedulingControlsFeaturesARM<'a>
+{
+}
 impl<'a> PhysicalDeviceSchedulingControlsFeaturesARM<'a> {
     #[inline]
     pub fn scheduling_controls(mut self, scheduling_controls: bool) -> Self {
@@ -62431,12 +58239,12 @@ impl ::core::default::Default for PhysicalDeviceSchedulingControlsPropertiesARM<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceSchedulingControlsPropertiesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceSchedulingControlsPropertiesARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceSchedulingControlsPropertiesARM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceSchedulingControlsPropertiesARM<'a>
 {
 }
 impl<'a> PhysicalDeviceSchedulingControlsPropertiesARM<'a> {
@@ -62473,16 +58281,16 @@ impl ::core::default::Default for PhysicalDeviceRelaxedLineRasterizationFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'a>
 {
 }
 impl<'a> PhysicalDeviceRelaxedLineRasterizationFeaturesIMG<'a> {
@@ -62516,15 +58324,18 @@ impl ::core::default::Default for PhysicalDeviceRenderPassStripedFeaturesARM<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRenderPassStripedFeaturesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRenderPassStripedFeaturesARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceRenderPassStripedFeaturesARM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRenderPassStripedFeaturesARM<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRenderPassStripedFeaturesARM<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceRenderPassStripedFeaturesARM<'a>
+{
+}
 impl<'a> PhysicalDeviceRenderPassStripedFeaturesARM<'a> {
     #[inline]
     pub fn render_pass_striped(mut self, render_pass_striped: bool) -> Self {
@@ -62558,12 +58369,12 @@ impl ::core::default::Default for PhysicalDeviceRenderPassStripedPropertiesARM<'
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRenderPassStripedPropertiesARM<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRenderPassStripedPropertiesARM<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceRenderPassStripedPropertiesARM<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceRenderPassStripedPropertiesARM<'a>
 {
 }
 impl<'a> PhysicalDeviceRenderPassStripedPropertiesARM<'a> {
@@ -62605,7 +58416,7 @@ impl ::core::default::Default for RenderPassStripeInfoARM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassStripeInfoARM<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassStripeInfoARM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_STRIPE_INFO_ARM;
 }
 impl<'a> RenderPassStripeInfoARM<'a> {
@@ -62641,11 +58452,11 @@ impl ::core::default::Default for RenderPassStripeBeginInfoARM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassStripeBeginInfoARM<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassStripeBeginInfoARM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_STRIPE_BEGIN_INFO_ARM;
 }
-unsafe impl Extends<RenderingInfo<'_>> for RenderPassStripeBeginInfoARM<'_> {}
-unsafe impl Extends<RenderPassBeginInfo<'_>> for RenderPassStripeBeginInfoARM<'_> {}
+unsafe impl<'a> Extends<'a, RenderingInfo<'a>> for RenderPassStripeBeginInfoARM<'a> {}
+unsafe impl<'a> Extends<'a, RenderPassBeginInfo<'a>> for RenderPassStripeBeginInfoARM<'a> {}
 impl<'a> RenderPassStripeBeginInfoARM<'a> {
     #[inline]
     pub fn stripe_infos(mut self, stripe_infos: &'a [RenderPassStripeInfoARM<'a>]) -> Self {
@@ -62680,10 +58491,10 @@ impl ::core::default::Default for RenderPassStripeSubmitInfoARM<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderPassStripeSubmitInfoARM<'a> {
+unsafe impl TaggedStructure<'_> for RenderPassStripeSubmitInfoARM<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDER_PASS_STRIPE_SUBMIT_INFO_ARM;
 }
-unsafe impl Extends<CommandBufferSubmitInfo<'_>> for RenderPassStripeSubmitInfoARM<'_> {}
+unsafe impl<'a> Extends<'a, CommandBufferSubmitInfo<'a>> for RenderPassStripeSubmitInfoARM<'a> {}
 impl<'a> RenderPassStripeSubmitInfoARM<'a> {
     #[inline]
     pub fn stripe_semaphore_infos(
@@ -62719,16 +58530,16 @@ impl ::core::default::Default for PhysicalDeviceShaderMaximalReconvergenceFeatur
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR<'a> {
@@ -62764,15 +58575,18 @@ impl ::core::default::Default for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderSubgroupRotateFeaturesKHR<'a> {
     #[inline]
     pub fn shader_subgroup_rotate(mut self, shader_subgroup_rotate: bool) -> Self {
@@ -62812,15 +58626,18 @@ impl ::core::default::Default for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'_
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderExpectAssumeFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderExpectAssumeFeaturesKHR<'a> {
     #[inline]
     pub fn shader_expect_assume(mut self, shader_expect_assume: bool) -> Self {
@@ -62852,15 +58669,18 @@ impl ::core::default::Default for PhysicalDeviceShaderFloatControls2FeaturesKHR<
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderFloatControls2FeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderFloatControls2FeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderFloatControls2FeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderFloatControls2FeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderFloatControls2FeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderFloatControls2FeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderFloatControls2FeaturesKHR<'a> {
     #[inline]
     pub fn shader_float_controls2(mut self, shader_float_controls2: bool) -> Self {
@@ -62892,16 +58712,16 @@ impl ::core::default::Default for PhysicalDeviceDynamicRenderingLocalReadFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'a>
 {
 }
 impl<'a> PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR<'a> {
@@ -62937,11 +58757,17 @@ impl ::core::default::Default for RenderingAttachmentLocationInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingAttachmentLocationInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RenderingAttachmentLocationInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDERING_ATTACHMENT_LOCATION_INFO_KHR;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for RenderingAttachmentLocationInfoKHR<'_> {}
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>> for RenderingAttachmentLocationInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for RenderingAttachmentLocationInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for RenderingAttachmentLocationInfoKHR<'a>
+{
+}
 impl<'a> RenderingAttachmentLocationInfoKHR<'a> {
     #[inline]
     pub fn color_attachment_locations(mut self, color_attachment_locations: &'a [u32]) -> Self {
@@ -62980,11 +58806,17 @@ impl ::core::default::Default for RenderingInputAttachmentIndexInfoKHR<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for RenderingInputAttachmentIndexInfoKHR<'a> {
+unsafe impl TaggedStructure<'_> for RenderingInputAttachmentIndexInfoKHR<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR;
 }
-unsafe impl Extends<GraphicsPipelineCreateInfo<'_>> for RenderingInputAttachmentIndexInfoKHR<'_> {}
-unsafe impl Extends<CommandBufferInheritanceInfo<'_>> for RenderingInputAttachmentIndexInfoKHR<'_> {}
+unsafe impl<'a> Extends<'a, GraphicsPipelineCreateInfo<'a>>
+    for RenderingInputAttachmentIndexInfoKHR<'a>
+{
+}
+unsafe impl<'a> Extends<'a, CommandBufferInheritanceInfo<'a>>
+    for RenderingInputAttachmentIndexInfoKHR<'a>
+{
+}
 impl<'a> RenderingInputAttachmentIndexInfoKHR<'a> {
     #[inline]
     pub fn color_attachment_input_indices(
@@ -63033,15 +58865,18 @@ impl ::core::default::Default for PhysicalDeviceShaderQuadControlFeaturesKHR<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderQuadControlFeaturesKHR<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderQuadControlFeaturesKHR<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderQuadControlFeaturesKHR<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderQuadControlFeaturesKHR<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceShaderQuadControlFeaturesKHR<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderQuadControlFeaturesKHR<'a>
+{
+}
 impl<'a> PhysicalDeviceShaderQuadControlFeaturesKHR<'a> {
     #[inline]
     pub fn shader_quad_control(mut self, shader_quad_control: bool) -> Self {
@@ -63073,16 +58908,16 @@ impl ::core::default::Default for PhysicalDeviceShaderAtomicFloat16VectorFeature
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV<'a> {
@@ -63120,12 +58955,15 @@ impl ::core::default::Default for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceMapMemoryPlacedFeaturesEXT<'a> {}
 impl<'a> PhysicalDeviceMapMemoryPlacedFeaturesEXT<'a> {
     #[inline]
     pub fn memory_map_placed(mut self, memory_map_placed: bool) -> Self {
@@ -63167,12 +59005,12 @@ impl ::core::default::Default for PhysicalDeviceMapMemoryPlacedPropertiesEXT<'_>
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceMapMemoryPlacedPropertiesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceMapMemoryPlacedPropertiesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_MAP_MEMORY_PLACED_PROPERTIES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceMapMemoryPlacedPropertiesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceMapMemoryPlacedPropertiesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceMapMemoryPlacedPropertiesEXT<'a> {
@@ -63209,10 +59047,10 @@ impl ::core::default::Default for MemoryMapPlacedInfoEXT<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for MemoryMapPlacedInfoEXT<'a> {
+unsafe impl TaggedStructure<'_> for MemoryMapPlacedInfoEXT<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::MEMORY_MAP_PLACED_INFO_EXT;
 }
-unsafe impl Extends<MemoryMapInfoKHR<'_>> for MemoryMapPlacedInfoEXT<'_> {}
+unsafe impl<'a> Extends<'a, MemoryMapInfoKHR<'a>> for MemoryMapPlacedInfoEXT<'a> {}
 impl<'a> MemoryMapPlacedInfoEXT<'a> {
     #[inline]
     pub fn placed_address(mut self, placed_address: *mut c_void) -> Self {
@@ -63244,12 +59082,15 @@ impl ::core::default::Default for PhysicalDeviceRawAccessChainsFeaturesNV<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceRawAccessChainsFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceRawAccessChainsFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>> for PhysicalDeviceRawAccessChainsFeaturesNV<'_> {}
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceRawAccessChainsFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceRawAccessChainsFeaturesNV<'a>
+{
+}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>> for PhysicalDeviceRawAccessChainsFeaturesNV<'a> {}
 impl<'a> PhysicalDeviceRawAccessChainsFeaturesNV<'a> {
     #[inline]
     pub fn shader_raw_access_chains(mut self, shader_raw_access_chains: bool) -> Self {
@@ -63281,15 +59122,18 @@ impl ::core::default::Default for PhysicalDeviceCommandBufferInheritanceFeatures
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceCommandBufferInheritanceFeaturesNV<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceCommandBufferInheritanceFeaturesNV<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_COMMAND_BUFFER_INHERITANCE_FEATURES_NV;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceCommandBufferInheritanceFeaturesNV<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceCommandBufferInheritanceFeaturesNV<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceCommandBufferInheritanceFeaturesNV<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceCommandBufferInheritanceFeaturesNV<'a>
+{
+}
 impl<'a> PhysicalDeviceCommandBufferInheritanceFeaturesNV<'a> {
     #[inline]
     pub fn command_buffer_inheritance(mut self, command_buffer_inheritance: bool) -> Self {
@@ -63321,15 +59165,18 @@ impl ::core::default::Default for PhysicalDeviceImageAlignmentControlFeaturesMES
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageAlignmentControlFeaturesMESA<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageAlignmentControlFeaturesMESA<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceImageAlignmentControlFeaturesMESA<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceImageAlignmentControlFeaturesMESA<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>> for PhysicalDeviceImageAlignmentControlFeaturesMESA<'_> {}
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceImageAlignmentControlFeaturesMESA<'a>
+{
+}
 impl<'a> PhysicalDeviceImageAlignmentControlFeaturesMESA<'a> {
     #[inline]
     pub fn image_alignment_control(mut self, image_alignment_control: bool) -> Self {
@@ -63361,12 +59208,12 @@ impl ::core::default::Default for PhysicalDeviceImageAlignmentControlPropertiesM
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceImageAlignmentControlPropertiesMESA<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceImageAlignmentControlPropertiesMESA<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_PROPERTIES_MESA;
 }
-unsafe impl Extends<PhysicalDeviceProperties2<'_>>
-    for PhysicalDeviceImageAlignmentControlPropertiesMESA<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceProperties2<'a>>
+    for PhysicalDeviceImageAlignmentControlPropertiesMESA<'a>
 {
 }
 impl<'a> PhysicalDeviceImageAlignmentControlPropertiesMESA<'a> {
@@ -63400,10 +59247,10 @@ impl ::core::default::Default for ImageAlignmentControlCreateInfoMESA<'_> {
         }
     }
 }
-unsafe impl<'a> TaggedStructure for ImageAlignmentControlCreateInfoMESA<'a> {
+unsafe impl TaggedStructure<'_> for ImageAlignmentControlCreateInfoMESA<'_> {
     const STRUCTURE_TYPE: StructureType = StructureType::IMAGE_ALIGNMENT_CONTROL_CREATE_INFO_MESA;
 }
-unsafe impl Extends<ImageCreateInfo<'_>> for ImageAlignmentControlCreateInfoMESA<'_> {}
+unsafe impl<'a> Extends<'a, ImageCreateInfo<'a>> for ImageAlignmentControlCreateInfoMESA<'a> {}
 impl<'a> ImageAlignmentControlCreateInfoMESA<'a> {
     #[inline]
     pub fn maximum_requested_alignment(mut self, maximum_requested_alignment: u32) -> Self {
@@ -63435,16 +59282,16 @@ impl ::core::default::Default for PhysicalDeviceShaderReplicatedCompositesFeatur
         }
     }
 }
-unsafe impl<'a> TaggedStructure for PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'a> {
+unsafe impl TaggedStructure<'_> for PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'_> {
     const STRUCTURE_TYPE: StructureType =
         StructureType::PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT;
 }
-unsafe impl Extends<PhysicalDeviceFeatures2<'_>>
-    for PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, PhysicalDeviceFeatures2<'a>>
+    for PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'a>
 {
 }
-unsafe impl Extends<DeviceCreateInfo<'_>>
-    for PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'_>
+unsafe impl<'a> Extends<'a, DeviceCreateInfo<'a>>
+    for PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'a>
 {
 }
 impl<'a> PhysicalDeviceShaderReplicatedCompositesFeaturesEXT<'a> {

--- a/ash/tests/fail/long_lived_root_struct_borrow.rs
+++ b/ash/tests/fail/long_lived_root_struct_borrow.rs
@@ -1,4 +1,5 @@
 use ash::vk;
+use vk::AnyTaggedStructure as _;
 
 fn main() {
     let mut layers = vec![];

--- a/ash/tests/fail/long_lived_root_struct_borrow.stderr
+++ b/ash/tests/fail/long_lived_root_struct_borrow.stderr
@@ -1,23 +1,23 @@
 error[E0502]: cannot borrow `api` as immutable because it is also borrowed as mutable
-  --> tests/fail/long_lived_root_struct_borrow.rs:10:10
+  --> tests/fail/long_lived_root_struct_borrow.rs:11:10
    |
-7  |     let pdev_props = vk::PhysicalDeviceProperties2::default().push(&mut api);
+8  |     let pdev_props = vk::PhysicalDeviceProperties2::default().push(&mut api);
    |                                                                    -------- mutable borrow occurs here
 ...
-10 |     dbg!(&api);
+11 |     dbg!(&api);
    |          ^^^^ immutable borrow occurs here
 ...
-13 |     dbg!(pdev_props); // Holds a borrow on api and layers
+14 |     dbg!(pdev_props); // Holds a borrow on api and layers
    |          ---------- mutable borrow later used here
 
 error[E0502]: cannot borrow `layers` as immutable because it is also borrowed as mutable
-  --> tests/fail/long_lived_root_struct_borrow.rs:11:10
+  --> tests/fail/long_lived_root_struct_borrow.rs:12:10
    |
-6  |         vk::PhysicalDeviceLayeredApiPropertiesListKHR::default().layered_apis(&mut layers);
+7  |         vk::PhysicalDeviceLayeredApiPropertiesListKHR::default().layered_apis(&mut layers);
    |                                                                               ----------- mutable borrow occurs here
 ...
-11 |     dbg!(&layers);
+12 |     dbg!(&layers);
    |          ^^^^^^^ immutable borrow occurs here
-12 |
-13 |     dbg!(pdev_props); // Holds a borrow on api and layers
+13 |
+14 |     dbg!(pdev_props); // Holds a borrow on api and layers
    |          ---------- mutable borrow later used here

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -2012,7 +2012,6 @@ fn derive_debug(
 fn derive_getters_and_setters(
     struct_: &vkxml::Struct,
     members: &[PreprocessedMember<'_>],
-    root_structs: &HashSet<Ident>,
     has_lifetimes: &HashSet<Ident>,
 ) -> Option<TokenStream> {
     if &struct_.name == "VkBaseInStructure"
@@ -2330,74 +2329,6 @@ fn derive_getters_and_setters(
         })
     });
 
-    // The `p_next` field should only be considered if this struct is also a root struct
-    let root_struct_next_field = next_field.filter(|_| root_structs.contains(&name));
-
-    // We only implement a next method for root structs with a `pnext` field.
-    let next_function = if let Some(next_member) = root_struct_next_field {
-        let next_field = &next_member.vkxml_field;
-        assert_eq!(next_field.basetype, "void");
-        quote! {
-            /// Prepends the given extension struct between the root and the first pointer. This
-            /// method only exists on structs that can be passed to a function directly. Only
-            /// valid extension structs can be pushed into the chain.
-            /// If the chain looks like `A -> B -> C`, and you call `A.push(&mut D)`, then the
-            /// chain will look like `A -> D -> B -> C`.
-            ///
-            /// # Panics
-            /// If `next` contains a pointer chain of its own, this function will panic.  Call
-            /// `unsafe` [`Self::extend()`] to insert this chain instead.
-            pub fn push<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-                // SAFETY: All implementors of T are required to have the `BaseOutStructure` layout
-                let next_base = unsafe { &mut *<*mut T>::cast::<BaseOutStructure<'a>>(next) };
-                // `next` here can contain a pointer chain.  This function refuses to insert the struct,
-                // in favour of calling unsafe extend().
-                assert!(next_base.p_next.is_null(), "push() expects a struct without an existing p_next pointer chain (equal to NULL)");
-                next_base.p_next = self.p_next as _;
-                self.p_next = <*mut T>::cast(next);
-                self
-            }
-
-            /// Prepends the given extension struct between the root and the first pointer. This
-            /// method only exists on structs that can be passed to a function directly. Only
-            /// valid extension structs can be pushed into the chain.
-            /// If the chain looks like `A -> B -> C` and `D -> E`, and you call `A.extend(&mut D)`,
-            /// then the chain will look like `A -> D -> E -> B -> C`.
-            ///
-            /// # Safety
-            /// This function will walk the [`BaseOutStructure::p_next`] chain of `next`, requiring
-            /// all non-`NULL` pointers to point to a valid Vulkan structure starting with the
-            /// [`BaseOutStructure`] layout.
-            ///
-            /// The last struct in this chain (i.e. the one where `p_next` is `NULL`) must
-            /// be writable memory, as its `p_next` field will be updated with the value of
-            /// `self.p_next`.
-            pub unsafe fn extend<T: Extends<Self> + ?Sized>(mut self, next: &'a mut T) -> Self {
-                // `next` here can contain a pointer chain. This means that we must correctly
-                // attach he head to the root and the tail to the rest of the chain
-                // For example:
-                //
-                // next = A -> B
-                // Before: `Root -> C -> D -> E`
-                // After: `Root -> A -> B -> C -> D -> E`
-                //                 ^^^^^^
-                //                 next chain
-                let last_next = ptr_chain_iter(next).last().unwrap();
-                (*last_next).p_next = self.p_next as _;
-                self.p_next = <*mut T>::cast(next);
-                self
-            }
-
-            #[doc(hidden)]
-            #[deprecated = "Migrate to `push()` if `next` does not have an existing chain (i.e. `p_next` is `NULL`), `extend()` otherwise"]
-            pub unsafe fn push_next<T: Extends<Self> + ?Sized>(self, next: &'a mut T) -> Self {
-                self.extend(next)
-            }
-        }
-    } else {
-        quote!()
-    };
-
     let lifetime = has_lifetimes.contains(&name).then(|| quote!(<'a>));
 
     // If the struct extends something we need to implement the traits.
@@ -2408,7 +2339,7 @@ fn derive_getters_and_setters(
         .map(|extends| {
             let base = name_to_tokens(extends);
             // Extension structs always have a pNext, and therefore always have a lifetime.
-            quote!(unsafe impl Extends<#base<'_>> for #name<'_> {})
+            quote!(unsafe impl<'a> Extends<'a, #base<'a>> for #name<'a> {})
         });
 
     let impl_structure_type_trait = structure_type_field.map(|member| {
@@ -2422,7 +2353,7 @@ fn derive_getters_and_setters(
 
         let value = variant_ident("VkStructureType", value);
         quote! {
-            unsafe impl #lifetime TaggedStructure for #name #lifetime {
+            unsafe impl TaggedStructure<'_> for #name<'_> {
                 const STRUCTURE_TYPE: StructureType = StructureType::#value;
             }
         }
@@ -2434,8 +2365,6 @@ fn derive_getters_and_setters(
 
         impl #lifetime #name #lifetime {
             #(#setters)*
-
-            #next_function
         }
     };
 
@@ -2463,7 +2392,6 @@ struct PreprocessedMember<'a> {
 pub fn generate_struct(
     struct_: &vkxml::Struct,
     vk_parse_types: &HashMap<String, &vk_parse::Type>,
-    root_structs: &HashSet<Ident>,
     union_types: &HashSet<&str>,
     has_lifetimes: &HashSet<Ident>,
 ) -> TokenStream {
@@ -2599,7 +2527,7 @@ pub fn generate_struct(
     let debug_tokens = derive_debug(struct_, &members, union_types, has_lifetime);
     let default_tokens = derive_default(struct_, &members, has_lifetime);
     let send_sync_tokens = derive_send_sync(struct_, has_lifetime);
-    let setter_tokens = derive_getters_and_setters(struct_, &members, root_structs, has_lifetimes);
+    let setter_tokens = derive_getters_and_setters(struct_, &members, has_lifetimes);
     let manual_derive_tokens = manual_derives(struct_);
     let dbg_str = if debug_tokens.is_none() {
         quote!(#[cfg_attr(feature = "debug", derive(Debug))])
@@ -2709,25 +2637,6 @@ fn generate_union(union: &vkxml::Union, has_lifetimes: &HashSet<Ident>) -> Token
         }
     }
 }
-/// Root structs are all structs that are extended by other structs.
-pub fn root_structs(
-    definitions: &[&vk_parse::Type],
-    allowed_types: &HashSet<&str>,
-) -> HashSet<Ident> {
-    // Loop over all structs and collect their extends
-    definitions
-        .iter()
-        .filter(|type_| {
-            type_
-                .name
-                .as_ref()
-                .is_some_and(|name| allowed_types.contains(name.as_str()))
-        })
-        .filter_map(|type_| type_.structextends.as_ref())
-        .flat_map(|e| e.split(','))
-        .map(name_to_tokens)
-        .collect()
-}
 pub fn generate_definition_vk_parse(
     definition: &vk_parse::Type,
     allowed_types: &HashSet<&str>,
@@ -2753,7 +2662,6 @@ pub fn generate_definition(
     definition: &vkxml::DefinitionsElement,
     allowed_types: &HashSet<&str>,
     union_types: &HashSet<&str>,
-    root_structs: &HashSet<Ident>,
     has_lifetimes: &HashSet<Ident>,
     vk_parse_types: &HashMap<String, &vk_parse::Type>,
     bitflags_cache: &mut HashSet<Ident>,
@@ -2771,7 +2679,6 @@ pub fn generate_definition(
             Some(generate_struct(
                 struct_,
                 vk_parse_types,
-                root_structs,
                 union_types,
                 has_lifetimes,
             ))
@@ -3358,8 +3265,6 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         })
         .collect();
 
-    let root_structs = root_structs(&vk_parse_types, &required_types);
-
     let vk_parse_types = vk_parse_types
         .into_iter()
         .filter_map(|t| t.name.clone().map(|n| (n, t)))
@@ -3371,7 +3276,6 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
                 def,
                 &required_types,
                 &union_types,
-                &root_structs,
                 &has_lifetimes,
                 &vk_parse_types,
                 &mut bitflags_cache,
@@ -3439,8 +3343,8 @@ pub fn write_source_code<P: AsRef<Path>>(vk_headers_dir: &Path, src_dir: P) {
         use super::native::*;
         use super::platform_types::*;
         use super::{
-            ptr_chain_iter, wrap_c_str_slice_until_nul, write_c_str_slice_with_nul,
-            CStrTooLargeForStaticArray, Extends, Handle, Packed24_8, TaggedStructure,
+            wrap_c_str_slice_until_nul, write_c_str_slice_with_nul, CStrTooLargeForStaticArray, Extends,
+            Handle, Packed24_8, TaggedStructure,
         };
         use core::ffi::*;
         use core::fmt;


### PR DESCRIPTION
Having these functions generated for every root struct in our definitions file contributes to significant bloat, in part because of their massive documentation comments and not containing any generator-dynamic code or identifiers.

Now that `trait Extends{Root}` was generalized into a single `trait Extends<Root>` with the root structure as generic argument, it becomes possible to build on top of that and define a default trait function on every Vulkan structure.  These functions require the "pushed" type to derive `Extends<Self>`, hence limiting the function to be called without ever having to track if the root structure is being extended.
