### PR TITLE
ash: Enable `mostly-unused` hint to speed up compilation

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -44,3 +44,6 @@ no-dev-version = true
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[hints]
+mostly-unused = true


### PR DESCRIPTION
Rust recently introduced the `mostly-unused` hint to speed up compilation of large crates where a significant portion of the contents are unlikely to be used concurrently.  `ash` is such a crate, which takes quite long to compile relative to the amount and kind of abstraction it provides, simply caused by the vastness of the Vulkan API (and possible remaining inefficiencies in our generated code).  This hint helps the compiler defer code generation until it knows it is definitely referenced and used, much like generics and `#[inline]` (the latter is already used consistently across this crate).  All in all this new hint [reduces compile time of the `ash` crate by about 8%](https://github.com/rust-lang/cargo/issues/15644#issuecomment-3172739856).

It however requires the use of a `nightly` compiler and passing of the `-Zprofile-hint-mostly-unused` flag.  The newly introduced `[hints]` table is not a syntax or parsing error on older compilers, but does issue a matching `unused manifest key: hints` warning.  We should decide whether to merge this flag now and ignore that warning while developing, allowing users to automatically take advantage of this annotation when future Rust versions enable it automatically.  Consumer crates can also configure it directly in their `[profile]` table however.

https://blog.rust-lang.org/inside-rust/2025/07/15/call-for-testing-hint-mostly-unused/
