### PR TITLE
Add a DispatchableHandle trait to allow bypassing the integer to pointer

### DIFF
--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -30,6 +30,12 @@ pub mod native;
 mod platform_types;
 pub use platform_types::*;
 
+pub trait DispatchableHandle: Handle {
+    // We choose to use a pointer type for the parameter to avoid possible integer-to-pointer cast,
+    // to keep the pointer provenance. See details at https://github.com/ash-rs/ash/issues/996.
+    fn from_raw_ptr(_: *mut u8) -> Self;
+}
+
 pub trait Handle: Sized {
     const TYPE: ObjectType;
     fn as_raw(self) -> u64;

--- a/ash/src/vk/macros.rs
+++ b/ash/src/vk/macros.rs
@@ -141,6 +141,11 @@ macro_rules! define_handle {
                 Self(x as _)
             }
         }
+        impl $crate::vk::DispatchableHandle for $name {
+            fn from_raw_ptr(x: *mut u8) -> Self {
+                Self(x)
+            }
+        }
         unsafe impl Send for $name {}
         unsafe impl Sync for $name {}
         impl $name {


### PR DESCRIPTION
... so that Handle::from_raw is more friendly to miri tests with strict provenance.

Closes #996