### PR TITLE
docs: Replace gfx-rs with wgpu in libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ cargo run -p ash-examples --bin texture
 
 ### Libraries that use ash
 
-- [gfx-rs](https://github.com/gfx-rs/gfx) - gfx-rs is a low-level, cross-platform graphics abstraction library in Rust.
+- [wgpu](https://github.com/gfx-rs/wgpu) - A cross-platform, safe, pure-Rust graphics API.
 
 ## A thanks to
 


### PR DESCRIPTION
gfx-rs has been deprecated for quite some time, and wgpu is it's successor. Also wgpu is probably the most widely-used project that depends on ash (since it is used by Firefox, Bevy & countless other projects).