### PR TITLE
extensions/khr/acceleration_structure: Make some arguments optional for `VK_KHR_opacity_micromap`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This trait must be imported in scope (`use ash::vk::TaggedStructure as _;`) to use the `push()` and `extend()` methods.
 - Renamed all extension `::new()` constructors to `::load()`, signifying they're only loading function pointers. (#1021)
 - Replace `specs/1.3-extensions` registry links with new `refpages/latest` documentation links
+- `extensions::khr::acceleration_structure` now takes `Option`al references in the following arguments (#1041):
+  - `max_primitive_counts` in `get_acceleration_structure_build_sizes_khr()`;
+  - `build_range_infos` in `cmd_build_acceleration_structures()`.
 
 ### Removed
 

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -4,7 +4,7 @@ use crate::vk;
 use crate::RawPtr;
 use crate::VkResult;
 use alloc::vec::Vec;
-use core::mem;
+use core::{mem, ptr};
 
 impl crate::khr::acceleration_structure::Device {
     /// <https://docs.vulkan.org/refpages/latest/refpages/source/vkCreateAccelerationStructureKHR.html>
@@ -46,7 +46,7 @@ impl crate::khr::acceleration_structure::Device {
         &self,
         command_buffer: vk::CommandBuffer,
         infos: &[vk::AccelerationStructureBuildGeometryInfoKHR<'_>],
-        build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR]],
+        build_range_infos: &[Option<&[vk::AccelerationStructureBuildRangeInfoKHR]>],
     ) {
         assert_eq!(infos.len(), build_range_infos.len());
 
@@ -54,8 +54,13 @@ impl crate::khr::acceleration_structure::Device {
             .iter()
             .zip(infos.iter())
             .map(|(range_info, info)| {
-                assert_eq!(range_info.len(), info.geometry_count as usize);
-                range_info.as_ptr()
+                if let Some(range_info) = range_info {
+                    assert_eq!(range_info.len(), info.geometry_count as usize);
+                    range_info.as_ptr()
+                } else {
+                    // Must be NULL for at least VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-11544
+                    ptr::null()
+                }
             })
             .collect::<Vec<_>>();
 
@@ -262,19 +267,22 @@ impl crate::khr::acceleration_structure::Device {
         &self,
         build_type: vk::AccelerationStructureBuildTypeKHR,
         build_info: &vk::AccelerationStructureBuildGeometryInfoKHR<'_>,
-        max_primitive_counts: &[u32],
+        max_primitive_counts: Option<&[u32]>,
         size_info: &mut vk::AccelerationStructureBuildSizesInfoKHR<'_>,
     ) {
-        assert_eq!(
-            max_primitive_counts.len(),
-            build_info.geometry_count as usize
-        );
+        let max_primitive_counts = if let Some(c) = max_primitive_counts {
+            assert_eq!(c.len(), build_info.geometry_count as usize);
+            c.as_ptr()
+        } else {
+            // Must be NULL for at least VUID-vkGetAccelerationStructureBuildSizesKHR-pMaxPrimitiveCounts-11613
+            ptr::null()
+        };
 
         (self.fp.get_acceleration_structure_build_sizes_khr)(
             self.handle,
             build_type,
             build_info,
-            max_primitive_counts.as_ptr(),
+            max_primitive_counts,
             size_info,
         )
     }


### PR DESCRIPTION
Depends on #1041

The new KHR Opacity Micromap extension leverages existing `vk::AccelerationStructureKHR` objects and related building functions (as opposed to defining bespoke types and commands in the EXT), but makes some input arguments to the existing Acceleration Structure commands optional.  These need to be adjusted in our high-level wrapper to accommodate for these requirements:

- `max_primitive_counts` in `get_acceleration_structure_build_sizes_khr()`;
- `build_range_infos` in `cmd_build_acceleration_structures()`.

Note that `build_range_infos` in `build_acceleration_structures()` is not affected, because Opacity Micromaps are limited to device-builds.

See the VUID changes in https://github.com/KhronosGroup/Vulkan-Headers/commit/0e9de566b7d4051c5cc1b762e242c46565956bdf for more details.
