### PR TITLE
ash-window: Keep loaded fns around via new `SurfaceFactory` object

### DIFF
--- a/ash-examples/src/lib.rs
+++ b/ash-examples/src/lib.rs
@@ -232,7 +232,7 @@ impl ExampleBase {
                 .collect();
 
             let mut extension_names =
-                ash_window::enumerate_required_extensions(window.display_handle()?.as_raw())
+                ash_window::enumerate_required_extensions(event_loop.display_handle()?.as_raw())
                     .unwrap()
                     .to_vec();
             extension_names.push(debug_utils::NAME.as_ptr());
@@ -284,18 +284,21 @@ impl ExampleBase {
             let debug_call_back = debug_utils_loader
                 .create_debug_utils_messenger(&debug_info, None)
                 .unwrap();
-            let surface = ash_window::create_surface(
+
+            let surface_factory = ash_window::SurfaceFactory::new(
                 &entry,
                 &instance,
-                window.display_handle()?.as_raw(),
-                window.window_handle()?.as_raw(),
-                None,
+                event_loop.display_handle()?.as_raw(),
             )
             .unwrap();
+            let surface = surface_factory
+                .create_surface(window.window_handle()?.as_raw(), None)
+                .unwrap();
+            let surface_loader = surface::Instance::load(&entry, &instance);
+
             let pdevices = instance
                 .enumerate_physical_devices()
                 .expect("Physical device error");
-            let surface_loader = surface::Instance::load(&entry, &instance);
             let (pdevice, queue_family_index) = pdevices
                 .iter()
                 .find_map(|pdevice| {

--- a/ash-window/Changelog.md
+++ b/ash-window/Changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Keep loaded `Surface` extensions around via a new `SurfaceFactory` object on which `create_surface()` is called (#1019)
+
 ## [0.13.0] - 2024-03-31
 
 - Bumped MSRV from 1.59 to 1.69 for `winit 0.28` and `raw-window-handle 0.5.1`, and `CStr::from_bytes_until_nul`. (#709, #716, #746)


### PR DESCRIPTION
Fixes #974

Even though `create_surface()` is typically off the hot path, we're repeatedly loading all platform-specific surface function pointers each time a new surface has to be created (sometimes for multiple windows, and on Android after every suspend-resume cycle when the app becomes invisible).  [In a subsequent patch](https://github.com/ash-rs/ash/pull/774) these loaded extensions can be used to call their respective `get_present_support()` without reloading the entire function-pointer struct too.

Additionally some users seem to be confused about object lifetimes when seeing this `Instance::new()` being dropped inside the implementation. This patch only marginally addresses that and users are more than free to just drop their `SurfaceFactory` object if no longer used (or recreate it later) without having any impact on the "parent/child relationship" mentioned in the `fn create_surface()` documentation.

For now the choice has been made to store the passed `DisplayHandle` field with the enum variant when used in `create_surface()` to reduce ambiguity by not requiring it to be passed again.  The user might still pass an incompatible `WindowHandle` in which case this returns `ERROR_EXTENSION_NOT_PRESENT`.
