### PR TITLE
Handle extension-wide `deprecatedby`/`supersededby` attributes

### DIFF
--- a/ash/src/extensions_generated.rs
+++ b/ash/src/extensions_generated.rs
@@ -129,6 +129,7 @@ pub mod amd {
         }
     }
     #[doc = "VK_AMD_negative_viewport_height"]
+    #[deprecated = "Obsoleted by VK_KHR_maintenance1"]
     pub mod negative_viewport_height {
         pub use {
             crate::vk::AMD_NEGATIVE_VIEWPORT_HEIGHT_NAME as NAME,
@@ -136,6 +137,7 @@ pub mod amd {
         };
     }
     #[doc = "VK_AMD_gpu_shader_half_float"]
+    #[deprecated = "Deprecated by VK_KHR_shader_float16_int8"]
     pub mod gpu_shader_half_float {
         pub use {
             crate::vk::AMD_GPU_SHADER_HALF_FLOAT_NAME as NAME,
@@ -231,6 +233,7 @@ pub mod amd {
         };
     }
     #[doc = "VK_AMD_gpu_shader_int16"]
+    #[deprecated = "Deprecated by VK_KHR_shader_float16_int8"]
     pub mod gpu_shader_int16 {
         pub use {
             crate::vk::AMD_GPU_SHADER_INT16_NAME as NAME,
@@ -2225,6 +2228,7 @@ pub mod arm {
 #[doc = "Extensions tagged EXT"]
 pub mod ext {
     #[doc = "VK_EXT_debug_report"]
+    #[deprecated = "Deprecated by VK_EXT_debug_utils"]
     pub mod debug_report {
         use crate::vk::*;
         use core::ffi::*;
@@ -2689,6 +2693,7 @@ pub mod ext {
         }
     }
     #[doc = "VK_EXT_validation_flags"]
+    #[deprecated = "Deprecated by VK_EXT_layer_settings"]
     pub mod validation_flags {
         pub use {
             crate::vk::EXT_VALIDATION_FLAGS_NAME as NAME,
@@ -2696,6 +2701,7 @@ pub mod ext {
         };
     }
     #[doc = "VK_EXT_shader_subgroup_ballot"]
+    #[deprecated = "Deprecated by VK_VERSION_1_2"]
     pub mod shader_subgroup_ballot {
         pub use {
             crate::vk::EXT_SHADER_SUBGROUP_BALLOT_NAME as NAME,
@@ -2703,6 +2709,7 @@ pub mod ext {
         };
     }
     #[doc = "VK_EXT_shader_subgroup_vote"]
+    #[deprecated = "Deprecated by VK_VERSION_1_1"]
     pub mod shader_subgroup_vote {
         pub use {
             crate::vk::EXT_SHADER_SUBGROUP_VOTE_NAME as NAME,
@@ -4867,6 +4874,7 @@ pub mod ext {
         };
     }
     #[doc = "VK_EXT_buffer_device_address"]
+    #[deprecated = "Deprecated by VK_KHR_buffer_device_address"]
     pub mod buffer_device_address {
         use crate::vk::*;
         use core::ffi::*;
@@ -5010,6 +5018,7 @@ pub mod ext {
         };
     }
     #[doc = "VK_EXT_validation_features"]
+    #[deprecated = "Deprecated by VK_EXT_layer_settings"]
     pub mod validation_features {
         pub use {
             crate::vk::EXT_VALIDATION_FEATURES_NAME as NAME,
@@ -6358,6 +6367,7 @@ pub mod ext {
         }
     }
     #[doc = "VK_EXT_descriptor_buffer"]
+    #[deprecated = "Deprecated by VK_EXT_descriptor_heap"]
     pub mod descriptor_buffer {
         use crate::vk::*;
         use core::ffi::*;
@@ -11812,6 +11822,7 @@ pub mod img {
         };
     }
     #[doc = "VK_IMG_format_pvrtc"]
+    #[deprecated = "Deprecated by "]
     pub mod format_pvrtc {
         pub use {
             crate::vk::IMG_FORMAT_PVRTC_NAME as NAME,
@@ -20701,6 +20712,7 @@ pub mod msft {
 #[doc = "Extensions tagged MVK"]
 pub mod mvk {
     #[doc = "VK_MVK_ios_surface"]
+    #[deprecated = "Deprecated by VK_EXT_metal_surface"]
     pub mod ios_surface {
         use crate::vk::*;
         use core::ffi::*;
@@ -20769,6 +20781,7 @@ pub mod mvk {
         }
     }
     #[doc = "VK_MVK_macos_surface"]
+    #[deprecated = "Deprecated by VK_EXT_metal_surface"]
     pub mod macos_surface {
         use crate::vk::*;
         use core::ffi::*;
@@ -20909,6 +20922,7 @@ pub mod nn {
 #[doc = "Extensions tagged NV"]
 pub mod nv {
     #[doc = "VK_NV_glsl_shader"]
+    #[deprecated = "Deprecated by "]
     pub mod glsl_shader {
         pub use {
             crate::vk::NV_GLSL_SHADER_NAME as NAME,
@@ -20916,6 +20930,7 @@ pub mod nv {
         };
     }
     #[doc = "VK_NV_dedicated_allocation"]
+    #[deprecated = "Deprecated by VK_KHR_dedicated_allocation"]
     pub mod dedicated_allocation {
         pub use {
             crate::vk::NV_DEDICATED_ALLOCATION_NAME as NAME,
@@ -20930,6 +20945,7 @@ pub mod nv {
         };
     }
     #[doc = "VK_NV_external_memory_capabilities"]
+    #[deprecated = "Deprecated by VK_KHR_external_memory_capabilities"]
     pub mod external_memory_capabilities {
         use crate::vk::*;
         use core::ffi::*;
@@ -21005,6 +21021,7 @@ pub mod nv {
         }
     }
     #[doc = "VK_NV_external_memory"]
+    #[deprecated = "Deprecated by VK_KHR_external_memory"]
     pub mod external_memory {
         pub use {
             crate::vk::NV_EXTERNAL_MEMORY_NAME as NAME,
@@ -21012,6 +21029,7 @@ pub mod nv {
         };
     }
     #[doc = "VK_NV_external_memory_win32"]
+    #[deprecated = "Deprecated by VK_KHR_external_memory_win32"]
     pub mod external_memory_win32 {
         use crate::vk::*;
         use core::ffi::*;
@@ -21326,6 +21344,7 @@ pub mod nv {
         }
     }
     #[doc = "VK_NV_ray_tracing"]
+    #[deprecated = "Deprecated by VK_KHR_ray_tracing_pipeline"]
     pub mod ray_tracing {
         use crate::vk::*;
         use core::ffi::*;
@@ -22767,6 +22786,7 @@ pub mod nv {
     }
     #[doc = "VK_NV_displacement_micromap"]
     #[cfg(feature = "provisional")]
+    #[deprecated = "Deprecated by VK_NV_cluster_acceleration_structure"]
     pub mod displacement_micromap {
         pub use {
             crate::vk::NV_DISPLACEMENT_MICROMAP_NAME as NAME,
@@ -23596,6 +23616,7 @@ pub mod nv {
         }
     }
     #[doc = "VK_NV_per_stage_descriptor_set"]
+    #[deprecated = "Deprecated by VK_EXT_descriptor_heap"]
     pub mod per_stage_descriptor_set {
         pub use {
             crate::vk::NV_PER_STAGE_DESCRIPTOR_SET_NAME as NAME,

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -5787,8 +5787,10 @@ pub type PFN_vkGetSwapchainGrallocUsage2ANDROID = unsafe extern "system" fn(
     gralloc_consumer_usage: *mut u64,
     gralloc_producer_usage: *mut u64,
 ) -> Result;
+#[deprecated = "Deprecated by VK_EXT_debug_utils"]
 pub const EXT_DEBUG_REPORT_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_debug_report\0") };
+#[deprecated = "Deprecated by VK_EXT_debug_utils"]
 pub const EXT_DEBUG_REPORT_SPEC_VERSION: u32 = 10u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateDebugReportCallbackEXT = unsafe extern "system" fn(
@@ -5814,8 +5816,10 @@ pub type PFN_vkDebugReportMessageEXT = unsafe extern "system" fn(
     p_layer_prefix: *const c_char,
     p_message: *const c_char,
 );
+#[deprecated = "Deprecated by "]
 pub const NV_GLSL_SHADER_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_glsl_shader\0") };
+#[deprecated = "Deprecated by "]
 pub const NV_GLSL_SHADER_SPEC_VERSION: u32 = 1u32;
 pub const EXT_DEPTH_RANGE_UNRESTRICTED_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_depth_range_unrestricted\0") };
@@ -5948,8 +5952,10 @@ pub type PFN_vkCmdDecodeVideoKHR = unsafe extern "system" fn(
 pub const AMD_GCN_SHADER_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gcn_shader\0") };
 pub const AMD_GCN_SHADER_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_KHR_dedicated_allocation"]
 pub const NV_DEDICATED_ALLOCATION_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_dedicated_allocation\0") };
+#[deprecated = "Deprecated by VK_KHR_dedicated_allocation"]
 pub const NV_DEDICATED_ALLOCATION_SPEC_VERSION: u32 = 1u32;
 pub const EXT_TRANSFORM_FEEDBACK_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_transform_feedback\0") };
@@ -6092,11 +6098,15 @@ pub type PFN_vkCmdDrawIndexedIndirectCount = unsafe extern "system" fn(
     max_draw_count: u32,
     stride: u32,
 );
+#[deprecated = "Obsoleted by VK_KHR_maintenance1"]
 pub const AMD_NEGATIVE_VIEWPORT_HEIGHT_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMD_negative_viewport_height\0") };
+#[deprecated = "Obsoleted by VK_KHR_maintenance1"]
 pub const AMD_NEGATIVE_VIEWPORT_HEIGHT_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_KHR_shader_float16_int8"]
 pub const AMD_GPU_SHADER_HALF_FLOAT_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gpu_shader_half_float\0") };
+#[deprecated = "Deprecated by VK_KHR_shader_float16_int8"]
 pub const AMD_GPU_SHADER_HALF_FLOAT_SPEC_VERSION: u32 = 2u32;
 pub const AMD_SHADER_BALLOT_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_ballot\0") };
@@ -6154,11 +6164,15 @@ pub const NV_CORNER_SAMPLED_IMAGE_SPEC_VERSION: u32 = 2u32;
 pub const KHR_MULTIVIEW_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_multiview\0") };
 pub const KHR_MULTIVIEW_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by "]
 pub const IMG_FORMAT_PVRTC_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_IMG_format_pvrtc\0") };
+#[deprecated = "Deprecated by "]
 pub const IMG_FORMAT_PVRTC_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_KHR_external_memory_capabilities"]
 pub const NV_EXTERNAL_MEMORY_CAPABILITIES_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory_capabilities\0") };
+#[deprecated = "Deprecated by VK_KHR_external_memory_capabilities"]
 pub const NV_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION: u32 = 1u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV =
@@ -6172,11 +6186,15 @@ pub type PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV =
         external_handle_type: ExternalMemoryHandleTypeFlagsNV,
         p_external_image_format_properties: *mut ExternalImageFormatPropertiesNV,
     ) -> Result;
+#[deprecated = "Deprecated by VK_KHR_external_memory"]
 pub const NV_EXTERNAL_MEMORY_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory\0") };
+#[deprecated = "Deprecated by VK_KHR_external_memory"]
 pub const NV_EXTERNAL_MEMORY_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_KHR_external_memory_win32"]
 pub const NV_EXTERNAL_MEMORY_WIN32_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory_win32\0") };
+#[deprecated = "Deprecated by VK_KHR_external_memory_win32"]
 pub const NV_EXTERNAL_MEMORY_WIN32_SPEC_VERSION: u32 = 1u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetMemoryWin32HandleNV = unsafe extern "system" fn(
@@ -6255,8 +6273,10 @@ pub type PFN_vkCmdDispatchBase = unsafe extern "system" fn(
     group_count_y: u32,
     group_count_z: u32,
 );
+#[deprecated = "Deprecated by VK_EXT_layer_settings"]
 pub const EXT_VALIDATION_FLAGS_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_validation_flags\0") };
+#[deprecated = "Deprecated by VK_EXT_layer_settings"]
 pub const EXT_VALIDATION_FLAGS_SPEC_VERSION: u32 = 3u32;
 pub const NN_VI_SURFACE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NN_vi_surface\0") };
@@ -6271,11 +6291,15 @@ pub type PFN_vkCreateViSurfaceNN = unsafe extern "system" fn(
 pub const KHR_SHADER_DRAW_PARAMETERS_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_draw_parameters\0") };
 pub const KHR_SHADER_DRAW_PARAMETERS_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_VERSION_1_2"]
 pub const EXT_SHADER_SUBGROUP_BALLOT_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_subgroup_ballot\0") };
+#[deprecated = "Deprecated by VK_VERSION_1_2"]
 pub const EXT_SHADER_SUBGROUP_BALLOT_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_VERSION_1_1"]
 pub const EXT_SHADER_SUBGROUP_VOTE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_subgroup_vote\0") };
+#[deprecated = "Deprecated by VK_VERSION_1_1"]
 pub const EXT_SHADER_SUBGROUP_VOTE_SPEC_VERSION: u32 = 1u32;
 pub const EXT_TEXTURE_COMPRESSION_ASTC_HDR_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_texture_compression_astc_hdr\0") };
@@ -6754,8 +6778,10 @@ pub type PFN_vkGetDisplayPlaneCapabilities2KHR = unsafe extern "system" fn(
     p_display_plane_info: *const DisplayPlaneInfo2KHR<'_>,
     p_capabilities: *mut DisplayPlaneCapabilities2KHR<'_>,
 ) -> Result;
+#[deprecated = "Deprecated by VK_EXT_metal_surface"]
 pub const MVK_IOS_SURFACE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_MVK_ios_surface\0") };
+#[deprecated = "Deprecated by VK_EXT_metal_surface"]
 pub const MVK_IOS_SURFACE_SPEC_VERSION: u32 = 3u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateIOSSurfaceMVK = unsafe extern "system" fn(
@@ -6764,8 +6790,10 @@ pub type PFN_vkCreateIOSSurfaceMVK = unsafe extern "system" fn(
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
+#[deprecated = "Deprecated by VK_EXT_metal_surface"]
 pub const MVK_MACOS_SURFACE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_MVK_macos_surface\0") };
+#[deprecated = "Deprecated by VK_EXT_metal_surface"]
 pub const MVK_MACOS_SURFACE_SPEC_VERSION: u32 = 3u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateMacOSSurfaceMVK = unsafe extern "system" fn(
@@ -6858,8 +6886,10 @@ pub const EXT_SAMPLER_FILTER_MINMAX_SPEC_VERSION: u32 = 2u32;
 pub const KHR_STORAGE_BUFFER_STORAGE_CLASS_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_storage_buffer_storage_class\0") };
 pub const KHR_STORAGE_BUFFER_STORAGE_CLASS_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_KHR_shader_float16_int8"]
 pub const AMD_GPU_SHADER_INT16_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gpu_shader_int16\0") };
+#[deprecated = "Deprecated by VK_KHR_shader_float16_int8"]
 pub const AMD_GPU_SHADER_INT16_SPEC_VERSION: u32 = 2u32;
 #[cfg(feature = "provisional")]
 pub const AMDX_SHADER_ENQUEUE_NAME: &CStr =
@@ -7341,8 +7371,10 @@ pub type PFN_vkCmdSetCoarseSampleOrderNV = unsafe extern "system" fn(
     custom_sample_order_count: u32,
     p_custom_sample_orders: *const CoarseSampleOrderCustomNV<'_>,
 );
+#[deprecated = "Deprecated by VK_KHR_ray_tracing_pipeline"]
 pub const NV_RAY_TRACING_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_ray_tracing\0") };
+#[deprecated = "Deprecated by VK_KHR_ray_tracing_pipeline"]
 pub const NV_RAY_TRACING_SPEC_VERSION: u32 = 3u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCreateAccelerationStructureNV = unsafe extern "system" fn(
@@ -7842,8 +7874,10 @@ pub const NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_SPEC_VERSION: u32 = 1u32;
 pub const KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_separate_depth_stencil_layouts\0") };
 pub const KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_KHR_buffer_device_address"]
 pub const EXT_BUFFER_DEVICE_ADDRESS_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_buffer_device_address\0") };
+#[deprecated = "Deprecated by VK_KHR_buffer_device_address"]
 pub const EXT_BUFFER_DEVICE_ADDRESS_SPEC_VERSION: u32 = 2u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetBufferDeviceAddress = unsafe extern "system" fn(
@@ -7862,8 +7896,10 @@ pub type PFN_vkGetPhysicalDeviceToolProperties = unsafe extern "system" fn(
 pub const EXT_SEPARATE_STENCIL_USAGE_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_separate_stencil_usage\0") };
 pub const EXT_SEPARATE_STENCIL_USAGE_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_EXT_layer_settings"]
 pub const EXT_VALIDATION_FEATURES_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_validation_features\0") };
+#[deprecated = "Deprecated by VK_EXT_layer_settings"]
 pub const EXT_VALIDATION_FEATURES_SPEC_VERSION: u32 = 6u32;
 pub const KHR_PRESENT_WAIT_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_present_wait\0") };
@@ -8443,8 +8479,10 @@ pub type PFN_vkQueueSubmit2 = unsafe extern "system" fn(
     p_submits: *const SubmitInfo2<'_>,
     fence: Fence,
 ) -> Result;
+#[deprecated = "Deprecated by VK_EXT_descriptor_heap"]
 pub const EXT_DESCRIPTOR_BUFFER_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_EXT_descriptor_buffer\0") };
+#[deprecated = "Deprecated by VK_EXT_descriptor_heap"]
 pub const EXT_DESCRIPTOR_BUFFER_SPEC_VERSION: u32 = 1u32;
 #[doc = "Deprecated: <https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets>"]
 #[allow(non_camel_case_types)]
@@ -9165,8 +9203,10 @@ pub type PFN_vkGetMicromapBuildSizesEXT = unsafe extern "system" fn(
     p_size_info: *mut MicromapBuildSizesInfoEXT<'_>,
 );
 #[cfg(feature = "provisional")]
+#[deprecated = "Deprecated by VK_NV_cluster_acceleration_structure"]
 pub const NV_DISPLACEMENT_MICROMAP_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_displacement_micromap\0") };
+#[deprecated = "Deprecated by VK_NV_cluster_acceleration_structure"]
 #[cfg(feature = "provisional")]
 pub const NV_DISPLACEMENT_MICROMAP_SPEC_VERSION: u32 = 2u32;
 pub const EXT_LOAD_STORE_OP_NONE_NAME: &CStr =
@@ -9983,8 +10023,10 @@ pub const KHR_VIDEO_DECODE_VP9_SPEC_VERSION: u32 = 1u32;
 pub const KHR_VIDEO_MAINTENANCE1_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_maintenance1\0") };
 pub const KHR_VIDEO_MAINTENANCE1_SPEC_VERSION: u32 = 1u32;
+#[deprecated = "Deprecated by VK_EXT_descriptor_heap"]
 pub const NV_PER_STAGE_DESCRIPTOR_SET_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_NV_per_stage_descriptor_set\0") };
+#[deprecated = "Deprecated by VK_EXT_descriptor_heap"]
 pub const NV_PER_STAGE_DESCRIPTOR_SET_SPEC_VERSION: u32 = 1u32;
 pub const QCOM_IMAGE_PROCESSING2_NAME: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_image_processing2\0") };

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1308,14 +1308,12 @@ pub fn generate_extension_commands<'a>(
         .flatten()
         .filter_map(get_variant!(vk_parse::InterfaceItem::Enum))
         .find(|e| e.name.contains("SPEC_VERSION"))
-        .and_then(|e| {
-            if let vk_parse::EnumSpec::Value { value, .. } = &e.spec {
-                let v: u32 = str::parse(value).unwrap();
-                Some(quote!(pub const #spec_version_ident: u32 = #v;))
-            } else {
-                None
-            }
-        });
+        .unwrap();
+    let vk_parse::EnumSpec::Value { value, .. } = &spec_version.spec else {
+        panic!("SPEC_VERSION is not a value");
+    };
+    let v: u32 = str::parse(value).unwrap();
+    let spec_version = quote!(pub const #spec_version_ident: u32 = #v;);
 
     let mut instance_commands = Vec::new();
     let mut device_commands = Vec::new();
@@ -1460,13 +1458,27 @@ pub fn generate_extension_commands<'a>(
         .provisional
         .then(|| quote!(#[cfg(feature = "provisional")]));
 
+    let deprecatedby = extension.deprecatedby.as_ref().map(|e| {
+        let e = format!("Deprecated by {e}");
+        quote!(#[deprecated = #e])
+    });
+    // TODO: Include `promotedto`?
+    let obsoletedby = extension.obsoletedby.as_ref().map(|e| {
+        let e = format!("Obsoleted by {e}");
+        quote!(#[deprecated = #e])
+    });
+
     ExtensionCommands {
         vendor,
         raw: quote! {
                 #provisional
+                #deprecatedby
+                #obsoletedby
                 pub const #name_ident: &CStr = unsafe {
                     CStr::from_bytes_with_nul_unchecked(#byte_name_ident)
                 };
+                #deprecatedby
+                #obsoletedby
                 #provisional
                 #spec_version
                 #raw_instance_fp
@@ -1475,6 +1487,8 @@ pub fn generate_extension_commands<'a>(
         high_level: quote! {
             #[doc = #full_extension_name]
             #provisional
+            #deprecatedby
+            #obsoletedby
             pub mod #extension_ident {
                 #hl_imports
 


### PR DESCRIPTION
After deciding to back out of marking individual commands and types as `#[deprecated]` because superseding functionality is unlikely to be widely available yet, there are however niche or vendor-specific extensions that have been replaced by more common EXT/KHR extensions or even stabilized features.  These would benefit from nudging the user towards the newer and/or cross-platform functionality which is more likely to be prevalent.