### PR TITLE
Fix vk::TransformMatrixKHR

### DIFF
--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -37135,7 +37135,7 @@ impl AabbPositionsKHR {
 #[doc = "<https://docs.vulkan.org/refpages/latest/refpages/source/VkTransformMatrixKHR.html>"]
 #[must_use]
 pub struct TransformMatrixKHR {
-    pub matrix: [[f32; 3]; 4],
+    pub matrix: [[f32; 4]; 3],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -2476,7 +2476,7 @@ pub fn generate_struct(
             #[doc = #khronos_link]
             #[must_use]
             pub struct TransformMatrixKHR {
-                pub matrix: [[f32; 3]; 4],
+                pub matrix: [[f32; 4]; 3],
             }
         };
     }


### PR DESCRIPTION
This is a regression caused by #951.

> matrix is a 3x4 row-major affine transformation matrix.

So the matrix should have 3 rows, each row with 4 elements.

After #951, to convert a `glam::Affine3A` into ` vk::TransformMatrixKHR` you'd write
```rs
pub fn glam_to_vk_transform(affine: Affine3A) -> vk::TransformMatrixKHR {
    // affine.matrix3 is column-major
    let x = &affine.matrix3.x_axis; // first column
    let y = &affine.matrix3.y_axis; // second column
    let z = &affine.matrix3.z_axis; // third column
    let w = &affine.translation;
    vk::TransformMatrixKHR {
        // row major
        matrix: [[x.x, y.x, z.x], [w.x, x.y, y.y], [z.y, w.y, x.z], [y.z, z.z, w.z]], // This is clearly wrong
    }
}
```

This is clearly wrong. This PR fixes it by correcting the array dimensions.
- Alternatively, just keep the flat array structure as before.